### PR TITLE
fix: store mirrored codex skill files as copies

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,1 +1,117 @@
-../../../.claude/commands/review.md
+---
+name: review
+description: Review a pull request with emphasis on implementation details, mathematical correctness, type safety, invariants, and scope discipline.
+---
+
+Review a PR for the flux project with mathematical and code correctness scrutiny.
+
+Usage: /review <PR number>
+
+## Context: division of review labor
+
+The **user** reviews API shape and test coverage — they check that the interface is clean and the tests are comprehensive. They rarely need to read implementation blocks in detail.
+
+The **agent** (this skill) reviews implementation details with a fine-tooth comb — catching subtleties the user will miss at a glance. This is the agent's primary value in review.
+
+Structure your review accordingly: lead with the implementation-detail findings that the user is unlikely to catch on their own. Don't spend the review restating things visible from the PR description.
+
+## Gather context
+
+1. Fetch PR metadata and changed file paths first:
+   ```sh
+   gh pr view <number> --json number,title,body,labels,headRefName,additions,deletions,files
+   ```
+2. Extract the linked issue number from `Closes #N` in the PR body.
+3. Read the full issue: `gh issue view <N>` — get the acceptance criterion and references.
+4. Read the epoch roadmap to understand where this fits: `project/epoch_*/roadmap.md`.
+5. Read `project/components.md` to map the changed files to their expected component scope. Flag if the PR touches files outside that scope without justification.
+6. Read only the changed files and the direct dependency files required to review them.
+7. Fetch targeted diff context for the touched files. Avoid reading the full PR diff unless the PR is small enough that the broad diff is itself the smallest sufficient context.
+
+## Review lenses
+
+Work through each lens in order. Be specific — name the file and line number when flagging something.
+
+### 1. Mathematical correctness (most important)
+- Does the implementation match the mathematical definition cited in the issue?
+- Is the right object being computed? (e.g., is the boundary operator actually the transpose of d?)
+- Are edge cases handled: empty mesh, boundary cells, degenerate orientations?
+- Are the right invariants being tested? Random-input property tests must exist for any new operator.
+- Do test names state the invariant explicitly: `test "dd = 0 for ..."`?
+- Is floating-point comparison done with explicit epsilon, not exact equality?
+
+### 2. Type safety and comptime
+- Is k-form type safety enforced at compile time via `comptime`?
+- Can a 2-form be accidentally passed where a 1-form is expected? If so, flag it.
+- Are comptime constants used where the value is statically known?
+- Are trait/interface requirements checked with `@hasDecl` or `@typeInfo` at comptime?
+
+### 3. Memory and layout
+- SoA layout (`std.MultiArrayList`) for any new mesh entity types?
+- Explicit allocator passed everywhere — no hidden allocations?
+- Are all allocated resources deferred for cleanup (`defer x.deinit(allocator)`)?
+
+### 4. TigerStyle
+- `const` by default — any unnecessary `var`?
+- All loops bounded — any unbounded iteration?
+- Assertions present for preconditions and postconditions (`std.debug.assert`)?
+- Comments explain *why*, not what?
+- Names are full words, units appended?
+
+### 5. Implementation subtleties
+These are the findings the user is least likely to catch:
+- Off-by-one errors in index arithmetic
+- Sign convention mismatches (orientation of simplices, boundary vs coboundary)
+- Numerical stability concerns (division by small quantities, catastrophic cancellation)
+- Redundant computation that could be hoisted or cached
+- Unnecessary allocations in hot paths
+- Code that duplicates logic existing elsewhere in the component
+
+### 6. Process
+- PR body has `Closes #N`?
+- Acceptance criterion from the issue is stated and verified?
+- Were any non-obvious architectural decisions made? If yes, are they in the decision log?
+- Labels correct: `type/`, `domain/`, `priority/` all set?
+- Does this introduce an interface that conflicts with a known horizon in `project/horizons.md`?
+- Are there follow-on issues that should be opened before this merges?
+
+## Output format
+
+Write a structured review with a clear verdict at the top:
+
+```
+## Review: PR #<N> — <title>
+
+**Verdict:** APPROVE | REQUEST CHANGES | BLOCK
+
+### Key findings (implementation detail)
+<The most important things the user would miss — specific, with file:line references>
+
+### Mathematical Correctness
+<findings>
+
+### Type Safety & Comptime
+<findings>
+
+### Memory & Layout
+<findings>
+
+### TigerStyle
+<findings>
+
+### Implementation Subtleties
+<findings>
+
+### Process
+<findings>
+
+### Summary
+<one paragraph — what's good, what must change before merge>
+```
+
+After writing the review, ask the user: "Post this as a GitHub review comment? (y/n)"
+
+If yes:
+```sh
+gh pr review <number> --comment --body "<review text>"
+```

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,1 +1,34 @@
-../../../.claude/commands/status.md
+---
+name: status
+description: Summarize the current epoch, milestone, open work, blockers, and acceptance-criterion status from docs, GitHub state, and tests.
+---
+
+Check the current epoch and milestone status for the flux project.
+
+## Steps
+
+1. Read `project/epoch_*/roadmap.md` for the most recent epoch — get the current milestone name and its acceptance criterion.
+2. Read `project/components.md` for component context.
+3. Run the following gh commands to get live state:
+   ```sh
+   gh milestone list --state open
+   gh issue list --state open --label "priority/high"
+   gh issue list --state open --milestone "<current milestone name>"
+   gh issue list --state closed --milestone "<current milestone name>"
+   ```
+4. Check for tests covering the acceptance criterion: `zig build test --summary all`
+
+Report, in order:
+1. **Current epoch** — goal and epoch document path
+2. **Current milestone** — name, acceptance criterion, issue counts (open / closed)
+3. **In-progress work** — any open PRs or draft PRs
+4. **Blocked issues** — any with `status/blocked` or `status/needs-decision`
+5. **High-priority open issues** — list them with their `domain/` and `type/` labels
+6. **Acceptance criterion status** — passing or not, based on test output
+7. **Decision log health** — are there entries since last check? If the milestone has had PRs merged but no decisions logged, flag it.
+8. **Recommended next action** — name a specific issue number or suggest `/tackle`
+
+Label reference for filtering:
+- `type/invariant` — math property work (usually on the critical path)
+- `status/blocked` — stuck issues that may need a decision
+- `priority/high` — must close before milestone is done

--- a/.agents/skills/tackle/SKILL.md
+++ b/.agents/skills/tackle/SKILL.md
@@ -1,1 +1,156 @@
-../../../.claude/commands/tackle.md
+---
+name: tackle
+description: Select the highest-priority unblocked issue for the current milestone, work it to a reviewable PR, and stop for review.
+---
+
+Find and work the highest-priority open issue to completion — one issue, one branch, one PR, CI passes, stop for review.
+
+## Find the issue
+
+1. Read `project/components.md` to understand codebase scope boundaries.
+2. Read `project/epoch_*/roadmap.md` for the current epoch to understand milestone priorities and acceptance criteria.
+3. Read `project/horizons.md` — before writing any interface, check that it does not preclude a known future direction.
+4. Get live state:
+   ```sh
+   gh milestone list --state open
+   gh issue list --state open --label "priority/high" --json number,title,labels,milestone
+   gh issue list --state open --label "status/blocked" --json number,title,labels,milestone
+   ```
+5. Select the best issue to work next using this priority order:
+   - On the current milestone (check which milestone is earliest in the roadmap)
+   - `type/invariant` preferred — these are on the critical path for acceptance criteria
+   - `priority/high` over `priority/medium`
+   - Issues that unblock other `status/blocked` issues
+   - Skip `status/blocked` issues (they can't be worked until unblocked)
+   - Non-epoch bugs (`type/bug`) may take priority if they are breaking something
+
+6. Present the chosen issue to the user: number, title, acceptance criterion, and a one-sentence rationale for why this one. Ask for confirmation or redirection.
+
+## Scope the work
+
+On confirmation:
+
+1. Read the full issue body: `gh issue view <number>`
+2. Identify the **component scope** from `project/components.md` based on the issue's `domain/` label. Name the component and direct dependencies explicitly before opening source files.
+3. Create a branch and immediately open a draft PR:
+   ```sh
+   git checkout main && git pull
+   git checkout -b <number>-<short-slug>
+   git commit --allow-empty -m "chore: open draft PR for #<number>"
+   git push -u origin <number>-<short-slug>
+   gh pr create --draft \
+     --title "<imperative title>" \
+     --body "Closes #<number>
+
+   ## What
+
+   <one sentence: what this PR delivers>
+
+   ## Acceptance criterion
+
+   <from the issue>
+
+   ## Tasks
+
+   - [ ] Write property tests encoding the acceptance criterion
+   - [ ] Design public API (stubs)
+   - [ ] Implement
+   - [ ] CI green
+   " \
+     --label "<type/X,domain/X,priority/X>"
+   ```
+   Slug format: lowercase, hyphens, ≤5 words. Example: `42-csr-incidence-matrix`.
+
+4. Read all relevant source files within the component scope before writing any code.
+   Start with the files named in the issue and the component entry in `project/components.md`. Only expand to additional direct dependencies when the current files prove they are needed. Do not read unrelated modules "for context".
+
+## Phase 1: Tests
+
+Write the tests first. These define what "done" means.
+
+1. Identify the mathematical invariant or behavioral property from the acceptance criterion.
+2. Write property tests that verify this invariant. Use random inputs where applicable.
+3. Write example-based tests for edge cases (empty mesh, boundary cells, degenerate inputs).
+4. Tests should fail at this point — the implementation doesn't exist yet.
+5. Commit and push:
+   ```sh
+   git add <test files>
+   git commit -m "test(domain): add failing tests for <invariant>"
+   git push
+   ```
+
+## Phase 2: API design
+
+Design the public interface before implementing internals.
+
+1. Write function signatures, struct definitions, and type-level constraints as stubs.
+2. Use `@compileError("not yet implemented")` or `unreachable` for function bodies.
+3. Verify the tests compile against the stubs (they should fail at runtime, not compile time).
+4. **Checkpoint: present the API surface to the user.** Show the type signatures, struct layout, and how tests use them. This is where design choices surface — ask for confirmation before proceeding.
+5. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
+   - Read the current epoch's `decision_log.md`
+   - Append the decision in the standard format (see `/decide`)
+   - Commit the decision log alongside the stubs
+6. Commit and push:
+   ```sh
+   git add <source files> <decision log if updated>
+   git commit -m "feat(domain): stub API for <capability>"
+   git push
+   ```
+
+## Phase 3: Implement
+
+Fill in the stubs until tests pass.
+
+1. Implement in small steps. Each step must compile and pass all existing tests before moving on.
+2. **Commit after every coherent unit of progress** — a working constructor, a helper function, a passing test case. Target roughly 50–150 lines per commit; if you are approaching 200+ lines uncommitted, stop and commit what you have.
+3. `zig build ci --summary all` between every commit. No exceptions.
+4. Push after every 1–2 commits to maintain remote checkpoints.
+5. If you realize an approach is wrong, you can reset to an earlier commit — the remote has the history. State what you're resetting and why before doing it.
+6. When all acceptance criterion tests pass, that is the final implementation commit.
+7. If additional non-obvious decisions were made during implementation, log them to the decision log.
+
+The rhythm is: **write → test → commit → push → repeat**.
+
+## Phase 4: Finalize
+
+1. Run `zig build ci --summary all` one final time.
+2. Update the draft PR description:
+   - Check all completed task boxes
+   - Add a "## Decisions" section if any were logged
+   - Add a "## Limitations" section for known gaps
+3. Answer the molecule checklist:
+   - Does this introduce an interface that conflicts with a known horizon in `project/horizons.md`?
+   - Does existing documentation need updating?
+   - Does this change the public API in a way that affects other modules?
+   - Are there follow-on issues that should be opened?
+4. Mark the PR as ready for review:
+   ```sh
+   gh pr ready <number>
+   ```
+5. Report the PR URL and **STOP**. Do not merge.
+
+The user reviews API shape and test coverage. The agent (via `/review`) reviews implementation details.
+
+## After review
+
+Merging is the user's decision. Only merge when the user explicitly says to (e.g., "merge it", "LGTM", "ship it"). Then:
+
+1. Check CI: `gh pr checks <number>` — all checks must pass.
+2. Merge:
+    ```sh
+    gh pr merge <number> --squash --delete-branch
+    ```
+3. Confirm the issue was auto-closed: `gh issue view <number>`
+4. Report: what was merged, what the next recommended issue is.
+
+## Constraints
+
+- **Never merge without explicit user approval.** CI green is necessary but not sufficient.
+- Never skip `zig build ci --summary all` before pushing.
+- Never merge with failing CI.
+- Never put more than one issue's work in a single PR.
+- Never write more than ~200 lines without compiling, testing, and committing.
+- Stay within the component scope identified at the start. If you find yourself needing to read or modify files outside the scope, state why and get confirmation.
+- Draft PR opens immediately. Commits push frequently. The remote is your checkpoint system.
+- A PR with fewer than 3 commits is a signal that either the work was trivial (issue was too small) or the agent was not committing incrementally. Neither is acceptable for well-sized issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,355 @@
-.claude/CLAUDE.md
+# flux
+
+High-performance FEEC/DEC simulation framework in Zig. Targets accurate simulation of Maxwell's equations and incompressible Euler equations with exact discrete conservation laws.
+
+See `project/initial.md` for the full architectural specification.
+
+---
+
+## Fast Orientation
+
+Assume fresh context. Do **not** start by scanning the whole repository.
+
+Read in this order:
+
+1. This file for workflow rules and project expectations.
+2. `project/components.md` for the codebase map and component boundaries.
+3. Only the artifact that matches the current assignment:
+   - implementation: the current issue/PR, then only the relevant component files
+   - planning: the latest `project/epoch_*/roadmap.md`
+   - design alignment: `project/vision.md` and `project/horizons.md`
+   - decision logging: the current `project/epoch_N/decision_log.md`
+4. Expand scope only when the current artifact proves you need more context.
+
+Default rule: before any exploratory tool call, ask what the **smallest sufficient document or file set** is for the current task.
+
+Do not read unrelated `src/` files "just to learn the repo". Learn the repo through `project/components.md`, then open only the component and direct dependencies that the task actually touches.
+
+---
+
+## Hard Rules
+
+- **Never merge a PR without explicit user approval.** After opening a PR,
+  report the URL and stop. CI green is necessary but not sufficient — the user
+  reviews every PR. Only run `gh pr merge` when the user explicitly says to
+  (e.g., "merge it", "LGTM", "ship it"). This is non-negotiable.
+
+---
+
+## Build & Test
+
+```sh
+zig build                       # build
+zig build test --summary all    # run all tests (with output)
+zig build fmt                   # check formatting
+zig build ci --summary all      # all CI checks: build + test + fmt
+zig build run                   # run stub (directs to examples)
+zig build example-maxwell2d     # run 2D Maxwell electromagnetic example
+zig build bench                 # run operator benchmarks (informational)
+zig build bench -- --check      # compare against baselines, fail on >20% regression
+zig build bench -- --update     # run benchmarks and save baselines.json
+zig build bench -- --json       # output JSON to stdout
+zig build docs                  # generate API docs to zig-out/docs/
+zig build serve-docs            # build docs and serve at http://127.0.0.1:8080
+```
+
+---
+
+## Vision Alignment
+
+`project/vision.md` is the north star. Every design decision — discretization
+choice, abstraction boundary, API shape — must be checked against it before
+committing. If a decision deviates from the vision, it is not automatically
+wrong, but it must be:
+
+1. **Logged** in the epoch's `decision_log.md` as a deliberate, temporary move.
+2. **Named**: state what vision principle it trades against and why the tradeoff
+   is acceptable right now.
+3. **Bounded**: note the condition under which it should be revisited.
+
+A decision that conflicts with the vision and is not logged is a bug in the
+project, not just the code.
+
+`project/horizons.md` tracks validated but unscheduled architectural ideas.
+Before finalizing any interface, check horizons to ensure the design does not
+preclude a known future direction. When ideation produces a horizon-level
+insight, add it there — not in the epoch roadmap.
+
+---
+
+## Work Structure
+
+Development has three levels of granularity. Each level has a definition of done.
+
+### Sub-atomics: Commits
+
+Commits are save states. Commit early, commit often. A commit should represent
+a coherent, describable unit of progress — a passing test, a compiling refactor,
+a new invariant — not a finished feature. They are local history: branchable,
+cherry-pickable, revertable. Use them liberally.
+
+Commit messages follow conventional commits (`feat:`, `fix:`, `test:`,
+`refactor:`, `chore:`, `docs:`). The subject line says what changed; the body,
+when needed, says why.
+
+### Atoms: Issues
+
+An issue is the smallest unit of releasable work. Each issue owns **3–5 tasks**
+(checkboxes) that together deliver a complete capability. At minimum, one task
+is a test task and one is an implementation task. Diagnostics, edge-case
+handling, and documentation updates are bundled into the issue — not filed
+separately.
+
+**An issue is well-sized when:**
+- It requires at least one non-obvious design choice (triggers `/decide`)
+- It produces a PR that benefits from review (not trivially correct by inspection)
+- It maps to roughly 5+ commits of meaningful progress
+
+**An issue is too small when:**
+- It's a single function addition with an obvious implementation
+- The entire PR could be reviewed in under 2 minutes
+- No design choices were made
+
+**An issue is too big when:**
+- It touches more than 2 component scopes (see `project/components.md`)
+- The tasks list exceeds 7 items
+- You can't state the single capability it delivers in one sentence
+
+An issue is done when:
+
+1. **The implementation exists** and compiles cleanly.
+2. **Tests exist** that verify the invariant, not just the happy path. The
+   testing hierarchy, in ascending order of proof strength:
+   - Example-based unit tests (necessary but not sufficient)
+   - Property-based / fuzz tests on random inputs (required for all operators)
+   - `comptime` / type-level guarantees (promoted here whenever possible — a
+     compile error is stronger than any runtime test)
+3. **CI passes**: build, test, fmt, lint all green.
+4. **The PR description is honest**: what was done, what was not done, what the
+   known limitations are.
+
+Open a draft PR when the branch is created, not when the work is done. This
+keeps CI running continuously and creates a living dialogue thread for the work.
+
+### Molecules: Pull Requests
+
+Before moving a draft PR to ready-for-review, ask the downstream questions:
+
+- Does any existing documentation need updating (including `project/vision.md`)?
+- Does `README.md` need updating to stay consistent with the vision?
+- Does `.github/settings.yml` (repo description, topics) need updating?
+- Is there a new capability that warrants a new example demonstrating it
+  end-to-end?
+- Does this change the public API in a way that affects other modules?
+- Does this introduce or resolve a decision that should be logged?
+- Are there follow-on issues that should be opened now, while the context is
+  fresh?
+
+`README.md` and `.github/settings.yml` are public-facing artifacts that must
+stay consistent with `project/vision.md`. When the vision evolves, they drift
+unless explicitly checked.
+
+A PR that introduces new atoms without answering these questions is incomplete,
+even if CI is green. The molecule is not just the code — it is the code plus its
+consequences in the broader system.
+
+---
+
+## Project Workflow
+
+### Epochs → Milestones → Issues
+
+- **Epoch**: A substantial body of work (~1 month or more). Living documents in `project/epoch_N/`. Tracked as a GitHub Project.
+- **Milestone**: ~1–2 weeks of validated work. Each has an explicit mathematical acceptance criterion. 5–10 issues per milestone. Tracked as a GitHub Milestone.
+- **Issue**: A complete capability with 3–5 tasks. Produces a PR with ~5+ commits. 5–10 per milestone. Tracked as GitHub Issues linked to the milestone.
+
+A milestone is **done** when its acceptance criterion passes in CI — not when the code exists.
+
+### Component Scopes
+
+`project/components.md` maps each codebase component to its source files and
+dependencies. Skills use this to limit context window usage. When working an
+issue, load only the relevant component and its direct dependencies — do not
+explore the full codebase.
+
+### Decision Log
+
+Every non-obvious architectural decision goes in `project/epoch_N/decision_log.md` with:
+- The decision made
+- Alternatives considered
+- Rationale at the time
+
+This is a first-class artifact. Before refactoring something that seems wrong, check the decision log — there may be a reason.
+
+### Epoch Directory Structure
+
+```
+project/
+  initial.md          # original architectural specification (read-only reference)
+  vision.md           # north star — design commitments and philosophy
+  horizons.md         # validated but unscheduled architectural ideas
+  epoch_1/
+    roadmap.md        # milestones, goals, acceptance criteria
+    decision_log.md   # architectural decisions + rationale
+    retrospective.md  # written at epoch end — what held, what didn't
+  epoch_2/
+    ...
+```
+
+---
+
+## Mathematical Invariants
+
+These must hold exactly (to machine precision where applicable) and must be verified by tests:
+
+- **dd = 0**: applying the exterior derivative twice yields zero (cohomological identity); test on random inputs
+- **∇·B = 0**: discrete magnetic divergence identically zero — enforced structurally, not approximately
+- **Circulation conservation**: total circulation over macroscopic loops preserved for incompressible Euler flows
+
+Property-based tests on random meshes and random cochain inputs are the primary correctness mechanism for discrete operators. An operator is not implemented until this kind of test exists and passes.
+
+---
+
+## Code Conventions
+
+### Zig
+
+- Use `comptime` to enforce k-form type safety — a function accepting a 1-form must reject a 2-form at compile time, not runtime
+- SoA layout via `std.MultiArrayList` for all mesh entities; justify explicitly if deviating
+- Explicit allocators everywhere — no hidden heap allocations
+- `const` by default; mutability is the exception and should be obvious
+- Assert preconditions and invariants with `std.debug.assert`; assertions are not optional
+- All loops must be bounded — no unbounded iteration
+
+### Naming
+
+- Full words, no abbreviations: `exterior_derivative`, not `ext_deriv`; `boundary_operator`, not `bop`
+- Units and qualifiers appended in descending significance: `volume_dual_meters3`, `count_cells_max`
+
+### Diagrams
+
+- Use Mermaid (` ```mermaid ` code blocks) for all graphs, flowcharts, and dependency diagrams
+- Never use ASCII box-drawing art — it breaks across fonts and renderers
+
+### Comments
+
+- Explain *why*, not what — the code says what
+- Mathematical content uses Unicode symbols: ∂, ∇, ∈, ★, ∧, ⟨⟩, Ω
+- Cite sources with author, title, and equation number — do not cite fabricated URLs
+
+### Testing
+
+- Write the mathematical property test before the implementation
+- Use `std.testing.expectEqual` for exact checks; tolerance-based comparison for floating-point with explicit epsilon
+- Test names should state the invariant: `test "dd = 0 for random 1-forms on triangular mesh"`
+
+---
+
+## GitHub Labels
+
+Labels are defined in `.github/settings.yml` (managed by Probot) and auto-applied to PRs via `.github/labeler.yml` based on changed file paths.
+
+| Prefix | Purpose | Values |
+|--------|---------|--------|
+| `type/` | Kind of work | `bug`, `feature`, `invariant`, `perf`, `docs`, `refactor`, `test`, `ci` |
+| `phase/` | Roadmap phase | `1` through `5` |
+| `domain/` | Codebase area | `topology`, `forms`, `operators`, `io`, `em`, `fluid`, `build` |
+| `priority/` | Urgency | `high`, `medium`, `low` |
+| `status/` | Workflow state | `blocked`, `needs-decision`, `good-first-issue` |
+
+When creating issues, always set `type/`, `phase/`, `domain/`, and `priority/`. Use labels for filtering:
+```sh
+gh issue list --label "phase/1,type/feature"   # current phase features
+gh issue list --label "type/invariant"          # all math property work
+gh issue list --label "status/blocked"          # what's stuck
+```
+
+## Issue Templates
+
+Three templates in `.github/ISSUE_TEMPLATE/`:
+- **implementation** — new functionality; requires a concrete acceptance criterion
+- **bug** — broken/incorrect behavior; asks for the violated invariant
+- **invariant** — mathematical property to implement or verify; requires a test plan
+
+Blank issues are disabled. Every issue must use a template.
+
+## CI
+
+Four jobs run in parallel on every push and PR (`.github/workflows/ci.yml`):
+
+| Job | Command | What it catches |
+|-----|---------|-----------------|
+| `build` | `zig build` | Type errors, comptime failures |
+| `test` | `zig build test` | All `test` blocks |
+| `fmt` | `zig fmt --check src/ build.zig` | Formatting |
+| `lint` | `zig ast-check` on all `.zig` files | Parse/AST errors without full codegen |
+
+All four must pass. Branch protection is configured in `.github/settings.yml`.
+
+---
+
+## Skills
+
+### Development workflow
+
+| Skill | Invoked by | When |
+|-------|-----------|------|
+| `/ideate` | user | Sharing raw ideas, brainstorming features, thinking aloud about project direction |
+| `/epoch` | user | Planning upcoming work, discussing what to build next |
+| `/milestone` | user | Epoch is planned, ready to create GitHub artifacts for a specific milestone |
+| `/tackle` | user | Ready to start coding, asks "what should I work on" |
+| `/decide` | agent (during `/tackle`) or user | A non-obvious architectural choice is made during implementation |
+| `/review` | user | A PR is ready for review. Agent reviews implementation details; user reviews API + tests |
+| `/retro` | user | Epoch boundary — reconstruct decisions, write retrospective, identify improvements |
+| `/status` | user | Asks about progress, what's done, what's next, or what's blocking |
+
+### Code quality (run on `main`, between epochs or mid-epoch)
+
+| Skill | What it checks |
+|-------|---------------|
+| `/audit` | **Umbrella** — spawns all four lenses in parallel, consolidates results |
+| `/audit-safety` | Assertion coverage, bounds, memory safety, numerical safety, invariant enforcement |
+| `/audit-style` | Naming, dead code, stale references, comment quality, duplication |
+| `/audit-perf` | Memory layout, allocation patterns, algorithmic efficiency, SIMD readiness |
+| `/audit-tests` | Coverage gaps, property test quality, redundancy, convergence tests, comptime promotion |
+
+### Workflow sequence
+
+```
+/ideate → /epoch → /milestone → /tackle (→ /decide as needed) → /review → /retro
+                                                    ↑
+                                          /audit-* (between epochs or mid-epoch)
+```
+
+**Proactive suggestions:**
+- When the user shares loose ideas or "what if" thoughts → suggest `/ideate`
+- After any planning discussion → suggest `/epoch` if no epoch doc exists yet
+- After epoch doc exists and user asks about a milestone → suggest `/milestone`
+- At the start of a coding session → suggest `/tackle` with a preview of the top issue
+- After implementation work completes → suggest `/review` before merging
+- At epoch boundaries → suggest `/retro` before starting next epoch planning
+- When code feels messy or between epochs → suggest `/audit-*` to generate hygiene issues
+
+---
+
+## Target Directory Layout
+
+```
+src/
+  root.zig          # library entry point — re-exports public API
+  main.zig          # stub CLI (directs to examples)
+  topology/         # CW complexes, incidence matrices
+  forms/            # discrete k-forms / cochains
+  operators/        # d, ★, and their compositions
+  math/             # sparse linear algebra primitives
+  io/               # VTK export
+  integrators/      # generic time steppers (leapfrog, forward Euler)
+  concepts/         # comptime concept validators
+examples/
+  maxwell_2d/       # 2D electromagnetic simulation (cavity, dipole)
+project/
+  initial.md
+  epoch_1/
+  epoch_2/
+  ...
+```


### PR DESCRIPTION
## What
Replace symlinked Codex skill entrypoints with real copied files and make AGENTS.md a real file instead of a symlink to .claude/CLAUDE.md.

## Why
The previous PR missed that some Codex skill entrypoints and AGENTS.md were still symlinks. If symlink resolution is unreliable in downstream tooling, discovery can fail even when the content is correct.

## Changes
- convert .agents/skills/review/SKILL.md to a regular file copy
- convert .agents/skills/status/SKILL.md to a regular file copy
- convert .agents/skills/tackle/SKILL.md to a regular file copy
- convert AGENTS.md to a regular file copy of .claude/CLAUDE.md

## Validation
- verified the affected paths are regular files, not symlinks
- verified the copied contents match the Claude source files

## Notes
This is intentionally narrow and only fixes the remaining symlink-backed mirrors that were left behind.