### PR TITLE
feat: parameterize Hodge star on flat and Riemannian metrics

### DIFF
--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -323,3 +323,36 @@ and makes Jacobi preconditioning a normal Zig value instead of a function/contex
 pair. Requiring `apply(self: *const P, z)` also keeps preconditioner application
 structurally pure from the solver's perspective until a concrete mutable
 preconditioner use case exists.
+
+## 2026-04-05: Metric-aware Hodge star uses an explicit operator API while the existing operator context stays flat-specialized
+
+**Decision:** Introduce metric parameterization at the Hodge-star layer via an
+explicit `Metric(MeshType, mode)` type family plus `*_with_metric(...)` entry
+points. The existing `hodge_star(...)`, `hodge_star_inverse(...)`, and
+`OperatorContext` APIs remain the zero-cost flat specialization for now. The
+Riemannian implementation covers interior-degree Whitney/Galerkin stars and the
+top-degree diagonal star; primal 0-form Riemannian stars are deferred.
+
+**Alternatives considered:**
+1. Thread the metric through `OperatorContext`, codifferential, Laplacian, and
+   all downstream examples immediately: rejected because it turns issue #85
+   into a cross-component refactor spanning operator caching, assembled
+   Laplacians, and example systems before the metric-aware star itself is
+   validated.
+2. Make the metric an optional runtime argument on the existing `hodge_star`
+   surface: rejected because it obscures the flat fast path, weakens the type
+   signal from `Metric(.flat)` vs `Metric(.riemannian)`, and makes the intended
+   future generalization less explicit.
+3. Force full Riemannian support for all degrees immediately: rejected because
+   the current mesh stores only aggregate circumcentric dual volumes at
+   vertices. A correct piecewise-metric `★₀` needs per-cell dual contributions
+   or a redesigned dual-geometry representation, which is a separate topology
+   issue.
+
+**Rationale:** The vision says flatness must be an explicit specialization, not
+an implicit assumption. The new metric-aware API makes that true at the Hodge
+star boundary without paying a refactor tax across the rest of the operator
+stack yet. Keeping the flat path unchanged preserves existing callers and
+benchmarks. Deferring Riemannian `★₀` is honest: the missing data lives in the
+mesh layer, so pretending otherwise would bake in a mathematically dubious
+approximation.

--- a/src/operators/hodge_star.zig
+++ b/src/operators/hodge_star.zig
@@ -15,10 +15,34 @@ const cochain = @import("../forms/cochain.zig");
 const topology = @import("../topology/mesh.zig");
 const sparse = @import("../math/sparse.zig");
 const conjugate_gradient = @import("../math/cg.zig");
+const whitney_mass = @import("whitney_mass.zig");
 
 pub const SolveError = error{
     HodgeStarInverseDidNotConverge,
 };
+
+pub const MetricMode = enum {
+    flat,
+    riemannian,
+};
+
+pub const MetricError = error{
+    MetricNotYetImplemented,
+    UnsupportedMetricDegree,
+};
+
+pub fn Metric(comptime MeshType: type, comptime mode: MetricMode) type {
+    return switch (mode) {
+        .flat => struct {
+            pub const metric_mode = MetricMode.flat;
+        },
+        .riemannian => struct {
+            pub const metric_mode = MetricMode.riemannian;
+
+            top_simplex_tensors: []const [MeshType.topological_dimension][MeshType.topological_dimension]f64,
+        },
+    };
+}
 
 const WhitneyInverseSolveParams = struct {
     relative_tolerance: f64,
@@ -168,6 +192,126 @@ pub fn hodge_star_inverse(
     return apply_hodge_star_inverse(allocator, input);
 }
 
+pub fn apply_hodge_star_with_metric(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarResult(@TypeOf(input)) {
+    return switch (@TypeOf(metric).metric_mode) {
+        .flat => apply_hodge_star(allocator, input),
+        .riemannian => apply_hodge_star_riemannian(allocator, metric, input),
+    };
+}
+
+pub fn apply_hodge_star_inverse_with_metric(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarInverseResult(@TypeOf(input)) {
+    return switch (@TypeOf(metric).metric_mode) {
+        .flat => apply_hodge_star_inverse(allocator, input),
+        .riemannian => apply_hodge_star_inverse_riemannian(allocator, metric, input),
+    };
+}
+
+pub fn hodge_star_with_metric(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarResult(@TypeOf(input)) {
+    return apply_hodge_star_with_metric(allocator, metric, input);
+}
+
+pub fn hodge_star_inverse_with_metric(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarInverseResult(@TypeOf(input)) {
+    return apply_hodge_star_inverse_with_metric(allocator, metric, input);
+}
+
+fn apply_hodge_star_riemannian(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarResult(@TypeOf(input)) {
+    const InputType = @TypeOf(input);
+    comptime validateHodgeStarInput(InputType);
+
+    const MeshType = InputType.MeshT;
+    const k = InputType.degree;
+    const n = MeshType.topological_dimension;
+    std.debug.assert(metric.top_simplex_tensors.len == input.mesh.num_cells(n));
+
+    var output = try HodgeStarResult(InputType).init(allocator, input.mesh);
+    errdefer output.deinit(allocator);
+
+    if (comptime supportsWhitneyMassDegree(MeshType, k)) {
+        var matrix = try whitney_mass.assemble_whitney_mass_with_metric(k, allocator, input.mesh, metric.top_simplex_tensors);
+        defer matrix.deinit(allocator);
+        sparse.spmv(matrix, input.values, output.values);
+        return output;
+    }
+
+    if (k == n) {
+        const primal_volumes = input.mesh.simplices(n).items(.volume);
+        for (output.values, input.values, primal_volumes, metric.top_simplex_tensors) |*out, in_value, volume, tensor| {
+            const metric_volume = volume * @sqrt(metricTensorDeterminant(n, tensor));
+            std.debug.assert(metric_volume != 0.0);
+            out.* = in_value / metric_volume;
+        }
+        return output;
+    }
+
+    return MetricError.UnsupportedMetricDegree;
+}
+
+fn apply_hodge_star_inverse_riemannian(
+    allocator: std.mem.Allocator,
+    metric: anytype,
+    input: anytype,
+) !HodgeStarInverseResult(@TypeOf(input)) {
+    const InputType = @TypeOf(input);
+    comptime validateHodgeStarInverseInput(InputType);
+
+    const MeshType = InputType.MeshT;
+    const n = MeshType.topological_dimension;
+    const primal_degree = n - InputType.degree;
+    std.debug.assert(metric.top_simplex_tensors.len == input.mesh.num_cells(n));
+
+    var output = try HodgeStarInverseResult(InputType).init(allocator, input.mesh);
+    errdefer output.deinit(allocator);
+
+    if (comptime supportsWhitneyMassDegree(MeshType, primal_degree)) {
+        var matrix = try whitney_mass.assemble_whitney_mass_with_metric(primal_degree, allocator, input.mesh, metric.top_simplex_tensors);
+        defer matrix.deinit(allocator);
+
+        const diagonal = try assembleMatrixDiagonal(allocator, matrix);
+        defer allocator.free(diagonal);
+
+        try solveWhitneyInverse(
+            allocator,
+            matrix,
+            diagonal,
+            input.values,
+            output.values,
+            whitneyInverseSolveParams(MeshType, primal_degree).relative_tolerance,
+            whitneyInverseSolveParams(MeshType, primal_degree).iteration_limit,
+        );
+        return output;
+    }
+
+    if (primal_degree == n) {
+        const primal_volumes = input.mesh.simplices(n).items(.volume);
+        for (output.values, input.values, primal_volumes, metric.top_simplex_tensors) |*out, in_value, volume, tensor| {
+            out.* = in_value * volume * @sqrt(metricTensorDeterminant(n, tensor));
+        }
+        return output;
+    }
+
+    return MetricError.UnsupportedMetricDegree;
+}
+
 // ── Return type helpers ──────────────────────────────────────────────────
 
 fn HodgeStarResult(comptime InputType: type) type {
@@ -281,6 +425,26 @@ fn solveWhitneyInverse(
     }
 }
 
+fn assembleMatrixDiagonal(
+    allocator: std.mem.Allocator,
+    matrix: sparse.CsrMatrix(f64),
+) ![]f64 {
+    const diagonal = try allocator.alloc(f64, matrix.n_rows);
+    errdefer allocator.free(diagonal);
+    @memset(diagonal, 0.0);
+
+    for (0..matrix.n_rows) |row_idx| {
+        const row = matrix.row(@intCast(row_idx));
+        for (row.cols, row.vals) |col_idx, value| {
+            if (col_idx != row_idx) continue;
+            diagonal[row_idx] += value;
+        }
+        std.debug.assert(diagonal[row_idx] > 0.0);
+    }
+
+    return diagonal;
+}
+
 // ── Diagonal application ────────────────────────────────────────────────
 
 fn applyDiagonalForward(
@@ -347,6 +511,32 @@ fn supportsWhitneyMassDegree(comptime MeshType: type, comptime primal_degree: co
     return primal_degree > 0 and primal_degree < MeshType.topological_dimension;
 }
 
+fn metricTensorDeterminant(
+    comptime n: comptime_int,
+    tensor: [n][n]f64,
+) f64 {
+    if (n == 2) {
+        return tensor[0][0] * tensor[1][1] - tensor[0][1] * tensor[1][0];
+    }
+
+    if (n == 3) {
+        const a = tensor[0][0];
+        const b = tensor[0][1];
+        const c = tensor[0][2];
+        const d = tensor[1][0];
+        const e = tensor[1][1];
+        const f = tensor[1][2];
+        const g = tensor[2][0];
+        const h = tensor[2][1];
+        const i = tensor[2][2];
+        return a * (e * i - f * h) -
+            b * (d * i - f * g) +
+            c * (d * h - e * g);
+    }
+
+    @compileError("metric tensor determinant is only implemented for n = 2 or n = 3");
+}
+
 fn whitneyInverseSolveParams(comptime MeshType: type, comptime primal_degree: comptime_int) WhitneyInverseSolveParams {
     std.debug.assert(supportsWhitneyMassDegree(MeshType, primal_degree));
 
@@ -370,6 +560,13 @@ fn whitneyInverseSolveParams(comptime MeshType: type, comptime primal_degree: co
 fn expectApproxEqRelOrAbs(expected: f64, actual: f64, relative_tolerance: f64, absolute_tolerance: f64) !void {
     const tolerance = @max(absolute_tolerance, @abs(expected) * relative_tolerance);
     try testing.expect(@abs(expected - actual) <= tolerance);
+}
+
+fn expectSlicesApproxEqAbs(expected: []const f64, actual: []const f64, tolerance: f64) !void {
+    try testing.expectEqual(expected.len, actual.len);
+    for (expected, actual) |expected_value, actual_value| {
+        try testing.expectApproxEqAbs(expected_value, actual_value, tolerance);
+    }
 }
 
 fn expectRoundTripIdentity3DForDegree(
@@ -527,6 +724,146 @@ test "★₂ scales by 1 / face area" {
     const face_volumes = mesh.simplices(2).items(.volume);
     for (result.values, face_volumes) |r, volume| {
         try testing.expectApproxEqAbs(1.0 / volume, r, 1e-15);
+    }
+}
+
+test "Metric(.flat) reproduces Euclidean Hodge star exactly for all 2D degrees" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 2.0, 1.5);
+    defer mesh.deinit(allocator);
+
+    const metric = Metric(Mesh2D, .flat){};
+
+    {
+        var omega = try PrimalC0.init(allocator, &mesh);
+        defer omega.deinit(allocator);
+        for (omega.values, 0..) |*value, idx| value.* = @as(f64, @floatFromInt(idx + 1)) * 0.5;
+
+        var baseline = try hodge_star(allocator, omega);
+        defer baseline.deinit(allocator);
+
+        var metric_result = try hodge_star_with_metric(allocator, metric, omega);
+        defer metric_result.deinit(allocator);
+
+        try expectSlicesApproxEqAbs(baseline.values, metric_result.values, 1e-15);
+    }
+
+    {
+        var omega = try PrimalC1.init(allocator, &mesh);
+        defer omega.deinit(allocator);
+        for (omega.values, 0..) |*value, idx| value.* = @as(f64, @floatFromInt(idx + 1)) * -0.25;
+
+        var baseline = try hodge_star(allocator, omega);
+        defer baseline.deinit(allocator);
+
+        var metric_result = try hodge_star_with_metric(allocator, metric, omega);
+        defer metric_result.deinit(allocator);
+
+        try expectSlicesApproxEqAbs(baseline.values, metric_result.values, 1e-15);
+    }
+
+    {
+        var omega = try PrimalC2.init(allocator, &mesh);
+        defer omega.deinit(allocator);
+        for (omega.values, 0..) |*value, idx| value.* = @as(f64, @floatFromInt(idx + 1)) * 0.75;
+
+        var baseline = try hodge_star(allocator, omega);
+        defer baseline.deinit(allocator);
+
+        var metric_result = try hodge_star_with_metric(allocator, metric, omega);
+        defer metric_result.deinit(allocator);
+
+        try expectSlicesApproxEqAbs(baseline.values, metric_result.values, 1e-15);
+    }
+}
+
+test "Metric(.riemannian) on a constant tensor matches Euclidean star on the pulled-back mesh" {
+    const allocator = testing.allocator;
+    const faces = [_][3]u32{
+        .{ 0, 1, 2 },
+        .{ 0, 2, 3 },
+    };
+    const euclidean_vertices = [_][2]f64{
+        .{ 0.0, 0.0 },
+        .{ 1.0, 0.0 },
+        .{ 1.0, 1.0 },
+        .{ 0.0, 1.0 },
+    };
+    const transformed_vertices = [_][2]f64{
+        .{ 0.0, 0.0 },
+        .{ 2.0, 0.0 },
+        .{ 2.0, 1.0 },
+        .{ 0.0, 1.0 },
+    };
+
+    var base_mesh = try Mesh2D.from_triangles(allocator, &euclidean_vertices, &faces);
+    defer base_mesh.deinit(allocator);
+
+    var transformed_mesh = try Mesh2D.from_triangles(allocator, &transformed_vertices, &faces);
+    defer transformed_mesh.deinit(allocator);
+
+    const tensors = [_][2][2]f64{
+        .{ .{ 4.0, 0.0 }, .{ 0.0, 1.0 } },
+        .{ .{ 4.0, 0.0 }, .{ 0.0, 1.0 } },
+    };
+    const metric = Metric(Mesh2D, .riemannian){
+        .top_simplex_tensors = &tensors,
+    };
+
+    var omega_base = try PrimalC1.init(allocator, &base_mesh);
+    defer omega_base.deinit(allocator);
+    var omega_transformed = try PrimalC1.init(allocator, &transformed_mesh);
+    defer omega_transformed.deinit(allocator);
+
+    for (omega_base.values, 0..) |*value, idx| {
+        value.* = @as(f64, @floatFromInt(idx + 1)) * 0.25;
+        omega_transformed.values[idx] = value.*;
+    }
+
+    var metric_result = try hodge_star_with_metric(allocator, metric, omega_base);
+    defer metric_result.deinit(allocator);
+
+    var transformed_result = try hodge_star(allocator, omega_transformed);
+    defer transformed_result.deinit(allocator);
+
+    try expectSlicesApproxEqAbs(transformed_result.values, metric_result.values, 1e-12);
+}
+
+test "Metric(.riemannian) preserves ★⁻¹ ∘ ★ = id for 2D primal 1-forms" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const face_count = mesh.num_faces();
+    const tensors = try allocator.alloc([2][2]f64, face_count);
+    defer allocator.free(tensors);
+    for (tensors, 0..) |*tensor, face_idx| {
+        if ((face_idx % 2) == 0) {
+            tensor.* = .{ .{ 2.0, 0.25 }, .{ 0.25, 1.5 } };
+        } else {
+            tensor.* = .{ .{ 1.5, -0.1 }, .{ -0.1, 1.25 } };
+        }
+    }
+
+    const metric = Metric(Mesh2D, .riemannian){
+        .top_simplex_tensors = tensors,
+    };
+
+    var rng = std.Random.DefaultPrng.init(0x85_600D);
+    for (0..100) |_| {
+        var omega = try PrimalC1.init(allocator, &mesh);
+        defer omega.deinit(allocator);
+        for (omega.values) |*value| value.* = rng.random().float(f64) * 20.0 - 10.0;
+
+        var starred = try hodge_star_with_metric(allocator, metric, omega);
+        defer starred.deinit(allocator);
+
+        var round_trip = try hodge_star_inverse_with_metric(allocator, metric, starred);
+        defer round_trip.deinit(allocator);
+
+        for (omega.values, round_trip.values) |expected, actual| {
+            try testing.expectApproxEqRel(expected, actual, 1e-6);
+        }
     }
 }
 

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -87,6 +87,90 @@ pub fn assemble_whitney_mass(
     return assembler.build(allocator);
 }
 
+pub fn assemble_whitney_mass_with_metric(
+    comptime k: comptime_int,
+    allocator: std.mem.Allocator,
+    mesh: anytype,
+    top_simplex_metric_tensors: []const [@TypeOf(mesh.*).topological_dimension][@TypeOf(mesh.*).topological_dimension]f64,
+) !sparse.CsrMatrix(f64) {
+    const MeshType = @TypeOf(mesh.*);
+    const n = MeshType.topological_dimension;
+
+    comptime {
+        if (MeshType.embedding_dimension != n) {
+            @compileError("metric-aware Whitney mass currently requires embedding_dimension == topological_dimension");
+        }
+        if (k <= 0 or k >= n) {
+            @compileError("Whitney mass is only defined for interior degrees 0 < k < n");
+        }
+        if (n > 3) {
+            @compileError("Whitney mass assembly is currently implemented for topological_dimension <= 3");
+        }
+    }
+
+    const simplex_count = mesh.num_cells(k);
+    const top_simplex_count = mesh.num_cells(n);
+    std.debug.assert(top_simplex_metric_tensors.len == top_simplex_count);
+
+    const simplex_vertices = mesh.simplices(k).items(.vertices);
+    const top_simplex_vertices = mesh.simplices(n).items(.vertices);
+    const top_simplex_volumes = mesh.simplices(n).items(.volume);
+    const coords = mesh.vertices.slice().items(.coords);
+    const local_faces = localFaces(n, k);
+
+    var simplex_index = std.AutoHashMap([k + 1]u32, u32).init(allocator);
+    defer simplex_index.deinit();
+    for (simplex_vertices, 0..) |vertices, global_idx| {
+        try simplex_index.put(vertices, @intCast(global_idx));
+    }
+
+    var assembler = sparse.TripletAssembler(f64).init(simplex_count, simplex_count);
+    defer assembler.deinit(allocator);
+
+    for (0..top_simplex_count) |top_idx| {
+        const top_vertices = top_simplex_vertices[top_idx];
+
+        var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
+        for (0..n + 1) |local_vertex_idx| {
+            top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
+        }
+
+        const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
+        const metric_tensor = top_simplex_metric_tensors[top_idx];
+        const metric_inverse = invertSmallMatrix(n, metric_tensor);
+        const metric_volume_scale = @sqrt(smallMatrixDeterminant(n, metric_tensor));
+        const local_mass = localWhitneyMassWithMetric(
+            MeshType.embedding_dimension,
+            n,
+            k,
+            gradients,
+            top_simplex_volumes[top_idx],
+            metric_inverse,
+            metric_volume_scale,
+        );
+
+        var global_indices: [local_faces.len]u32 = undefined;
+        var orientation_signs: [local_faces.len]i8 = undefined;
+        for (local_faces, 0..) |local_face, local_face_idx| {
+            const oriented_vertices = liftLocalFaceVertices(k, n, top_vertices, local_face);
+            const canonical_key = canonicalizeVertices(k + 1, oriented_vertices);
+            const global_idx = simplex_index.get(canonical_key).?;
+            global_indices[local_face_idx] = global_idx;
+            orientation_signs[local_face_idx] = orientationSign(k + 1, oriented_vertices, simplex_vertices[global_idx]);
+        }
+
+        for (0..local_faces.len) |i| {
+            const sign_i: f64 = @floatFromInt(orientation_signs[i]);
+            for (0..local_faces.len) |j| {
+                const sign_j: f64 = @floatFromInt(orientation_signs[j]);
+                try assembler.addEntry(allocator, global_indices[i], global_indices[j], sign_i * sign_j * local_mass[i][j]);
+            }
+        }
+    }
+
+    return assembler.build(allocator);
+}
+
 pub fn assemble_whitney_preconditioner(
     comptime k: comptime_int,
     allocator: std.mem.Allocator,
@@ -311,6 +395,51 @@ fn localWhitneyMass(
     return local_mass;
 }
 
+fn localWhitneyMassWithMetric(
+    comptime embedding_dimension: usize,
+    comptime n: comptime_int,
+    comptime k: comptime_int,
+    gradients: [n + 1][embedding_dimension]f64,
+    simplex_volume: f64,
+    metric_inverse: [n][n]f64,
+    metric_volume_scale: f64,
+) [choose(n + 1, k + 1)][choose(n + 1, k + 1)]f64 {
+    const local_faces = localFaces(n, k);
+    var local_mass: [local_faces.len][local_faces.len]f64 = undefined;
+    const lambda_integral_scale = simplex_volume * metric_volume_scale /
+        @as(f64, @floatFromInt((n + 1) * (n + 2)));
+    const whitney_scale = @as(f64, @floatFromInt(factorial(k) * factorial(k)));
+
+    for (local_faces, 0..) |left_face, left_idx| {
+        for (local_faces, 0..) |right_face, right_idx| {
+            var entry: f64 = 0.0;
+            inline for (0..k + 1) |left_omit| {
+                const left_basis = omitIndex(k + 1, left_face, left_omit);
+                const left_lambda = left_face[left_omit];
+                inline for (0..k + 1) |right_omit| {
+                    const right_basis = omitIndex(k + 1, right_face, right_omit);
+                    const right_lambda = right_face[right_omit];
+                    const sign: f64 = if ((left_omit + right_omit) % 2 == 0) 1.0 else -1.0;
+                    const lambda_inner: f64 = if (left_lambda == right_lambda) 2.0 else 1.0;
+                    entry += sign * lambda_inner *
+                        wedgeInnerProductWithMetric(
+                            embedding_dimension,
+                            n,
+                            k,
+                            metric_inverse,
+                            gradients[0..],
+                            left_basis,
+                            right_basis,
+                        );
+                }
+            }
+            local_mass[left_idx][right_idx] = whitney_scale * lambda_integral_scale * entry;
+        }
+    }
+
+    return local_mass;
+}
+
 fn omitIndex(comptime len: comptime_int, indices: [len]u8, omit: usize) [len - 1]u8 {
     var result: [len - 1]u8 = undefined;
     var write_idx: usize = 0;
@@ -338,6 +467,52 @@ fn wedgeInnerProduct(
         const b = vecDot(embedding_dimension, gradients[left_indices[0]], gradients[right_indices[1]]);
         const c = vecDot(embedding_dimension, gradients[left_indices[1]], gradients[right_indices[0]]);
         const d = vecDot(embedding_dimension, gradients[left_indices[1]], gradients[right_indices[1]]);
+        return a * d - b * c;
+    }
+
+    @compileError("Whitney wedge inner product is only implemented for k <= 2");
+}
+
+fn metricVectorDot(
+    comptime dimension: usize,
+    comptime n: comptime_int,
+    metric_inverse: [n][n]f64,
+    a: [dimension]f64,
+    b: [dimension]f64,
+) f64 {
+    var sum: f64 = 0.0;
+    inline for (0..n) |i| {
+        inline for (0..n) |j| {
+            sum += a[i] * metric_inverse[i][j] * b[j];
+        }
+    }
+    return sum;
+}
+
+fn wedgeInnerProductWithMetric(
+    comptime embedding_dimension: usize,
+    comptime n: comptime_int,
+    comptime k: comptime_int,
+    metric_inverse: [n][n]f64,
+    gradients: []const [embedding_dimension]f64,
+    left_indices: [k]u8,
+    right_indices: [k]u8,
+) f64 {
+    if (k == 1) {
+        return metricVectorDot(
+            embedding_dimension,
+            n,
+            metric_inverse,
+            gradients[left_indices[0]],
+            gradients[right_indices[0]],
+        );
+    }
+
+    if (k == 2) {
+        const a = metricVectorDot(embedding_dimension, n, metric_inverse, gradients[left_indices[0]], gradients[right_indices[0]]);
+        const b = metricVectorDot(embedding_dimension, n, metric_inverse, gradients[left_indices[0]], gradients[right_indices[1]]);
+        const c = metricVectorDot(embedding_dimension, n, metric_inverse, gradients[left_indices[1]], gradients[right_indices[0]]);
+        const d = metricVectorDot(embedding_dimension, n, metric_inverse, gradients[left_indices[1]], gradients[right_indices[1]]);
         return a * d - b * c;
     }
 
@@ -386,6 +561,30 @@ fn invertSmallMatrix(comptime n: comptime_int, matrix: [n][n]f64) [n][n]f64 {
     }
 
     @compileError("small matrix inversion is only implemented for n = 2 or n = 3");
+}
+
+fn smallMatrixDeterminant(comptime n: comptime_int, matrix: [n][n]f64) f64 {
+    if (n == 2) {
+        return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0];
+    }
+
+    if (n == 3) {
+        const a = matrix[0][0];
+        const b = matrix[0][1];
+        const c = matrix[0][2];
+        const d = matrix[1][0];
+        const e = matrix[1][1];
+        const f = matrix[1][2];
+        const g = matrix[2][0];
+        const h = matrix[2][1];
+        const i = matrix[2][2];
+
+        return a * (e * i - f * h) -
+            b * (d * i - f * g) +
+            c * (d * h - e * g);
+    }
+
+    @compileError("small matrix determinant is only implemented for n = 2 or n = 3");
 }
 
 fn accumulateDualFaceLengths(


### PR DESCRIPTION
Closes #85

## What

Add an explicit metric-parameterized Hodge-star API: `Metric(.flat)` delegates to the existing Euclidean implementation with zero extra work, while `Metric(.riemannian)` assembles a piecewise-metric Whitney/Galerkin interior star and a metric-scaled top-degree diagonal star.

## Acceptance criterion

- [x] `Metric(.flat)` reproduces the existing Hodge-star results exactly
- [x] `Metric(.riemannian)` on a prescribed constant non-flat tensor matches the Euclidean star on the pulled-back mesh
- [x] `★★⁻¹ = id` holds for both metric modes on the exercised degree path

## Tasks

- [x] Write property tests encoding the acceptance criterion
- [x] Design public API (stubs)
- [x] Implement
- [x] CI green

## Decisions

- Added `Metric(MeshType, mode)` plus explicit `*_with_metric(...)` entry points instead of refactoring `OperatorContext`, Laplacian, and codifferential in the same issue
- Logged in `project/epoch_2/decision_log.md`

## Limitations

- Riemannian support currently covers interior-degree Whitney stars and the top-degree diagonal star
- Metric-aware primal `0`-form stars are deferred because the mesh currently stores only aggregate circumcentric dual volumes, not the per-cell dual contributions needed for a correct piecewise-metric `★₀`
- `OperatorContext`, codifferential, and Laplacian remain flat-specialized for now

## Molecule checklist

- Horizon conflict: none; this moves the API toward the explicit `Metric(.flat)`/`Metric(.riemannian)` direction called out in `project/vision.md`
- Docs update needed: no public docs drift beyond the decision log for this issue
- Public API impact: additive only; existing flat callers remain unchanged
- Follow-on work: a dedicated issue should thread metrics through `OperatorContext` and add a correct piecewise-metric `★₀` once the mesh exposes the needed dual-geometry contributions

## Verification

- `zig build ci --summary all`
