### PR TITLE
docs: epoch 1 retrospective and retroactive decision log

### DIFF
--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -97,6 +97,17 @@ Duration: <actual time from first commit to last merge>
 
 Present the draft to the user for review. The retrospective is a shared document — the agent writes it, the user edits and approves it.
 
+## Phase 3.5: Close milestones
+
+After the retrospective is written, close all milestones belonging to the epoch on GitHub:
+
+```sh
+# For each milestone in the epoch:
+gh api repos/:owner/:repo/milestones/<number> -X PATCH -f state=closed
+```
+
+Milestones stay open during the epoch so new issues can still be threaded in. Closing them is a retro-time action — it marks the epoch as formally complete.
+
 ## Phase 4: Identify improvements
 
 Based on the retrospective, propose specific changes:

--- a/project/epoch_1/decision_log.md
+++ b/project/epoch_1/decision_log.md
@@ -1,3 +1,73 @@
 # Epoch 1 Decision Log
 
 <!-- Append entries with /decide. Format: ## YYYY-MM-DD: <title> -->
+
+## 2026-03-22: SW-NE diagonal split for uniform grid [retroactive]
+
+**Decision:** Uniform grid triangulation uses a consistent SW-NE diagonal split per cell, producing right triangles.
+
+**Alternatives considered:**
+- Alternating diagonal splits (would avoid systematic degeneracy)
+- Delaunay-quality triangulation (more complex, better element quality)
+
+**Rationale:** Simplest scheme. But right triangles sharing a hypotenuse have coincident circumcenters, which created the degenerate dual edge problem that propagated through ★₁, the Ampere step, and the dipole demo. In hindsight, the mesh generator should not have been the source of operator degeneracies.
+
+**Source:** PR #47, commit a1cec65
+
+## 2026-03-22: Circumcentric dual → barycentric dual [retroactive]
+
+**Decision:** Switched `uniform_grid` from circumcentric to barycentric dual after the circumcentric dual produced `dual_length = 0` on all diagonal edges, making ★₁ singular on ~1/3 of edges.
+
+**Alternatives considered:**
+- Keep circumcentric dual with pseudo-inverse workarounds (chosen initially, propagated workarounds into Hodge star, Ampere step, and tests)
+- Non-degenerate mesh generator (would fix root cause but doesn't help uniform grids)
+- Whitney/Galerkin mass matrix (correct long-term fix, tracked as #70)
+
+**Rationale:** Should have chosen barycentric from the start. The circumcentric degeneracy was a known issue from PR #47 but was worked around rather than fixed. The workarounds polluted multiple modules (Hodge star round-trip tests, Ampere step pseudo-inverse logic). Barycentric dual trades primal-dual orthogonality for non-degeneracy — introduces ~8% systematic error that doesn't converge, but this is acceptable until the Whitney/Galerkin mass matrix replaces the diagonal ★₁.
+
+**Source:** PR #69, commit 0a44562
+
+## 2026-03-22: Cochain as pure data — no mesh pointer [retroactive]
+
+**Decision:** `Cochain` stores only `values: []f64`, initialized with a cell count. Operators receive the mesh separately.
+
+**Alternatives considered:**
+- Store mesh pointer inside cochain (original PR #50 design, changed in PR #51)
+
+**Rationale:** Decouples data from topology. However, a real cochain is inherently connected to its topology — the cochain *is* a function on the cells of the complex. Carrying a mesh reference would be more mathematically faithful and would let operators extract the mesh from the cochain directly. This should be revisited.
+
+**Source:** PR #51, commit fc10c7b
+
+## 2026-03-24: Standalone update functions, not methods on State [retroactive]
+
+**Decision:** `faraday_step` and `ampere_step` are free functions, not methods on `MaxwellState`.
+
+**Alternatives considered:**
+- Method-style `state.faraday_step(dt)`
+
+**Rationale:** Separates state representation from integration logic, aligning with the pluggable time-integrator horizon. Reasonable for now, but as more physics modules appear, a generic `State` type with methods may be preferable to ad-hoc free functions per physics domain.
+
+**Source:** PR #60, commit 81e2416
+
+## 2026-03-24: Direct diagonal Ampere step with pseudo-inverse [retroactive]
+
+**Decision:** Ampere step used manual diagonal ★₁⁻¹ with pseudo-inverse (0/0 → 0) instead of the generic `compose.chain` with `hodge_star_inverse`.
+
+**Alternatives considered:**
+- Use generic chain composition (panics on zero entries)
+
+**Rationale:** Workaround for the circumcentric dual degeneracy. Superseded by PR #69's barycentric dual switch, which eliminated the zero entries entirely. This decision was a symptom of the earlier wrong choice on circumcentric dual.
+
+**Source:** PR #60, commit 81e2416; removed in PR #69
+
+## 2026-03-24: Comptime-recursive type threading for chain() [retroactive]
+
+**Decision:** `chain` uses `@TypeOf(op(undefined_allocator, undefined_input))` to resolve each operator's return type at comptime without evaluating function bodies.
+
+**Alternatives considered:**
+- Trait/interface-based type registration
+- Runtime type checks
+
+**Rationale:** Leverages Zig's type system naturally — degree/duality mismatches become compile errors through operator signatures alone. Good choice for now. Trait/interface abstractions may be added later as the operator algebra grows, but the comptime approach remains the right foundation.
+
+**Source:** PR #59, commit d703bda

--- a/project/epoch_1/retrospective.md
+++ b/project/epoch_1/retrospective.md
@@ -1,3 +1,81 @@
 # Epoch 1 Retrospective
 
-<!-- Written at epoch end. What held? What didn't? What would we change? -->
+Date: 2026-03-26
+Duration: ~5 days (March 22 – March 26, 2026)
+
+## What was planned
+
+Three milestones building from mesh topology through operators to a working Maxwell simulation:
+
+- **M1: Mesh + Visualization** (14 issues) — SoA mesh, boundary operators, geometry, VTK export
+- **M2: Typed Forms + Discrete Operators** (14 issues) — comptime-typed cochains, d, ★, Laplacian
+- **M3: Maxwell Simulation** (14 issues) — leapfrog FDTD, PEC BCs, dipole source, demos, CLI
+
+Total: 42 issues, 3 milestones.
+
+## What was delivered
+
+Everything shipped. 42/42 issues closed, 20 PRs merged, 5,151 lines of Zig, 104 tests passing.
+
+The framework goes from nothing to a working 2D Maxwell simulation with:
+- Dimension-agnostic mesh with typed boundary operators
+- Comptime-enforced k-form degree and primal/dual duality
+- Exterior derivative, Hodge star, Laplace-de Rham operator
+- VTK export with time-series support
+- Leapfrog integrator with structural ∇·B = 0
+- Two runnable demos (dipole radiation, cavity resonance) with CLI
+- Python visualizer for GIF output
+
+## Acceptance criteria status
+
+| Milestone | Criterion | Status |
+|-----------|-----------|--------|
+| M1: Mesh + Visualization | ∂∂ = 0 exact; .vtu round-trips in ParaView | ✅ |
+| M2: Typed Forms + Discrete Operators | Compile-time degree rejection; dd = 0 on 1000 random inputs; ★★⁻¹ = id | ✅ |
+| M3: Maxwell Simulation | d₂B = 0 every timestep; 1000 steps stable; .vtu snapshots show field evolution | ✅ |
+
+## What held
+
+**Comptime type safety.** Degree and duality encoded as comptime parameters caught real bugs at compile time. Passing a dual cochain to a primal operator is a compile error. This is the right foundation — it should be extended, not relaxed.
+
+**Property-based testing.** dd = 0 and ★★⁻¹ = id on 1000 random inputs caught issues that example-based tests would have missed. The fuzz tests are load-bearing correctness infrastructure.
+
+**VTK pipeline.** Zero-dependency .vtu serializer with time-series support worked end-to-end. ParaView visualization was immediately useful for debugging the dipole radiation pattern.
+
+**Standalone update functions.** Keeping `faraday_step` and `ampere_step` as free functions made it easy to compose the leapfrog integrator and will make pluggable integrators straightforward.
+
+**The comptime-recursive `chain()`.** Type threading via `@TypeOf` on undefined inputs was elegant and caught real composition errors. No extra machinery needed.
+
+## What didn't hold
+
+**Decision logging — completely absent.** Zero entries during the epoch despite 6 non-trivial architectural choices. Every decision had to be reconstructed retroactively from PR descriptions. The `/decide` skill was never invoked. This is the biggest process failure of the epoch.
+
+**Circumcentric dual assumption.** The initial choice of circumcentric dual for uniform grids propagated degeneracies (zero dual lengths on diagonal edges) through the Hodge star, Ampere step, and into the physics. Workarounds accumulated across 4+ PRs before the root cause was fixed in PR #69 by switching to barycentric dual. The degeneracy was documented in PR #47 as a "known limitation" rather than treated as a design problem to solve immediately. This violated the "zero technical debt" principle.
+
+**Issue granularity was too fine.** Many issues were trivially batched: PR #47 closed 9 issues, PR #54 closed 5, PR #49 closed 3. Issues like "vertex coordinate storage" and "explicit allocator API" were not meaningful units of work — they were implementation details of the mesh struct. The roadmap called for 12–15 issues per milestone but several were below the "requires a non-obvious design choice" threshold.
+
+**Milestones not closed.** All three milestones show 0 open issues but remain in "open" state on GitHub. Minor, but sloppy.
+
+## Process observations
+
+**Speed vs rigor tradeoff.** 42 issues in 5 days is fast. But the speed came at the cost of decision logging and issue quality. The epoch proved the architecture works end-to-end — that was the primary goal. But the process artifacts (decision log, issue sizing) need tightening for epoch 2.
+
+**Workaround propagation.** The circumcentric dual issue is a case study in how a "known limitation" becomes technical debt. The fix was straightforward (swap circumcenter → barycenter) but wasn't done until the demo visibly broke. Earlier action would have avoided the pseudo-inverse workarounds in the Ampere step and the entry-by-entry degenerate-edge skipping in the Hodge star tests.
+
+**PR batching was effective.** Bundling related issues into single PRs (e.g., all VTK export issues in PR #49, all Hodge star issues in PR #54) was the right call — splitting would have been churn. The issue templates should reflect that a PR can close multiple issues when they form a single logical unit.
+
+**No `/decide` usage despite needing it.** The skill exists but was never triggered. Either the threshold for "non-obvious" was set too high in practice, or the friction of invoking `/decide` mid-implementation was too high.
+
+## Recommendations for next epoch
+
+1. **Enforce decision logging.** Lower the bar for what triggers `/decide`. Any new type, interface change, or workaround is a decision. Consider making `/decide` a checklist item on the PR template rather than relying on mid-implementation invocation.
+
+2. **Coarser issue granularity.** Target 5–10 issues per milestone, not 12–15. Each issue should require at least one design choice and produce a reviewable PR. "Add field X to struct Y" is not an issue — it's a commit.
+
+3. **Fix known limitations immediately.** "Known limitation" in a PR description should trigger either (a) a fix in the same PR, or (b) a blocking issue that prevents downstream work from building on the limitation. Do not document degeneracies and move on.
+
+4. **Close milestones.** Automate or add to the PR-merge checklist: when the last issue in a milestone closes, close the milestone.
+
+5. **Cochain should carry mesh reference.** Filed as #72. A cochain without its complex is just an array of floats — the mathematical semantics are lost. This should be addressed early in epoch 2.
+
+6. **Whitney/Galerkin mass matrix for ★₁.** The barycentric diagonal Hodge star has ~8% non-converging error. Tracked as #70. This is the main accuracy bottleneck and should be a milestone-level goal.


### PR DESCRIPTION
## Summary

- **Retrospective** — full epoch 1 retro covering what was planned, delivered, what held, what didn't, process observations, and recommendations for epoch 2
- **Decision log** — 6 retroactively reconstructed architectural decisions (circumcentric→barycentric dual, cochain as pure data, standalone update functions, pseudo-inverse Ampere step, comptime chain() typing, SW-NE grid split)
- **Retro skill update** — added Phase 3.5 to close milestones at retro time (not per-PR)
- **Milestones closed** — M1, M2, M3 all closed on GitHub

## Follow-up issues

- #72 — Cochain carries mesh reference (from decision log review)
- #70 — Whitney/Galerkin mass matrix for ★₁ (existing)

## Test plan

- [x] No code changes — docs and skill definition only
- [x] `zig build ci --summary all` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)