### PR TITLE
refactor(diffusion): extract shared time-stepped scaffold

### DIFF
--- a/examples/diffusion/README.md
+++ b/examples/diffusion/README.md
@@ -26,6 +26,7 @@ zig build -Doptimize=ReleaseFast run-diffusion -- --surface sphere --refinement 
 - Plane mode uses backward Euler on the square with homogeneous Dirichlet boundary data.
 - Sphere mode solves on a triangulated unit sphere and compares against a known analytic eigenmode.
 - The family API is surface-selected at comptime: one public module, two internal runtimes.
+- Plane and sphere share a diffusion-specific time-stepped scaffold; mesh construction, exact solutions, and solve details stay local to each runtime.
 
 ## Verification
 

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const flux = @import("flux");
 const common = @import("examples_common");
+const shared = @import("shared.zig");
 
 const sparse = flux.math.sparse;
 const cg = flux.math.cg;
@@ -32,12 +33,7 @@ pub const ConfigImpl = struct {
     }
 };
 
-pub const RunResultImpl = struct {
-    elapsed_s: f64,
-    steps: u32,
-    snapshot_count: u32,
-    l2_error: f64,
-};
+pub const RunResultImpl = shared.RunResult;
 
 pub const ConvergenceResultImpl = struct {
     grid: u32,
@@ -193,21 +189,11 @@ fn simulateCase(
     defer state.deinit(allocator);
     initializeState(&mesh, state.values, initial_condition, 0.0);
 
-    const exact = try allocator.alloc(f64, mesh.num_vertices());
-    defer allocator.free(exact);
-
-    const reduced_rhs = try allocator.alloc(f64, heat_system.interior_vertices.len);
-    defer allocator.free(reduced_rhs);
-    const reduced_solution = try allocator.alloc(f64, heat_system.interior_vertices.len);
-    defer allocator.free(reduced_solution);
-    seedReducedSolution(&heat_system, state.values, reduced_solution);
-
-    const loop_result = try common.runExactFieldLoop(
+    return shared.runTimeSteppedDiffusion(
         Mesh2D,
         allocator,
         &mesh,
         state.values,
-        exact,
         .{
             .steps = config.steps,
             .dt = dt,
@@ -218,23 +204,12 @@ fn simulateCase(
             .progress_writer = progress_writer,
         },
         HeatExactInitializer{ .initial_condition = initial_condition },
-        HeatStepper{
+        HeatStepperBuilder{
             .mesh = &mesh,
             .heat_system = &heat_system,
-            .state_values = state.values,
-            .reduced_rhs = reduced_rhs,
-            .reduced_solution = reduced_solution,
         },
+        HeatErrorMeasure{},
     );
-
-    const l2_error = weightedL2Error(&mesh, state.values, exact);
-
-    return .{
-        .elapsed_s = loop_result.elapsed_s,
-        .steps = config.steps,
-        .snapshot_count = loop_result.snapshot_count,
-        .l2_error = l2_error,
-    };
 }
 
 fn convergenceConfig(grid: u32) ConfigImpl {
@@ -283,6 +258,29 @@ fn seedReducedSolution(
     }
 }
 
+const HeatStepperBuilder = struct {
+    mesh: *const Mesh2D,
+    heat_system: *const HeatSystem,
+
+    pub fn scratchLen(self: @This()) usize {
+        return self.heat_system.interior_vertices.len;
+    }
+
+    pub fn seedSolution(self: @This(), state_values: []const f64, solution: []f64) void {
+        seedReducedSolution(self.heat_system, state_values, solution);
+    }
+
+    pub fn makeStepper(self: @This(), state_values: []f64, rhs: []f64, solution: []f64) HeatStepper {
+        return .{
+            .mesh = self.mesh,
+            .heat_system = self.heat_system,
+            .state_values = state_values,
+            .reduced_rhs = rhs,
+            .reduced_solution = solution,
+        };
+    }
+};
+
 const HeatStepper = struct {
     mesh: *const Mesh2D,
     heat_system: *const HeatSystem,
@@ -299,6 +297,12 @@ const HeatStepper = struct {
             self.reduced_rhs,
             self.reduced_solution,
         );
+    }
+};
+
+const HeatErrorMeasure = struct {
+    pub fn compute(_: @This(), mesh: *const Mesh2D, approx: []const f64, exact: []const f64) f64 {
+        return weightedL2Error(mesh, approx, exact);
     }
 };
 

--- a/examples/diffusion/shared.zig
+++ b/examples/diffusion/shared.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const common = @import("examples_common");
+
+pub const RunResult = struct {
+    elapsed_s: f64,
+    steps: u32,
+    snapshot_count: u32,
+    l2_error: f64,
+};
+
+pub const RunConfig = struct {
+    steps: u32,
+    dt: f64,
+    final_time: f64,
+    frames: u32,
+    output_dir: []const u8,
+    output_base_name: []const u8,
+    progress_writer: ?*std.Io.Writer = null,
+};
+
+pub fn runTimeSteppedDiffusion(
+    comptime MeshType: type,
+    allocator: std.mem.Allocator,
+    mesh: *const MeshType,
+    state_values: []f64,
+    config: RunConfig,
+    exact_initializer: anytype,
+    stepper_builder: anytype,
+    error_measure: anytype,
+) !RunResult {
+    std.debug.assert(config.steps > 0);
+    std.debug.assert(config.dt > 0.0);
+    std.debug.assert(config.final_time > 0.0);
+
+    const scratch_len = stepper_builder.scratchLen();
+    const exact = try allocator.alloc(f64, state_values.len);
+    defer allocator.free(exact);
+    const rhs = try allocator.alloc(f64, scratch_len);
+    defer allocator.free(rhs);
+    const solution = try allocator.alloc(f64, scratch_len);
+    defer allocator.free(solution);
+
+    stepper_builder.seedSolution(state_values, solution);
+    const stepper = stepper_builder.makeStepper(state_values, rhs, solution);
+
+    const loop_result = try common.runExactFieldLoop(
+        MeshType,
+        allocator,
+        mesh,
+        state_values,
+        exact,
+        .{
+            .steps = config.steps,
+            .dt = config.dt,
+            .final_time = config.final_time,
+            .frames = config.frames,
+            .output_dir = config.output_dir,
+            .output_base_name = config.output_base_name,
+            .progress_writer = config.progress_writer,
+        },
+        exact_initializer,
+        stepper,
+    );
+
+    return .{
+        .elapsed_s = loop_result.elapsed_s,
+        .steps = config.steps,
+        .snapshot_count = loop_result.snapshot_count,
+        .l2_error = error_measure.compute(mesh, state_values, exact),
+    };
+}
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}

--- a/examples/diffusion/sphere.zig
+++ b/examples/diffusion/sphere.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const flux = @import("flux");
 const common = @import("examples_common");
+const shared = @import("shared.zig");
 
 const sparse = flux.math.sparse;
 const cg = flux.math.cg;
@@ -24,12 +25,7 @@ pub const ConfigImpl = struct {
     }
 };
 
-pub const RunResultImpl = struct {
-    elapsed_s: f64,
-    steps: u32,
-    snapshot_count: u32,
-    l2_error: f64,
-};
+pub const RunResultImpl = shared.RunResult;
 
 pub const ConvergenceResultImpl = struct {
     refinement: u32,
@@ -149,21 +145,11 @@ fn simulateCase(
     defer state.deinit(allocator);
     initializeState(&mesh, state.values, 0.0);
 
-    const exact = try allocator.alloc(f64, mesh.num_vertices());
-    defer allocator.free(exact);
-
-    const rhs = try allocator.alloc(f64, state.values.len);
-    defer allocator.free(rhs);
-    const solution = try allocator.alloc(f64, state.values.len);
-    defer allocator.free(solution);
-    @memcpy(solution, state.values);
-
-    const loop_result = try common.runExactFieldLoop(
+    return shared.runTimeSteppedDiffusion(
         SurfaceMesh,
         allocator,
         &mesh,
         state.values,
-        exact,
         .{
             .steps = config.steps,
             .dt = dt,
@@ -174,22 +160,9 @@ fn simulateCase(
             .progress_writer = progress_writer,
         },
         ExactInitializer{},
-        Stepper{
-            .system = &system,
-            .state_values = state.values,
-            .rhs = rhs,
-            .solution = solution,
-        },
+        SurfaceStepperBuilder{ .system = &system },
+        SurfaceErrorMeasure{},
     );
-
-    const l2_error = weightedL2Error(&mesh, state.values, exact);
-
-    return .{
-        .elapsed_s = loop_result.elapsed_s,
-        .steps = config.steps,
-        .snapshot_count = loop_result.snapshot_count,
-        .l2_error = l2_error,
-    };
 }
 
 fn convergenceConfig(refinement: u32) ConfigImpl {
@@ -252,9 +225,36 @@ const Stepper = struct {
     }
 };
 
+const SurfaceStepperBuilder = struct {
+    system: *SurfaceSystem,
+
+    pub fn scratchLen(self: @This()) usize {
+        return self.system.masses.len;
+    }
+
+    pub fn seedSolution(_: @This(), state_values: []const f64, solution: []f64) void {
+        @memcpy(solution, state_values);
+    }
+
+    pub fn makeStepper(self: @This(), state_values: []f64, rhs: []f64, solution: []f64) Stepper {
+        return .{
+            .system = self.system,
+            .state_values = state_values,
+            .rhs = rhs,
+            .solution = solution,
+        };
+    }
+};
+
 const ExactInitializer = struct {
     pub fn fill(_: @This(), mesh: *const SurfaceMesh, values: []f64, time: f64) void {
         initializeState(mesh, values, time);
+    }
+};
+
+const SurfaceErrorMeasure = struct {
+    pub fn compute(_: @This(), mesh: *const SurfaceMesh, approx: []const f64, exact: []const f64) f64 {
+        return weightedL2Error(mesh, approx, exact);
     }
 };
 


### PR DESCRIPTION
Closes #158

## What

Extract a shared diffusion scaffold for plane and sphere examples so the time-stepped backward-Euler loop and convergence bookkeeping live in one place.

## Acceptance criterion

A shared diffusion scaffold owns the backward-Euler loop, system solve orchestration, and generic convergence/error bookkeeping, while geometry/exact-solution specifics stay in the plane/sphere callers.

## Tasks

- [x] Identify duplicated diffusion loop / solve orchestration across plane and sphere
- [x] Extract a shared scaffold without forcing unrelated examples into it
- [x] Keep geometry and exact-solution details in plane/sphere callers
- [x] Preserve existing diffusion convergence tests
- [x] `zig build ci --summary all` passes

## Decisions

- The shared helper lives in `examples/diffusion/shared.zig`, not `examples/common`, because it captures a diffusion-specific shape rather than a universal example runtime.
- Plane and sphere provide small builder adapters for their system-specific solve details; the shared scaffold owns exact-field allocation, RHS/solution scratch allocation, loop execution, and final error reporting.

## Limitations

- This does not attempt a universal scaffold across Maxwell, Euler, and diffusion; it targets the shared diffusion shape only.
