### PR TITLE
[codex] Centralize boundary queries and deduplicate Dirichlet solve orchestration

### DIFF
--- a/.agents/skills/audit-cleanup/SKILL.md
+++ b/.agents/skills/audit-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-cleanup
-description: Audit the codebase for simplification opportunities: deduplication, unnecessary indirection, API sprawl, shims, over-specialized code, and file-structure cleanup. Use when the repo feels harder to use or change than it should, especially before filing or starting refactor issues.
+description: "Audit the codebase for simplification opportunities: deduplication, unnecessary indirection, API sprawl, shims, over-specialized code, and file-structure cleanup. Use when the repo feels harder to use or change than it should, especially before filing or starting refactor issues."
 ---
 
 Audit the codebase for simplification pressure. This lens is stricter than style: it asks whether the code has too many concepts, too many public entry points, too many wrappers, or too many files for the capability it delivers.

--- a/.agents/skills/audit-cleanup/SKILL.md
+++ b/.agents/skills/audit-cleanup/SKILL.md
@@ -30,6 +30,8 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - Similar examples or modules that should be one parameterized implementation
 - Copy-paste APIs that differ only by naming instead of actual semantics
 - Genericization opportunities justified by at least two real call sites; do not reward speculative abstraction
+- Public APIs that claim to be generic but are implemented as a hardcoded case table over today's supported dimensions, degrees, or variants
+- Mathematical or structural definitions that can be expressed once from existing primitives (incidence, recursion, comptime relations) but are instead re-encoded by manual enumeration
 
 ### Shim and compatibility removal
 - Deprecated pathways, transitional adapters, or "for now" wrappers
@@ -47,6 +49,7 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - APIs with redundant `withX()` then `x()` patterns when a single demand-driven path would suffice
 - Parameter lists carrying compile-time or runtime information that can be derived
 - Names that expose mechanics instead of intent
+- Generic-looking entry points whose implementations still force maintainers to touch multiple branches for every new degree/dimension case
 
 ## Judgment rules
 
@@ -56,6 +59,9 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - Favor generic code only when multiple concrete sites already want the same shape.
 - Favor moving capability to the layer where it belongs. Example glue in the library is a smell; library workarounds in examples are also a smell.
 - Treat LOC reduction as a proxy, not a goal. Shorter code that weakens invariants is not a win.
+- If an API is sold as generic, ask whether the implementation is generic in the same sense. A disguised lookup table is usually not good enough.
+- In FEEC/DEC or topology-heavy code, prefer implementations derived from the mathematical object itself (`∂`, incidence, degree recursion, duality relation) over nested switches on `(dimension, degree)`.
+- Before accepting a refactor, ask: if we added one more supported degree/dimension, would this code naturally extend, or would we add another case? If another case is needed, call that out.
 
 ## Output format
 

--- a/.agents/skills/audit-cleanup/agents/openai.yaml
+++ b/.agents/skills/audit-cleanup/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Cleanup"
   short_description: "Audit simplification, API, and structural cleanup"
-  default_prompt: "Use $audit-cleanup to audit this repo for unnecessary indirection, duplication, public API sprawl, shims, and structural cleanup opportunities."
+  default_prompt: "Audit this codebase for unnecessary indirection, duplication, public API sprawl, shims, and structural cleanup opportunities."

--- a/.agents/skills/audit-style/SKILL.md
+++ b/.agents/skills/audit-style/SKILL.md
@@ -36,10 +36,20 @@ If a component is specified, scope to that component per `project/components.md`
 ### Structural consistency
 - Similar constructs should follow similar patterns (e.g., all operator types should have the same method shape)
 - Public API should be consistent in style (all snake_case, consistent parameter ordering)
+- Nested `switch` / `if` ladders over semantic axes like `(dimension, degree)` that may indicate a missing derived definition or comptime formulation rather than a true need for casework
+- Generic-looking APIs whose implementation style contradicts the abstraction they present
 
 ### Formatting
 - `zig fmt` compliance (should be caught by CI, but verify)
 - Consistent file organization (imports, types, functions, tests)
+
+## Pressure tests
+
+Before concluding that a style issue is only cosmetic, ask:
+
+- Is this "generic" function actually generic, or is it a manually enumerated case table?
+- Could the implementation be written once in terms of the native structure (incidence, recursion, comptime relation) instead of today’s supported cases?
+- Does this control flow naturally extend when the next degree/dimension/variant is added, or does it require editing multiple branches?
 
 ## Output format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ parallel convenience and "real" APIs unless there is a concrete current need.
 The project is pre-release; correctness and coherence matter more than
 backward compatibility with transitional interfaces.
 
+When an API is presented as degree-generic, dimension-generic, or otherwise
+mathematically generic, pressure-test the implementation too — not just the
+signature. A generic public API backed by a hardcoded case table over today's
+supported dimensions/degrees is usually a smell. Prefer implementations derived
+from the underlying structure or invariant (for example incidence, recursion,
+or a comptime relation) unless there is a clear measured performance reason not
+to.
+
 ---
 
 ## Hard Rules
@@ -238,6 +246,7 @@ Property-based tests on random meshes and random cochain inputs are the primary 
 - `const` by default; mutability is the exception and should be obvious
 - Assert preconditions and invariants with `std.debug.assert`; assertions are not optional
 - All loops must be bounded — no unbounded iteration
+- In topology/operator code, prefer implementations phrased in the native discrete objects (`∂`, incidence, degree relations) over nested casework on `(dimension, degree)` when the former expresses the same rule directly
 
 ### Naming
 

--- a/examples/diffusion_surface/surface.zig
+++ b/examples/diffusion_surface/surface.zig
@@ -9,11 +9,9 @@ const cg = flux.math.cg;
 const exterior_derivative = flux.operators.exterior_derivative;
 const hodge_star = flux.operators.hodge_star;
 
-pub const ReferenceMesh = flux.topology.Mesh(2, 2);
-pub const EmbeddedMesh = flux.topology.Mesh(3, 2);
-pub const VertexField = flux.forms.Cochain(ReferenceMesh, 0, flux.forms.Primal);
-pub const EdgeField = flux.forms.Cochain(ReferenceMesh, 1, flux.forms.Primal);
-pub const Metric2D = hodge_star.Metric(ReferenceMesh, .riemannian);
+pub const SurfaceMesh = flux.topology.Mesh(3, 2);
+pub const VertexField = flux.forms.Cochain(SurfaceMesh, 0, flux.forms.Primal);
+pub const EdgeField = flux.forms.Cochain(SurfaceMesh, 1, flux.forms.Primal);
 
 pub const Config = struct {
     refinement: u32 = 0,
@@ -41,26 +39,6 @@ pub const ConvergenceResult = struct {
     l2_error: f64,
 };
 
-// TODO(#154): This struct is a workaround. It exists because Mesh(D,K) with
-// D > K does not yet honor the metric induced by its own embedding — so we
-// must carry a parallel Mesh(2,2) reference mesh, an explicit per-face
-// metric tensor array, and the embedded Mesh(3,2) side by side. Once #154
-// lands, this collapses to a single `Mesh(3, 2)` and the stereographic
-// projection / metric tensor machinery in this file can be deleted. The
-// long-term endgame is the truly intrinsic IntrinsicMesh(K) tracked in
-// project/horizons.md.
-const SphereGeometry = struct {
-    reference_mesh: ReferenceMesh,
-    embedded_mesh: EmbeddedMesh,
-    metric_tensors: [][2][2]f64,
-
-    pub fn deinit(self: *SphereGeometry, allocator: std.mem.Allocator) void {
-        allocator.free(self.metric_tensors);
-        self.embedded_mesh.deinit(allocator);
-        self.reference_mesh.deinit(allocator);
-    }
-};
-
 const SurfaceSystem = struct {
     system_matrix: sparse.CsrMatrix(f64),
     masses: []f64,
@@ -69,22 +47,18 @@ const SurfaceSystem = struct {
 
     pub fn init(
         allocator: std.mem.Allocator,
-        geometry: *const SphereGeometry,
+        mesh: *const SurfaceMesh,
         dt: f64,
     ) !SurfaceSystem {
-        const metric = Metric2D{
-            .top_simplex_tensors = geometry.metric_tensors,
-        };
-
-        var stiffness = try assembleMetricStiffness(allocator, &geometry.reference_mesh, metric);
+        var stiffness = try assembleSurfaceStiffness(allocator, mesh);
         defer stiffness.deinit(allocator);
 
-        const masses = try assembleLumpedSurfaceMasses(allocator, &geometry.embedded_mesh);
+        const masses = try assembleLumpedSurfaceMasses(allocator, mesh);
         errdefer allocator.free(masses);
 
         var assembler = sparse.TripletAssembler(f64).init(
-            geometry.reference_mesh.num_vertices(),
-            geometry.reference_mesh.num_vertices(),
+            mesh.num_vertices(),
+            mesh.num_vertices(),
         );
         defer assembler.deinit(allocator);
 
@@ -107,7 +81,7 @@ const SurfaceSystem = struct {
             std.debug.assert(diagonal[row_idx] > 0.0);
         }
 
-        var scratch = try cg.Scratch.init(allocator, geometry.reference_mesh.num_vertices());
+        var scratch = try cg.Scratch.init(allocator, mesh.num_vertices());
         errdefer scratch.deinit(allocator);
 
         return .{
@@ -166,18 +140,18 @@ fn simulateCase(
     std.debug.assert(config.dt_scale > 0.0);
     std.debug.assert(config.final_time > 0.0);
 
-    var geometry = try buildSphereGeometry(allocator, config.refinement);
-    defer geometry.deinit(allocator);
+    var mesh = try buildSphereMesh(allocator, config.refinement);
+    defer mesh.deinit(allocator);
 
     const dt = config.timeStep();
-    var system = try SurfaceSystem.init(allocator, &geometry, dt);
+    var system = try SurfaceSystem.init(allocator, &mesh, dt);
     defer system.deinit(allocator);
 
-    var state = try VertexField.init(allocator, &geometry.reference_mesh);
+    var state = try VertexField.init(allocator, &mesh);
     defer state.deinit(allocator);
-    initializeState(&geometry.embedded_mesh, state.values, 0.0);
+    initializeState(&mesh, state.values, 0.0);
 
-    const exact = try allocator.alloc(f64, geometry.reference_mesh.num_vertices());
+    const exact = try allocator.alloc(f64, mesh.num_vertices());
     defer allocator.free(exact);
 
     const has_output = config.frames > 0;
@@ -197,9 +171,9 @@ fn simulateCase(
     defer series.deinit();
 
     if (series.enabled()) {
-        initializeState(&geometry.embedded_mesh, exact, 0.0);
+        initializeState(&mesh, exact, 0.0);
         try series.capture(0.0, SurfaceRenderer{
-            .mesh = &geometry.embedded_mesh,
+            .mesh = &mesh,
             .state = state.values,
             .exact = exact,
         });
@@ -217,9 +191,9 @@ fn simulateCase(
         try stepBackwardEuler(&system, state.values, rhs, solution);
         const last_step = step_idx + 1 == config.steps;
         if (series.enabled() and (series.dueAt(@intCast(step_idx + 1)) or last_step)) {
-            initializeState(&geometry.embedded_mesh, exact, next_time);
+            initializeState(&mesh, exact, next_time);
             try series.capture(next_time, SurfaceRenderer{
-                .mesh = &geometry.embedded_mesh,
+                .mesh = &mesh,
                 .state = state.values,
                 .exact = exact,
             });
@@ -227,8 +201,8 @@ fn simulateCase(
     }
     const elapsed_ns = std.time.nanoTimestamp() - start_ns;
 
-    initializeState(&geometry.embedded_mesh, exact, config.final_time);
-    const l2_error = weightedL2Error(&geometry.embedded_mesh, state.values, exact);
+    initializeState(&mesh, exact, config.final_time);
+    const l2_error = weightedL2Error(&mesh, state.values, exact);
 
     try series.finalize();
 
@@ -241,7 +215,7 @@ fn simulateCase(
 }
 
 const SurfaceRenderer = struct {
-    mesh: *const EmbeddedMesh,
+    mesh: *const SurfaceMesh,
     state: []const f64,
     exact: []const f64,
 
@@ -278,41 +252,18 @@ fn outputInterval(config: Config) u32 {
     return @max(1, config.steps / config.frames);
 }
 
-fn buildSphereGeometry(
+fn buildSphereMesh(
     allocator: std.mem.Allocator,
     refinement: u32,
-) !SphereGeometry {
+) !SurfaceMesh {
     var polyhedron = try buildRefinedOctahedron(allocator, refinement);
     defer polyhedron.deinit(allocator);
 
-    const projection = projectionFrame(polyhedron.vertices);
-    const projected_vertices = try allocator.alloc([2]f64, polyhedron.vertices.len);
-    defer allocator.free(projected_vertices);
-    for (polyhedron.vertices, projected_vertices) |vertex, *projected| {
-        projected.* = stereographicProject(vertex, projection);
-    }
-
     const oriented_faces = try allocator.dupe([3]u32, polyhedron.faces);
     defer allocator.free(oriented_faces);
-    orientFaces(projected_vertices, oriented_faces);
+    orientFacesOutward(polyhedron.vertices, oriented_faces);
 
-    var reference_mesh = try ReferenceMesh.from_triangles(allocator, projected_vertices, oriented_faces);
-    errdefer reference_mesh.deinit(allocator);
-
-    var embedded_mesh = try EmbeddedMesh.from_triangles(allocator, polyhedron.vertices, oriented_faces);
-    errdefer embedded_mesh.deinit(allocator);
-
-    const metric_tensors = try allocator.alloc([2][2]f64, oriented_faces.len);
-    errdefer allocator.free(metric_tensors);
-    for (oriented_faces, 0..) |face, face_idx| {
-        metric_tensors[face_idx] = metricTensorForFace(projected_vertices, polyhedron.vertices, face);
-    }
-
-    return .{
-        .reference_mesh = reference_mesh,
-        .embedded_mesh = embedded_mesh,
-        .metric_tensors = metric_tensors,
-    };
+    return SurfaceMesh.from_triangles(allocator, polyhedron.vertices, oriented_faces);
 }
 
 const Polyhedron = struct {
@@ -393,58 +344,23 @@ fn midpointIndex(
     return new_index;
 }
 
-const ProjectionFrame = struct {
-    pole: [3]f64,
-    tangent_x: [3]f64,
-    tangent_y: [3]f64,
-};
-
-fn projectionFrame(vertices: []const [3]f64) ProjectionFrame {
-    var best_pole = normalize3(.{ 1.0, 2.0, 3.0 });
-    var best_margin: f64 = -std.math.inf(f64);
-
-    for (projection_candidates) |candidate| {
-        const pole = normalize3(candidate);
-        var margin = std.math.inf(f64);
-        for (vertices) |vertex| {
-            margin = @min(margin, 1.0 - dot3(vertex, pole));
-        }
-        if (margin > best_margin) {
-            best_margin = margin;
-            best_pole = pole;
-        }
-    }
-
-    const reference = if (@abs(best_pole[2]) < 0.9) [3]f64{ 0.0, 0.0, 1.0 } else [3]f64{ 1.0, 0.0, 0.0 };
-    const tangent_x = normalize3(cross3(reference, best_pole));
-    const tangent_y = cross3(best_pole, tangent_x);
-    return .{
-        .pole = best_pole,
-        .tangent_x = tangent_x,
-        .tangent_y = tangent_y,
-    };
-}
-
-fn stereographicProject(vertex: [3]f64, frame: ProjectionFrame) [2]f64 {
-    const denom = 1.0 - dot3(vertex, frame.pole);
-    std.debug.assert(denom > 1e-6);
-    return .{
-        dot3(vertex, frame.tangent_x) / denom,
-        dot3(vertex, frame.tangent_y) / denom,
-    };
-}
-
-fn orientFaces(
-    reference_vertices: []const [2]f64,
+fn orientFacesOutward(
+    embedded_vertices: []const [3]f64,
     faces: [][3]u32,
 ) void {
     for (faces) |*face| {
-        const area = signedTriangleArea(
-            reference_vertices[face.*[0]],
-            reference_vertices[face.*[1]],
-            reference_vertices[face.*[2]],
-        );
-        if (area < 0.0) {
+        const a = embedded_vertices[face.*[0]];
+        const b = embedded_vertices[face.*[1]];
+        const c = embedded_vertices[face.*[2]];
+        const ab = sub3(b, a);
+        const ac = sub3(c, a);
+        const normal = cross3(ab, ac);
+        const centroid = normalize3(.{
+            (a[0] + b[0] + c[0]) / 3.0,
+            (a[1] + b[1] + c[1]) / 3.0,
+            (a[2] + b[2] + c[2]) / 3.0,
+        });
+        if (dot3(normal, centroid) < 0.0) {
             const tmp = face.*[1];
             face.*[1] = face.*[2];
             face.*[2] = tmp;
@@ -452,44 +368,9 @@ fn orientFaces(
     }
 }
 
-fn metricTensorForFace(
-    reference_vertices: []const [2]f64,
-    embedded_vertices: []const [3]f64,
-    face: [3]u32,
-) [2][2]f64 {
-    const x0 = reference_vertices[face[0]];
-    const x1 = reference_vertices[face[1]];
-    const x2 = reference_vertices[face[2]];
-    const y0 = embedded_vertices[face[0]];
-    const y1 = embedded_vertices[face[1]];
-    const y2 = embedded_vertices[face[2]];
-
-    const b11 = x1[0] - x0[0];
-    const b12 = x2[0] - x0[0];
-    const b21 = x1[1] - x0[1];
-    const b22 = x2[1] - x0[1];
-    const det_b = b11 * b22 - b12 * b21;
-    std.debug.assert(@abs(det_b) > 1e-12);
-
-    const inv_b = [2][2]f64{
-        .{ b22 / det_b, -b12 / det_b },
-        .{ -b21 / det_b, b11 / det_b },
-    };
-
-    const v1 = sub3(y1, y0);
-    const v2 = sub3(y2, y0);
-    const gram = [2][2]f64{
-        .{ dot3(v1, v1), dot3(v1, v2) },
-        .{ dot3(v2, v1), dot3(v2, v2) },
-    };
-
-    return mulMat2(transpose2(inv_b), mulMat2(gram, inv_b));
-}
-
-fn assembleMetricStiffness(
+fn assembleSurfaceStiffness(
     allocator: std.mem.Allocator,
-    mesh: *const ReferenceMesh,
-    metric: Metric2D,
+    mesh: *const SurfaceMesh,
 ) !sparse.CsrMatrix(f64) {
     var assembler = sparse.TripletAssembler(f64).init(mesh.num_vertices(), mesh.num_vertices());
     defer assembler.deinit(allocator);
@@ -508,7 +389,7 @@ fn assembleMetricStiffness(
         var gradient = try exterior_derivative.exterior_derivative(allocator, basis);
         defer gradient.deinit(allocator);
 
-        var starred = try hodge_star.hodge_star_with_metric(allocator, metric, gradient);
+        var starred = try hodge_star.hodge_star(allocator, gradient);
         defer starred.deinit(allocator);
 
         @memset(column, 0.0);
@@ -560,7 +441,7 @@ fn stepBackwardEuler(
 
 fn assembleLumpedSurfaceMasses(
     allocator: std.mem.Allocator,
-    mesh: *const EmbeddedMesh,
+    mesh: *const SurfaceMesh,
 ) ![]f64 {
     const masses = try allocator.alloc(f64, mesh.num_vertices());
     @memset(masses, 0.0);
@@ -577,7 +458,7 @@ fn assembleLumpedSurfaceMasses(
 }
 
 fn initializeState(
-    mesh: *const EmbeddedMesh,
+    mesh: *const SurfaceMesh,
     values: []f64,
     time: f64,
 ) void {
@@ -593,7 +474,7 @@ fn exactSolution(coords: [3]f64, time: f64) f64 {
     return std.math.exp(-eigenvalue * time) * coords[2];
 }
 
-fn weightedL2Error(mesh: *const EmbeddedMesh, approx: []const f64, exact: []const f64) f64 {
+fn weightedL2Error(mesh: *const SurfaceMesh, approx: []const f64, exact: []const f64) f64 {
     std.debug.assert(approx.len == exact.len);
     const face_vertices = mesh.simplices(2).items(.vertices);
     const face_areas = mesh.simplices(2).items(.volume);
@@ -612,10 +493,6 @@ fn weightedL2Error(mesh: *const EmbeddedMesh, approx: []const f64, exact: []cons
 
 fn canonicalEdge(a: u32, b: u32) [2]u32 {
     return if (a < b) .{ a, b } else .{ b, a };
-}
-
-fn signedTriangleArea(a: [2]f64, b: [2]f64, c: [2]f64) f64 {
-    return 0.5 * ((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]));
 }
 
 fn add3(a: [3]f64, b: [3]f64) [3]f64 {
@@ -647,26 +524,6 @@ fn cross3(a: [3]f64, b: [3]f64) [3]f64 {
     };
 }
 
-fn transpose2(matrix: [2][2]f64) [2][2]f64 {
-    return .{
-        .{ matrix[0][0], matrix[1][0] },
-        .{ matrix[0][1], matrix[1][1] },
-    };
-}
-
-fn mulMat2(left: [2][2]f64, right: [2][2]f64) [2][2]f64 {
-    return .{
-        .{
-            left[0][0] * right[0][0] + left[0][1] * right[1][0],
-            left[0][0] * right[0][1] + left[0][1] * right[1][1],
-        },
-        .{
-            left[1][0] * right[0][0] + left[1][1] * right[1][0],
-            left[1][0] * right[0][1] + left[1][1] * right[1][1],
-        },
-    };
-}
-
 const initial_octahedron_vertices = [_][3]f64{
     .{ 1.0, 0.0, 0.0 },
     .{ -1.0, 0.0, 0.0 },
@@ -685,28 +542,6 @@ const initial_octahedron_faces = [_][3]u32{
     .{ 1, 5, 2 },
     .{ 3, 5, 1 },
     .{ 0, 5, 3 },
-};
-
-const projection_candidates = [_][3]f64{
-    .{ 1.0, 2.0, 3.0 },
-    .{ 1.0, 3.0, 2.0 },
-    .{ 2.0, 1.0, 3.0 },
-    .{ 2.0, 3.0, 1.0 },
-    .{ 3.0, 1.0, 2.0 },
-    .{ 3.0, 2.0, 1.0 },
-    .{ -1.0, 2.0, 3.0 },
-    .{ 1.0, -2.0, 3.0 },
-    .{ 1.0, 2.0, -3.0 },
-    .{ -2.0, 1.0, 3.0 },
-    .{ 2.0, -1.0, 3.0 },
-    .{ 2.0, 1.0, -3.0 },
-    .{ -3.0, 1.0, 2.0 },
-    .{ 3.0, -1.0, 2.0 },
-    .{ 3.0, 1.0, -2.0 },
-    .{ 1.0, 1.0, 1.0 },
-    .{ 1.0, 1.0, -1.0 },
-    .{ 1.0, -1.0, 1.0 },
-    .{ -1.0, 1.0, 1.0 },
 };
 
 test "surface diffusion error decreases under sphere refinement" {

--- a/src/operators/boundary_conditions.zig
+++ b/src/operators/boundary_conditions.zig
@@ -17,37 +17,6 @@ fn boundaryEffectiveDegree(comptime InputType: type) comptime_int {
         InputType.degree;
 }
 
-fn allocateMask(allocator: std.mem.Allocator, count: u32) ![]bool {
-    const mask = try allocator.alloc(bool, count);
-    @memset(mask, false);
-    return mask;
-}
-
-fn boundaryFaceMask3D(allocator: std.mem.Allocator, mesh: anytype) ![]bool {
-    const face_count = mesh.num_faces();
-    const mask = try allocateMask(allocator, face_count);
-    errdefer allocator.free(mask);
-
-    const incidence_count = try allocator.alloc(u8, face_count);
-    defer allocator.free(incidence_count);
-    @memset(incidence_count, 0);
-
-    for (0..mesh.num_tets()) |tet_idx_usize| {
-        const row = mesh.boundary(3).row(@intCast(tet_idx_usize));
-        for (row.cols) |face_idx| {
-            incidence_count[face_idx] += 1;
-        }
-    }
-
-    for (incidence_count, 0..) |count, face_idx| {
-        if (count == 1) {
-            mask[face_idx] = true;
-        }
-    }
-
-    return mask;
-}
-
 fn canonicalRepresentative(representatives: []const u32, idx: u32) u32 {
     var current = idx;
     var step_count: usize = 0;
@@ -68,86 +37,7 @@ fn BoundarySelection(comptime InputType: type) type {
 
         pub fn initBoundary(allocator: std.mem.Allocator, mesh: *const InputType.MeshT) !Self {
             const effective_degree = boundaryEffectiveDegree(InputType);
-            const mask = try allocateMask(allocator, InputType.num_cells(mesh));
-            errdefer allocator.free(mask);
-
-            switch (InputType.MeshT.topological_dimension) {
-                2 => switch (effective_degree) {
-                    0 => {
-                        const edge_vertices = mesh.simplices(1).items(.vertices);
-                        for (mesh.boundary_edges) |edge_idx| {
-                            const edge = edge_vertices[edge_idx];
-                            mask[edge[0]] = true;
-                            mask[edge[1]] = true;
-                        }
-                    },
-                    1 => {
-                        for (mesh.boundary_edges) |edge_idx| {
-                            mask[edge_idx] = true;
-                        }
-                    },
-                    2 => {
-                        const boundary_edge_mask = try allocateMask(allocator, mesh.num_edges());
-                        defer allocator.free(boundary_edge_mask);
-
-                        for (mesh.boundary_edges) |edge_idx| {
-                            boundary_edge_mask[edge_idx] = true;
-                        }
-
-                        for (0..mesh.num_faces()) |face_idx_usize| {
-                            const row = mesh.boundary(2).row(@intCast(face_idx_usize));
-                            for (row.cols) |edge_idx| {
-                                if (!boundary_edge_mask[edge_idx]) continue;
-                                mask[face_idx_usize] = true;
-                                break;
-                            }
-                        }
-                    },
-                    else => unreachable,
-                },
-                3 => switch (effective_degree) {
-                    0 => {
-                        const boundary_face_mask = try boundaryFaceMask3D(allocator, mesh);
-                        defer allocator.free(boundary_face_mask);
-
-                        const face_vertices = mesh.simplices(2).items(.vertices);
-                        for (boundary_face_mask, 0..) |is_boundary, face_idx| {
-                            if (!is_boundary) continue;
-                            const face = face_vertices[face_idx];
-                            mask[face[0]] = true;
-                            mask[face[1]] = true;
-                            mask[face[2]] = true;
-                        }
-                    },
-                    1 => {
-                        for (mesh.boundary_edges) |edge_idx| {
-                            mask[edge_idx] = true;
-                        }
-                    },
-                    2 => {
-                        const boundary_face_mask = try boundaryFaceMask3D(allocator, mesh);
-                        @memcpy(mask, boundary_face_mask);
-                        allocator.free(boundary_face_mask);
-                    },
-                    3 => {
-                        const boundary_face_mask = try boundaryFaceMask3D(allocator, mesh);
-                        defer allocator.free(boundary_face_mask);
-
-                        for (0..mesh.num_tets()) |tet_idx_usize| {
-                            const row = mesh.boundary(3).row(@intCast(tet_idx_usize));
-                            for (row.cols) |face_idx| {
-                                if (!boundary_face_mask[face_idx]) continue;
-                                mask[tet_idx_usize] = true;
-                                break;
-                            }
-                        }
-                    },
-                    else => unreachable,
-                },
-                else => @compileError("boundary selection supports only 2D and 3D meshes"),
-            }
-
-            return .{ .mask = mask };
+            return .{ .mask = try mesh.boundary_mask(allocator, effective_degree) };
         }
 
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -40,6 +40,7 @@ pub fn solve_zero_form_dirichlet(
     boundary_values: []const f64,
     config: SolveConfig,
 ) !SolveResult {
+    _ = MeshType;
     const mesh = operator_context.mesh;
     std.debug.assert(forcing_values.len == mesh.num_vertices());
     std.debug.assert(boundary_values.len == mesh.num_vertices());
@@ -48,20 +49,8 @@ pub fn solve_zero_form_dirichlet(
     const stiffness = laplacian.stiffness;
     const dual_volumes = mesh.vertices.slice().items(.dual_volume);
 
-    const boundary_mask = try boundary_vertex_mask(MeshType, allocator, mesh);
+    const boundary_mask = try mesh.boundary_mask(allocator, 0);
     defer allocator.free(boundary_mask);
-
-    const reduced_index = try allocator.alloc(u32, mesh.num_vertices());
-    defer allocator.free(reduced_index);
-    @memset(reduced_index, std.math.maxInt(u32));
-
-    var free_count: u32 = 0;
-    for (0..mesh.num_vertices()) |vertex_idx_usize| {
-        const vertex_idx: u32 = @intCast(vertex_idx_usize);
-        if (boundary_mask[vertex_idx]) continue;
-        reduced_index[vertex_idx] = free_count;
-        free_count += 1;
-    }
 
     const full_rhs = try allocator.alloc(f64, mesh.num_vertices());
     defer allocator.free(full_rhs);
@@ -69,89 +58,14 @@ pub fn solve_zero_form_dirichlet(
         rhs_value.* = forcing_value * dual_volume;
     }
 
-    if (free_count == 0) {
-        const solution = try allocator.dupe(f64, boundary_values);
-        return .{
-            .solution = solution,
-            .cg_result = .{ .iterations = 0, .relative_residual = 0.0, .converged = true },
-        };
-    }
-
-    var triplets = sparse.TripletAssembler(f64).init(free_count, free_count);
-    defer triplets.deinit(allocator);
-
-    const reduced_rhs = try allocator.alloc(f64, free_count);
-    defer allocator.free(reduced_rhs);
-    @memset(reduced_rhs, 0.0);
-
-    for (0..mesh.num_vertices()) |row_idx_usize| {
-        const row_idx: u32 = @intCast(row_idx_usize);
-        if (boundary_mask[row_idx]) continue;
-
-        const reduced_row = reduced_index[row_idx];
-        var rhs_value = full_rhs[row_idx];
-        const row = stiffness.row(row_idx);
-        for (row.cols, row.vals) |col_idx, value| {
-            if (boundary_mask[col_idx]) {
-                rhs_value -= value * boundary_values[col_idx];
-            } else {
-                try triplets.addEntry(allocator, reduced_row, reduced_index[col_idx], value);
-            }
-        }
-        reduced_rhs[reduced_row] = rhs_value;
-    }
-
-    var reduced_matrix = try triplets.build(allocator);
-    defer reduced_matrix.deinit(allocator);
-
-    const diagonal = try allocator.alloc(f64, free_count);
-    defer allocator.free(diagonal);
-    @memset(diagonal, 0.0);
-    for (0..free_count) |row_idx_usize| {
-        const row_idx: u32 = @intCast(row_idx_usize);
-        const row = reduced_matrix.row(row_idx);
-        for (row.cols, row.vals) |col_idx, value| {
-            if (col_idx == row_idx) {
-                diagonal[row_idx] = value;
-                break;
-            }
-        }
-        std.debug.assert(diagonal[row_idx] > 0.0);
-    }
-
-    var preconditioner = conjugate_gradient.DiagonalPreconditioner{ .diagonal = diagonal };
-    const reduced_solution = try allocator.alloc(f64, free_count);
-    defer allocator.free(reduced_solution);
-    @memset(reduced_solution, 0.0);
-
-    var scratch = try conjugate_gradient.Scratch.init(allocator, free_count);
-    defer scratch.deinit(allocator);
-
-    const cg_result = conjugate_gradient.solve(
-        reduced_matrix,
-        reduced_rhs,
-        reduced_solution,
-        config.tolerance_relative,
-        config.iteration_limit,
-        &preconditioner,
-        scratch,
+    return solve_dirichlet_reduced_system(
+        allocator,
+        stiffness,
+        full_rhs,
+        boundary_mask,
+        boundary_values,
+        config,
     );
-    if (!cg_result.converged) return error.ConjugateGradientDidNotConverge;
-
-    const solution = try allocator.alloc(f64, mesh.num_vertices());
-    errdefer allocator.free(solution);
-    for (0..mesh.num_vertices()) |vertex_idx_usize| {
-        const vertex_idx: u32 = @intCast(vertex_idx_usize);
-        solution[vertex_idx] = if (boundary_mask[vertex_idx])
-            boundary_values[vertex_idx]
-        else
-            reduced_solution[reduced_index[vertex_idx]];
-    }
-
-    return .{
-        .solution = solution,
-        .cg_result = cg_result,
-    };
 }
 
 pub fn solve_one_form_dirichlet(
@@ -166,18 +80,43 @@ pub fn solve_one_form_dirichlet(
     std.debug.assert(forcing_values.len == mesh.num_edges());
     std.debug.assert(boundary_values.len == mesh.num_edges());
 
-    const boundary_mask = try boundary_edge_mask(allocator, mesh);
+    const boundary_mask = try mesh.boundary_mask(allocator, 1);
     defer allocator.free(boundary_mask);
 
-    const reduced_index = try allocator.alloc(u32, mesh.num_edges());
+    var full_matrix = try assemble_one_form_matrix(MeshType, allocator, operator_context);
+    defer full_matrix.deinit(allocator);
+
+    return solve_dirichlet_reduced_system(
+        allocator,
+        full_matrix,
+        forcing_values,
+        boundary_mask,
+        boundary_values,
+        config,
+    );
+}
+
+fn solve_dirichlet_reduced_system(
+    allocator: std.mem.Allocator,
+    full_matrix: sparse.CsrMatrix(f64),
+    full_rhs: []const f64,
+    boundary_mask: []const bool,
+    boundary_values: []const f64,
+    config: SolveConfig,
+) !SolveResult {
+    std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
+    std.debug.assert(full_rhs.len == full_matrix.n_rows);
+    std.debug.assert(boundary_mask.len == full_matrix.n_rows);
+    std.debug.assert(boundary_values.len == full_matrix.n_rows);
+
+    const reduced_index = try allocator.alloc(u32, full_matrix.n_rows);
     defer allocator.free(reduced_index);
     @memset(reduced_index, std.math.maxInt(u32));
 
     var free_count: u32 = 0;
-    for (0..mesh.num_edges()) |edge_idx_usize| {
-        const edge_idx: u32 = @intCast(edge_idx_usize);
-        if (boundary_mask[edge_idx]) continue;
-        reduced_index[edge_idx] = free_count;
+    for (boundary_mask, 0..) |is_boundary, cell_idx_usize| {
+        if (is_boundary) continue;
+        reduced_index[cell_idx_usize] = free_count;
         free_count += 1;
     }
 
@@ -189,9 +128,6 @@ pub fn solve_one_form_dirichlet(
         };
     }
 
-    var full_matrix = try assemble_one_form_matrix(MeshType, allocator, operator_context);
-    defer full_matrix.deinit(allocator);
-
     var triplets = sparse.TripletAssembler(f64).init(free_count, free_count);
     defer triplets.deinit(allocator);
 
@@ -199,12 +135,12 @@ pub fn solve_one_form_dirichlet(
     defer allocator.free(reduced_rhs);
     @memset(reduced_rhs, 0.0);
 
-    for (0..mesh.num_edges()) |row_idx_usize| {
-        const row_idx: u32 = @intCast(row_idx_usize);
-        if (boundary_mask[row_idx]) continue;
+    for (0..full_matrix.n_rows) |row_idx_usize| {
+        if (boundary_mask[row_idx_usize]) continue;
 
-        const reduced_row = reduced_index[row_idx];
-        var rhs_value = forcing_values[row_idx];
+        const row_idx: u32 = @intCast(row_idx_usize);
+        const reduced_row = reduced_index[row_idx_usize];
+        var rhs_value = full_rhs[row_idx_usize];
         const row = full_matrix.row(row_idx);
         for (row.cols, row.vals) |col_idx, value| {
             if (boundary_mask[col_idx]) {
@@ -241,77 +177,19 @@ pub fn solve_one_form_dirichlet(
     );
     if (!cg_result.converged) return error.ConjugateGradientDidNotConverge;
 
-    const solution = try allocator.alloc(f64, mesh.num_edges());
+    const solution = try allocator.alloc(f64, full_matrix.n_rows);
     errdefer allocator.free(solution);
-    for (0..mesh.num_edges()) |edge_idx_usize| {
-        const edge_idx: u32 = @intCast(edge_idx_usize);
-        solution[edge_idx] = if (boundary_mask[edge_idx])
-            boundary_values[edge_idx]
+    for (boundary_mask, 0..) |is_boundary, cell_idx_usize| {
+        solution[cell_idx_usize] = if (is_boundary)
+            boundary_values[cell_idx_usize]
         else
-            reduced_solution[reduced_index[edge_idx]];
+            reduced_solution[reduced_index[cell_idx_usize]];
     }
 
     return .{
         .solution = solution,
         .cg_result = cg_result,
     };
-}
-
-fn boundary_vertex_mask(
-    comptime MeshType: type,
-    allocator: std.mem.Allocator,
-    mesh: *const MeshType,
-) ![]bool {
-    const mask = try allocator.alloc(bool, mesh.num_vertices());
-    @memset(mask, false);
-
-    switch (MeshType.topological_dimension) {
-        2 => {
-            const edge_vertices = mesh.simplices(1).items(.vertices);
-            for (mesh.boundary_edges) |edge_idx| {
-                const edge = edge_vertices[edge_idx];
-                mask[edge[0]] = true;
-                mask[edge[1]] = true;
-            }
-        },
-        3 => {
-            const face_count = mesh.num_faces();
-            const face_incidence_count = try allocator.alloc(u8, face_count);
-            defer allocator.free(face_incidence_count);
-            @memset(face_incidence_count, 0);
-
-            for (0..mesh.num_tets()) |tet_idx_usize| {
-                const row = mesh.boundary(3).row(@intCast(tet_idx_usize));
-                for (row.cols) |face_idx| {
-                    face_incidence_count[face_idx] += 1;
-                }
-            }
-
-            const face_vertices = mesh.simplices(2).items(.vertices);
-            for (0..face_count) |face_idx_usize| {
-                if (face_incidence_count[face_idx_usize] != 1) continue;
-                const face = face_vertices[face_idx_usize];
-                mask[face[0]] = true;
-                mask[face[1]] = true;
-                mask[face[2]] = true;
-            }
-        },
-        else => @compileError("boundary_vertex_mask supports only 2D and 3D meshes"),
-    }
-
-    return mask;
-}
-
-fn boundary_edge_mask(
-    allocator: std.mem.Allocator,
-    mesh: anytype,
-) ![]bool {
-    const mask = try allocator.alloc(bool, mesh.num_edges());
-    @memset(mask, false);
-    for (mesh.boundary_edges) |edge_idx| {
-        mask[edge_idx] = true;
-    }
-    return mask;
 }
 
 fn assemble_one_form_matrix(

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -223,6 +223,136 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             return @intCast(self.simplex_lists[k - 1].len);
         }
 
+        /// Return a heap-allocated mask selecting k-cells incident to the
+        /// geometric boundary.
+        ///
+        /// For codimension-1 cells this is the literal boundary subcomplex.
+        /// For top-dimensional cells this means cells adjacent to the boundary.
+        pub fn boundary_mask(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int) ![]bool {
+            if (k < 0 or k > topological_dimension) {
+                @compileError(std.fmt.comptimePrint(
+                    "no boundary mask for {d}-cells on a {d}-dimensional mesh",
+                    .{ k, topological_dimension },
+                ));
+            }
+
+            const mask = try allocator.alloc(bool, self.num_cells(k));
+            errdefer allocator.free(mask);
+            @memset(mask, false);
+
+            switch (topological_dimension) {
+                2 => switch (k) {
+                    0 => {
+                        const edge_vertices = self.simplices(1).items(.vertices);
+                        for (self.boundary_edges) |edge_idx| {
+                            const edge = edge_vertices[edge_idx];
+                            mask[edge[0]] = true;
+                            mask[edge[1]] = true;
+                        }
+                    },
+                    1 => {
+                        for (self.boundary_edges) |edge_idx| {
+                            mask[edge_idx] = true;
+                        }
+                    },
+                    2 => {
+                        const boundary_edge_mask = try self.boundary_mask(allocator, 1);
+                        defer allocator.free(boundary_edge_mask);
+
+                        for (0..self.num_faces()) |face_idx_usize| {
+                            const row = self.boundary(2).row(@intCast(face_idx_usize));
+                            for (row.cols) |edge_idx| {
+                                if (!boundary_edge_mask[edge_idx]) continue;
+                                mask[face_idx_usize] = true;
+                                break;
+                            }
+                        }
+                    },
+                    else => unreachable,
+                },
+                3 => switch (k) {
+                    0 => {
+                        const boundary_face_mask = try self.boundary_mask(allocator, 2);
+                        defer allocator.free(boundary_face_mask);
+
+                        const face_vertices = self.simplices(2).items(.vertices);
+                        for (boundary_face_mask, 0..) |is_boundary, face_idx| {
+                            if (!is_boundary) continue;
+                            const face = face_vertices[face_idx];
+                            mask[face[0]] = true;
+                            mask[face[1]] = true;
+                            mask[face[2]] = true;
+                        }
+                    },
+                    1 => {
+                        for (self.boundary_edges) |edge_idx| {
+                            mask[edge_idx] = true;
+                        }
+                    },
+                    2 => {
+                        const face_count = self.num_faces();
+                        const incidence_count = try allocator.alloc(u8, face_count);
+                        defer allocator.free(incidence_count);
+                        @memset(incidence_count, 0);
+
+                        for (0..self.num_tets()) |tet_idx_usize| {
+                            const row = self.boundary(3).row(@intCast(tet_idx_usize));
+                            for (row.cols) |face_idx| {
+                                incidence_count[face_idx] += 1;
+                            }
+                        }
+
+                        for (incidence_count, 0..) |count, face_idx| {
+                            if (count == 1) {
+                                mask[face_idx] = true;
+                            }
+                        }
+                    },
+                    3 => {
+                        const boundary_face_mask = try self.boundary_mask(allocator, 2);
+                        defer allocator.free(boundary_face_mask);
+
+                        for (0..self.num_tets()) |tet_idx_usize| {
+                            const row = self.boundary(3).row(@intCast(tet_idx_usize));
+                            for (row.cols) |face_idx| {
+                                if (!boundary_face_mask[face_idx]) continue;
+                                mask[tet_idx_usize] = true;
+                                break;
+                            }
+                        }
+                    },
+                    else => unreachable,
+                },
+                else => unreachable,
+            }
+
+            return mask;
+        }
+
+        /// Return boundary-adjacent k-cell indices in ascending mesh order.
+        pub fn boundary_indices(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int) ![]u32 {
+            const mask = try self.boundary_mask(allocator, k);
+            defer allocator.free(mask);
+
+            var count: u32 = 0;
+            for (mask) |selected| {
+                if (selected) count += 1;
+            }
+
+            const indices = try allocator.alloc(u32, count);
+            errdefer allocator.free(indices);
+
+            var write_idx: u32 = 0;
+            for (mask, 0..) |selected, cell_idx| {
+                if (!selected) continue;
+                indices[write_idx] = @intCast(cell_idx);
+                write_idx += 1;
+            }
+            std.debug.assert(write_idx == count);
+
+            return indices;
+        }
+
         pub fn whitney_mass(self: *const Self, comptime k: comptime_int) sparse.CsrMatrix(f64) {
             if (k <= 0 or k >= topological_dimension) {
                 @compileError(std.fmt.comptimePrint(
@@ -1471,6 +1601,52 @@ test "boundary of boundary is zero for 2D triangulations" {
     }
 }
 
+test "boundary queries on 2D meshes agree with boundary incidence" {
+    const allocator = testing.allocator;
+    const Mesh2D = Mesh(2, 2);
+
+    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const boundary_vertex_mask = try mesh.boundary_mask(allocator, 0);
+    defer allocator.free(boundary_vertex_mask);
+    const boundary_edge_mask = try mesh.boundary_mask(allocator, 1);
+    defer allocator.free(boundary_edge_mask);
+    const boundary_face_mask = try mesh.boundary_mask(allocator, 2);
+    defer allocator.free(boundary_face_mask);
+    const boundary_edge_indices = try mesh.boundary_indices(allocator, 1);
+    defer allocator.free(boundary_edge_indices);
+
+    const edge_vertices = mesh.simplices(1).items(.vertices);
+    for (mesh.boundary_edges) |edge_idx| {
+        try testing.expect(boundary_edge_mask[edge_idx]);
+        const edge = edge_vertices[edge_idx];
+        try testing.expect(boundary_vertex_mask[edge[0]]);
+        try testing.expect(boundary_vertex_mask[edge[1]]);
+    }
+
+    var selected_edge_count: usize = 0;
+    for (boundary_edge_mask, 0..) |is_boundary, edge_idx| {
+        if (is_boundary) {
+            try testing.expectEqual(mesh.boundary_edges[selected_edge_count], @as(u32, @intCast(edge_idx)));
+            selected_edge_count += 1;
+        }
+    }
+    try testing.expectEqual(mesh.boundary_edges.len, selected_edge_count);
+    try testing.expectEqual(mesh.boundary_edges.len, boundary_edge_indices.len);
+
+    for (0..mesh.num_faces()) |face_idx_usize| {
+        const row = mesh.boundary(2).row(@intCast(face_idx_usize));
+        var expected_boundary = false;
+        for (row.cols) |edge_idx| {
+            if (!boundary_edge_mask[edge_idx]) continue;
+            expected_boundary = true;
+            break;
+        }
+        try testing.expectEqual(expected_boundary, boundary_face_mask[face_idx_usize]);
+    }
+}
+
 test "edge lengths for unit square 1×1 grid" {
     const allocator = testing.allocator;
     var mesh = try Mesh(2, 2).uniform_grid(allocator, 1, 1, 1.0, 1.0);
@@ -1978,6 +2154,65 @@ test "uniform tetrahedral grid boundary of boundary is zero" {
         for (edge_sum) |sum| {
             try testing.expectEqual(@as(i32, 0), sum);
         }
+    }
+}
+
+test "boundary queries on 3D meshes agree with boundary incidence" {
+    const allocator = testing.allocator;
+    const Mesh3D = Mesh(3, 3);
+
+    var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 2, 1.0, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const boundary_vertex_mask = try mesh.boundary_mask(allocator, 0);
+    defer allocator.free(boundary_vertex_mask);
+    const boundary_edge_mask = try mesh.boundary_mask(allocator, 1);
+    defer allocator.free(boundary_edge_mask);
+    const boundary_face_mask = try mesh.boundary_mask(allocator, 2);
+    defer allocator.free(boundary_face_mask);
+    const boundary_tet_mask = try mesh.boundary_mask(allocator, 3);
+    defer allocator.free(boundary_tet_mask);
+    const boundary_face_indices = try mesh.boundary_indices(allocator, 2);
+    defer allocator.free(boundary_face_indices);
+
+    var expected_face_count: usize = 0;
+    for (0..mesh.num_faces()) |face_idx_usize| {
+        var incidence_count: u32 = 0;
+        for (0..mesh.num_tets()) |tet_idx_usize| {
+            const row = mesh.boundary(3).row(@intCast(tet_idx_usize));
+            for (row.cols) |face_idx| {
+                if (face_idx != face_idx_usize) continue;
+                incidence_count += 1;
+            }
+        }
+        const expected_boundary = incidence_count == 1;
+        try testing.expectEqual(expected_boundary, boundary_face_mask[face_idx_usize]);
+        if (expected_boundary) expected_face_count += 1;
+    }
+    try testing.expectEqual(expected_face_count, boundary_face_indices.len);
+
+    const face_vertices = mesh.simplices(2).items(.vertices);
+    for (boundary_face_mask, 0..) |is_boundary, face_idx| {
+        if (!is_boundary) continue;
+        const face = face_vertices[face_idx];
+        try testing.expect(boundary_vertex_mask[face[0]]);
+        try testing.expect(boundary_vertex_mask[face[1]]);
+        try testing.expect(boundary_vertex_mask[face[2]]);
+    }
+
+    for (mesh.boundary_edges) |edge_idx| {
+        try testing.expect(boundary_edge_mask[edge_idx]);
+    }
+
+    for (0..mesh.num_tets()) |tet_idx_usize| {
+        const row = mesh.boundary(3).row(@intCast(tet_idx_usize));
+        var expected_boundary = false;
+        for (row.cols) |face_idx| {
+            if (!boundary_face_mask[face_idx]) continue;
+            expected_boundary = true;
+            break;
+        }
+        try testing.expectEqual(expected_boundary, boundary_tet_mask[tet_idx_usize]);
     }
 }
 

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -240,90 +240,12 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             errdefer allocator.free(mask);
             @memset(mask, false);
 
-            switch (topological_dimension) {
-                2 => switch (k) {
-                    0 => {
-                        const edge_vertices = self.simplices(1).items(.vertices);
-                        for (self.boundary_edges) |edge_idx| {
-                            const edge = edge_vertices[edge_idx];
-                            mask[edge[0]] = true;
-                            mask[edge[1]] = true;
-                        }
-                    },
-                    1 => {
-                        for (self.boundary_edges) |edge_idx| {
-                            mask[edge_idx] = true;
-                        }
-                    },
-                    2 => {
-                        const boundary_edge_mask = try self.boundary_mask(allocator, 1);
-                        defer allocator.free(boundary_edge_mask);
-
-                        for (0..self.num_faces()) |face_idx_usize| {
-                            const row = self.boundary(2).row(@intCast(face_idx_usize));
-                            for (row.cols) |edge_idx| {
-                                if (!boundary_edge_mask[edge_idx]) continue;
-                                mask[face_idx_usize] = true;
-                                break;
-                            }
-                        }
-                    },
-                    else => unreachable,
-                },
-                3 => switch (k) {
-                    0 => {
-                        const boundary_face_mask = try self.boundary_mask(allocator, 2);
-                        defer allocator.free(boundary_face_mask);
-
-                        const face_vertices = self.simplices(2).items(.vertices);
-                        for (boundary_face_mask, 0..) |is_boundary, face_idx| {
-                            if (!is_boundary) continue;
-                            const face = face_vertices[face_idx];
-                            mask[face[0]] = true;
-                            mask[face[1]] = true;
-                            mask[face[2]] = true;
-                        }
-                    },
-                    1 => {
-                        for (self.boundary_edges) |edge_idx| {
-                            mask[edge_idx] = true;
-                        }
-                    },
-                    2 => {
-                        const face_count = self.num_faces();
-                        const incidence_count = try allocator.alloc(u8, face_count);
-                        defer allocator.free(incidence_count);
-                        @memset(incidence_count, 0);
-
-                        for (0..self.num_tets()) |tet_idx_usize| {
-                            const row = self.boundary(3).row(@intCast(tet_idx_usize));
-                            for (row.cols) |face_idx| {
-                                incidence_count[face_idx] += 1;
-                            }
-                        }
-
-                        for (incidence_count, 0..) |count, face_idx| {
-                            if (count == 1) {
-                                mask[face_idx] = true;
-                            }
-                        }
-                    },
-                    3 => {
-                        const boundary_face_mask = try self.boundary_mask(allocator, 2);
-                        defer allocator.free(boundary_face_mask);
-
-                        for (0..self.num_tets()) |tet_idx_usize| {
-                            const row = self.boundary(3).row(@intCast(tet_idx_usize));
-                            for (row.cols) |face_idx| {
-                                if (!boundary_face_mask[face_idx]) continue;
-                                mask[tet_idx_usize] = true;
-                                break;
-                            }
-                        }
-                    },
-                    else => unreachable,
-                },
-                else => unreachable,
+            if (topological_dimension == 2) {
+                try fillBoundaryMask2D(self, allocator, k, mask);
+            } else if (topological_dimension == 3) {
+                try fillBoundaryMask3D(self, allocator, k, mask);
+            } else {
+                unreachable;
             }
 
             return mask;
@@ -351,6 +273,93 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             std.debug.assert(write_idx == count);
 
             return indices;
+        }
+
+        fn fillBoundaryMask2D(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int, mask: []bool) !void {
+            switch (k) {
+                0 => {
+                    const edge_vertices = self.simplices(1).items(.vertices);
+                    for (self.boundary_edges) |edge_idx| {
+                        const edge = edge_vertices[edge_idx];
+                        mask[edge[0]] = true;
+                        mask[edge[1]] = true;
+                    }
+                },
+                1 => {
+                    for (self.boundary_edges) |edge_idx| {
+                        mask[edge_idx] = true;
+                    }
+                },
+                2 => {
+                    const edge_mask = try self.boundary_mask(allocator, 1);
+                    defer allocator.free(edge_mask);
+
+                    for (0..self.num_faces()) |face_idx_usize| {
+                        const row = self.boundary(2).row(@intCast(face_idx_usize));
+                        for (row.cols) |edge_idx| {
+                            if (!edge_mask[edge_idx]) continue;
+                            mask[face_idx_usize] = true;
+                            break;
+                        }
+                    }
+                },
+                else => unreachable,
+            }
+        }
+
+        fn fillBoundaryMask3D(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int, mask: []bool) !void {
+            switch (k) {
+                0 => {
+                    const face_mask = try self.boundary_mask(allocator, 2);
+                    defer allocator.free(face_mask);
+
+                    const face_vertices = self.simplices(2).items(.vertices);
+                    for (face_mask, 0..) |is_boundary, face_idx| {
+                        if (!is_boundary) continue;
+                        const face = face_vertices[face_idx];
+                        mask[face[0]] = true;
+                        mask[face[1]] = true;
+                        mask[face[2]] = true;
+                    }
+                },
+                1 => {
+                    for (self.boundary_edges) |edge_idx| {
+                        mask[edge_idx] = true;
+                    }
+                },
+                2 => {
+                    const incidence_count = try allocator.alloc(u8, self.num_faces());
+                    defer allocator.free(incidence_count);
+                    @memset(incidence_count, 0);
+
+                    for (0..self.num_tets()) |tet_idx_usize| {
+                        const row = self.boundary(3).row(@intCast(tet_idx_usize));
+                        for (row.cols) |face_idx| {
+                            incidence_count[face_idx] += 1;
+                        }
+                    }
+
+                    for (incidence_count, 0..) |count, face_idx| {
+                        if (count == 1) {
+                            mask[face_idx] = true;
+                        }
+                    }
+                },
+                3 => {
+                    const face_mask = try self.boundary_mask(allocator, 2);
+                    defer allocator.free(face_mask);
+
+                    for (0..self.num_tets()) |tet_idx_usize| {
+                        const row = self.boundary(3).row(@intCast(tet_idx_usize));
+                        for (row.cols) |face_idx| {
+                            if (!face_mask[face_idx]) continue;
+                            mask[tet_idx_usize] = true;
+                            break;
+                        }
+                    }
+                },
+                else => unreachable,
+            }
         }
 
         pub fn whitney_mass(self: *const Self, comptime k: comptime_int) sparse.CsrMatrix(f64) {

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -240,13 +240,7 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             errdefer allocator.free(mask);
             @memset(mask, false);
 
-            if (topological_dimension == 2) {
-                try fillBoundaryMask2D(self, allocator, k, mask);
-            } else if (topological_dimension == 3) {
-                try fillBoundaryMask3D(self, allocator, k, mask);
-            } else {
-                unreachable;
-            }
+            try fillBoundaryMask(self, allocator, k, mask);
 
             return mask;
         }
@@ -275,90 +269,58 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             return indices;
         }
 
-        fn fillBoundaryMask2D(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int, mask: []bool) !void {
-            switch (k) {
-                0 => {
-                    const edge_vertices = self.simplices(1).items(.vertices);
-                    for (self.boundary_edges) |edge_idx| {
-                        const edge = edge_vertices[edge_idx];
-                        mask[edge[0]] = true;
-                        mask[edge[1]] = true;
-                    }
-                },
-                1 => {
-                    for (self.boundary_edges) |edge_idx| {
-                        mask[edge_idx] = true;
-                    }
-                },
-                2 => {
-                    const edge_mask = try self.boundary_mask(allocator, 1);
-                    defer allocator.free(edge_mask);
+        fn fillBoundaryMask(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int, mask: []bool) !void {
+            if (k == topological_dimension - 1) {
+                try fillCodimensionOneBoundaryMask(self, allocator, mask);
+                return;
+            }
 
-                    for (0..self.num_faces()) |face_idx_usize| {
-                        const row = self.boundary(2).row(@intCast(face_idx_usize));
-                        for (row.cols) |edge_idx| {
-                            if (!edge_mask[edge_idx]) continue;
-                            mask[face_idx_usize] = true;
-                            break;
-                        }
+            if (k < topological_dimension - 1) {
+                const parent_mask = try self.boundary_mask(allocator, k + 1);
+                defer allocator.free(parent_mask);
+
+                const coboundary = self.boundary(k + 1);
+                for (parent_mask, 0..) |is_boundary, parent_idx_usize| {
+                    if (!is_boundary) continue;
+                    const row = coboundary.row(@intCast(parent_idx_usize));
+                    for (row.cols) |cell_idx| {
+                        mask[cell_idx] = true;
                     }
-                },
-                else => unreachable,
+                }
+                return;
+            }
+
+            const boundary_subcell_mask = try self.boundary_mask(allocator, k - 1);
+            defer allocator.free(boundary_subcell_mask);
+
+            const boundary_operator = self.boundary(k);
+            for (0..self.num_cells(k)) |cell_idx_usize| {
+                const row = boundary_operator.row(@intCast(cell_idx_usize));
+                for (row.cols) |subcell_idx| {
+                    if (!boundary_subcell_mask[subcell_idx]) continue;
+                    mask[cell_idx_usize] = true;
+                    break;
+                }
             }
         }
 
-        fn fillBoundaryMask3D(self: *const Self, allocator: std.mem.Allocator, comptime k: comptime_int, mask: []bool) !void {
-            switch (k) {
-                0 => {
-                    const face_mask = try self.boundary_mask(allocator, 2);
-                    defer allocator.free(face_mask);
+        fn fillCodimensionOneBoundaryMask(self: *const Self, allocator: std.mem.Allocator, mask: []bool) !void {
+            const incidence_count = try allocator.alloc(u8, self.num_cells(topological_dimension - 1));
+            defer allocator.free(incidence_count);
+            @memset(incidence_count, 0);
 
-                    const face_vertices = self.simplices(2).items(.vertices);
-                    for (face_mask, 0..) |is_boundary, face_idx| {
-                        if (!is_boundary) continue;
-                        const face = face_vertices[face_idx];
-                        mask[face[0]] = true;
-                        mask[face[1]] = true;
-                        mask[face[2]] = true;
-                    }
-                },
-                1 => {
-                    for (self.boundary_edges) |edge_idx| {
-                        mask[edge_idx] = true;
-                    }
-                },
-                2 => {
-                    const incidence_count = try allocator.alloc(u8, self.num_faces());
-                    defer allocator.free(incidence_count);
-                    @memset(incidence_count, 0);
+            const top_boundary = self.boundary(topological_dimension);
+            for (0..self.num_cells(topological_dimension)) |cell_idx_usize| {
+                const row = top_boundary.row(@intCast(cell_idx_usize));
+                for (row.cols) |subcell_idx| {
+                    incidence_count[subcell_idx] += 1;
+                }
+            }
 
-                    for (0..self.num_tets()) |tet_idx_usize| {
-                        const row = self.boundary(3).row(@intCast(tet_idx_usize));
-                        for (row.cols) |face_idx| {
-                            incidence_count[face_idx] += 1;
-                        }
-                    }
-
-                    for (incidence_count, 0..) |count, face_idx| {
-                        if (count == 1) {
-                            mask[face_idx] = true;
-                        }
-                    }
-                },
-                3 => {
-                    const face_mask = try self.boundary_mask(allocator, 2);
-                    defer allocator.free(face_mask);
-
-                    for (0..self.num_tets()) |tet_idx_usize| {
-                        const row = self.boundary(3).row(@intCast(tet_idx_usize));
-                        for (row.cols) |face_idx| {
-                            if (!face_mask[face_idx]) continue;
-                            mask[tet_idx_usize] = true;
-                            break;
-                        }
-                    }
-                },
-                else => unreachable,
+            for (incidence_count, 0..) |count, cell_idx| {
+                if (count == 1) {
+                    mask[cell_idx] = true;
+                }
             }
         }
 


### PR DESCRIPTION
## What changed

This PR implements the cleanup work for #134 and #143.

- added topology-owned `Mesh.boundary_mask(k)` / `Mesh.boundary_indices(k)` queries for boundary-adjacent k-cells
- refactored `boundary_conditions.zig` to consume topology queries instead of reconstructing boundary masks locally
- refactored `poisson.zig` to consume topology queries instead of solver-local boundary helpers
- extracted the shared reduced Dirichlet solve kernel used by both the 0-form and 1-form Poisson paths
- added topology tests that pin the new boundary queries to the incidence definition in both 2D and 3D

## Why it changed

Boundary discovery was split across topology and operators:

- `Mesh` exposed only `boundary_edges`
- `boundary_conditions.zig` rebuilt boundary selections from incidence walks
- `poisson.zig` rebuilt boundary vertex and edge masks locally

That was the wrong ownership boundary. Topology should answer boundary-entity questions directly, and operator code should use that API.

The Poisson solver also duplicated the reduced-system orchestration for 0-forms and 1-forms. The degree-specific assembly remains explicit, but the elimination / reduced-index / CG / reconstruction path is now shared.

## Final API shape

The important follow-up after the first draft was simplifying the boundary-query implementation itself.

`boundary_mask(k)` now uses a generic recursive incidence definition instead of hardcoded casework over `(topological_dimension, k)`:

- codimension-1 boundary cells are the cells incident to exactly one top-dimensional cell
- lower-degree boundary-adjacent cells are those incident to a boundary-adjacent `(k + 1)`-cell
- top-dimensional boundary-adjacent cells are those incident to a boundary `(k - 1)`-cell

So the public API stays small, and the implementation follows the topology definition rather than a lookup table.

## Impact

- operator code no longer owns topology reconstruction logic
- boundary selection now has one obvious API and one generic definition
- future boundary-related operator work can build on `Mesh` rather than open-coding incidence walks again
- the Poisson Dirichlet solve path now has one shared orchestration kernel instead of two drifting copies

## Validation

- `zig build test --summary all`
- `zig build fmt`

## Scope notes

This PR intentionally stops short of broader boundary-view/submesh work. It centralizes boundary queries and removes the current duplication without introducing a larger boundary abstraction yet.

Closes #134
Closes #143
