### PR TITLE
feat(integrators): add evolution listener hooks

### DIFF
--- a/examples/common/runner.zig
+++ b/examples/common/runner.zig
@@ -65,11 +65,11 @@ fn buildPlan(config: RunLoopConfig) snapshot.Plan {
     return snapshot.Plan.disabled();
 }
 
-pub fn runEvolutionLoop(
+fn runCapturedLoop(
     allocator: std.mem.Allocator,
     evolution: anytype,
     config: RunLoopConfig,
-    renderer: anytype,
+    capturer: anytype,
 ) !RunLoopResult {
     const EvolutionType = @TypeOf(evolution.*);
     const plan = buildPlan(config);
@@ -84,20 +84,20 @@ pub fn runEvolutionLoop(
 
     const SnapshotListener = struct {
         series_ptr: *snapshot.Series,
-        renderer_value: @TypeOf(renderer),
-        total_steps: u32,
+        inner: @TypeOf(capturer),
         capture_initial: bool,
+        total_steps: u32,
 
         pub fn onRunBegin(self: *@This(), event: EvolutionType.Event) !void {
             if (!self.capture_initial or !self.series_ptr.enabled()) return;
             _ = event;
-            try self.series_ptr.capture(0.0, self.renderer_value);
+            try self.inner.capture(self.series_ptr, 0.0);
         }
 
         pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
             if (!self.series_ptr.enabled()) return;
             if (!self.series_ptr.dueAt(event.step_index, self.total_steps)) return;
-            try self.series_ptr.capture(event.time, self.renderer_value);
+            try self.inner.capture(self.series_ptr, event.time);
         }
 
         pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
@@ -108,9 +108,9 @@ pub fn runEvolutionLoop(
 
     var snapshot_listener = SnapshotListener{
         .series_ptr = &series,
-        .renderer_value = renderer,
-        .total_steps = config.steps,
+        .inner = capturer,
         .capture_initial = config.capture_initial,
+        .total_steps = config.steps,
     };
 
     var progress = if (config.progress_writer) |writer|
@@ -161,21 +161,34 @@ pub fn runEvolutionLoop(
     };
 }
 
+pub fn runEvolutionLoop(
+    allocator: std.mem.Allocator,
+    evolution: anytype,
+    config: RunLoopConfig,
+    renderer: anytype,
+) !RunLoopResult {
+    const Capturer = struct {
+        renderer_value: @TypeOf(renderer),
+
+        pub fn capture(self: @This(), series: anytype, time: f64) !void {
+            try series.capture(time, self.renderer_value);
+        }
+    };
+
+    return runCapturedLoop(
+        allocator,
+        evolution,
+        config,
+        Capturer{ .renderer_value = renderer },
+    );
+}
+
 pub fn runStepLoop(
     allocator: std.mem.Allocator,
     config: RunLoopConfig,
     stepper: anytype,
     capturer: anytype,
 ) !RunLoopResult {
-    const plan = buildPlan(config);
-    var series = try snapshot.Series.init(
-        allocator,
-        config.output_dir,
-        config.output_base_name,
-        plan,
-    );
-    defer series.deinit();
-
     const StepperWrapper = struct {
         inner: @TypeOf(stepper),
 
@@ -196,83 +209,7 @@ pub fn runStepLoop(
         .{ .inner = stepper },
         {},
     );
-
-    const SnapshotListener = struct {
-        series_ptr: *snapshot.Series,
-        inner: @TypeOf(capturer),
-        capture_initial: bool,
-        total_steps: u32,
-
-        pub fn onRunBegin(self: *@This(), event: EvolutionType.Event) !void {
-            if (!self.capture_initial or !self.series_ptr.enabled()) return;
-            _ = event;
-            try self.inner.capture(self.series_ptr, 0.0);
-        }
-
-        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
-            if (!self.series_ptr.enabled()) return;
-            if (!self.series_ptr.dueAt(event.step_index, self.total_steps)) return;
-            try self.inner.capture(self.series_ptr, event.time);
-        }
-
-        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
-            _ = event;
-            try self.series_ptr.finalize();
-        }
-    };
-
-    var snapshot_listener = SnapshotListener{
-        .series_ptr = &series,
-        .inner = capturer,
-        .capture_initial = config.capture_initial,
-        .total_steps = config.steps,
-    };
-    var progress = if (config.progress_writer) |writer|
-        progress_mod.Progress.init(writer, config.steps)
-    else
-        null;
-
-    const ProgressListener = struct {
-        progress_ptr: *progress_mod.Progress,
-
-        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
-            self.progress_ptr.update(event.step_index);
-        }
-
-        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
-            _ = event;
-            self.progress_ptr.finish();
-        }
-    };
-
-    const run_result = if (progress) |*bar| blk: {
-        var progress_listener = ProgressListener{ .progress_ptr = bar };
-        break :blk try evolution.run(
-            allocator,
-            .{
-                .steps = config.steps,
-                .dt = config.dt,
-                .final_time = config.final_time,
-            },
-            .{
-                &snapshot_listener,
-                &progress_listener,
-            },
-        );
-    } else try evolution.run(
-        allocator,
-        .{
-            .steps = config.steps,
-            .dt = config.dt,
-            .final_time = config.final_time,
-        },
-        .{&snapshot_listener},
-    );
-
-    return .{
-        .elapsed_s = run_result.elapsed_s,
-        .snapshot_count = series.count,
-    };
+    return runCapturedLoop(allocator, &evolution, config, capturer);
 }
 
 pub fn runSimulationLoop(

--- a/examples/common/runner.zig
+++ b/examples/common/runner.zig
@@ -65,16 +65,13 @@ fn buildPlan(config: RunLoopConfig) snapshot.Plan {
     return snapshot.Plan.disabled();
 }
 
-pub fn runStepLoop(
+pub fn runEvolutionLoop(
     allocator: std.mem.Allocator,
+    evolution: anytype,
     config: RunLoopConfig,
-    stepper: anytype,
-    capturer: anytype,
+    renderer: anytype,
 ) !RunLoopResult {
-    std.debug.assert(config.steps > 0);
-    std.debug.assert(config.dt > 0.0);
-    std.debug.assert(config.final_time > 0.0);
-
+    const EvolutionType = @TypeOf(evolution.*);
     const plan = buildPlan(config);
 
     var series = try snapshot.Series.init(
@@ -85,61 +82,197 @@ pub fn runStepLoop(
     );
     defer series.deinit();
 
-    if (config.capture_initial and series.enabled()) {
-        try capturer.capture(&series, 0.0);
-    }
+    const SnapshotListener = struct {
+        series_ptr: *snapshot.Series,
+        renderer_value: @TypeOf(renderer),
+        total_steps: u32,
+        capture_initial: bool,
+
+        pub fn onRunBegin(self: *@This(), event: EvolutionType.Event) !void {
+            if (!self.capture_initial or !self.series_ptr.enabled()) return;
+            _ = event;
+            try self.series_ptr.capture(0.0, self.renderer_value);
+        }
+
+        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
+            if (!self.series_ptr.enabled()) return;
+            if (!self.series_ptr.dueAt(event.step_index, self.total_steps)) return;
+            try self.series_ptr.capture(event.time, self.renderer_value);
+        }
+
+        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
+            _ = event;
+            try self.series_ptr.finalize();
+        }
+    };
+
+    var snapshot_listener = SnapshotListener{
+        .series_ptr = &series,
+        .renderer_value = renderer,
+        .total_steps = config.steps,
+        .capture_initial = config.capture_initial,
+    };
 
     var progress = if (config.progress_writer) |writer|
         progress_mod.Progress.init(writer, config.steps)
     else
         null;
 
-    const start_ns = std.time.nanoTimestamp();
-    for (0..config.steps) |step_idx| {
-        const next_time = config.dt * @as(f64, @floatFromInt(step_idx + 1));
-        try stepper.step(allocator);
+    const ProgressListener = struct {
+        progress_ptr: *progress_mod.Progress,
 
-        if (series.enabled() and series.dueAt(@intCast(step_idx + 1), config.steps)) {
-            try capturer.capture(&series, next_time);
+        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
+            self.progress_ptr.update(event.step_index);
         }
 
-        if (progress) |*bar| {
-            bar.update(@intCast(step_idx + 1));
+        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
+            _ = event;
+            self.progress_ptr.finish();
         }
-    }
-    const elapsed_ns = std.time.nanoTimestamp() - start_ns;
+    };
 
-    if (progress) |*bar| {
-        bar.finish();
-    }
-    try series.finalize();
+    const run_result = if (progress) |*bar| blk: {
+        var progress_listener = ProgressListener{ .progress_ptr = bar };
+        break :blk try evolution.run(
+            allocator,
+            .{
+                .steps = config.steps,
+                .dt = config.dt,
+                .final_time = config.final_time,
+            },
+            .{
+                &snapshot_listener,
+                &progress_listener,
+            },
+        );
+    } else try evolution.run(
+        allocator,
+        .{
+            .steps = config.steps,
+            .dt = config.dt,
+            .final_time = config.final_time,
+        },
+        .{&snapshot_listener},
+    );
 
     return .{
-        .elapsed_s = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0,
+        .elapsed_s = run_result.elapsed_s,
         .snapshot_count = series.count,
     };
 }
 
-pub fn runEvolutionLoop(
+pub fn runStepLoop(
     allocator: std.mem.Allocator,
-    evolution: anytype,
     config: RunLoopConfig,
-    renderer: anytype,
+    stepper: anytype,
+    capturer: anytype,
 ) !RunLoopResult {
-    const Capturer = struct {
-        renderer_value: @TypeOf(renderer),
+    const plan = buildPlan(config);
+    var series = try snapshot.Series.init(
+        allocator,
+        config.output_dir,
+        config.output_base_name,
+        plan,
+    );
+    defer series.deinit();
 
-        pub fn capture(self: @This(), series: anytype, time: f64) !void {
-            try series.capture(time, self.renderer_value);
+    const StepperWrapper = struct {
+        inner: @TypeOf(stepper),
+
+        pub fn step(self: *@This(), inner_allocator: std.mem.Allocator) !void {
+            try self.inner.step(inner_allocator);
+        }
+
+        pub fn deinit(self: *@This(), inner_allocator: std.mem.Allocator) void {
+            _ = self;
+            _ = inner_allocator;
         }
     };
 
-    return runStepLoop(
+    const EvolutionType = flux.integrators.evolution.Evolution(void, StepperWrapper, void);
+    var evolution = EvolutionType.init(
         allocator,
-        config,
-        evolution,
-        Capturer{ .renderer_value = renderer },
+        {},
+        .{ .inner = stepper },
+        {},
     );
+
+    const SnapshotListener = struct {
+        series_ptr: *snapshot.Series,
+        inner: @TypeOf(capturer),
+        capture_initial: bool,
+        total_steps: u32,
+
+        pub fn onRunBegin(self: *@This(), event: EvolutionType.Event) !void {
+            if (!self.capture_initial or !self.series_ptr.enabled()) return;
+            _ = event;
+            try self.inner.capture(self.series_ptr, 0.0);
+        }
+
+        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
+            if (!self.series_ptr.enabled()) return;
+            if (!self.series_ptr.dueAt(event.step_index, self.total_steps)) return;
+            try self.inner.capture(self.series_ptr, event.time);
+        }
+
+        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
+            _ = event;
+            try self.series_ptr.finalize();
+        }
+    };
+
+    var snapshot_listener = SnapshotListener{
+        .series_ptr = &series,
+        .inner = capturer,
+        .capture_initial = config.capture_initial,
+        .total_steps = config.steps,
+    };
+    var progress = if (config.progress_writer) |writer|
+        progress_mod.Progress.init(writer, config.steps)
+    else
+        null;
+
+    const ProgressListener = struct {
+        progress_ptr: *progress_mod.Progress,
+
+        pub fn onStep(self: *@This(), event: EvolutionType.Event) !void {
+            self.progress_ptr.update(event.step_index);
+        }
+
+        pub fn onRunEnd(self: *@This(), event: EvolutionType.Event) !void {
+            _ = event;
+            self.progress_ptr.finish();
+        }
+    };
+
+    const run_result = if (progress) |*bar| blk: {
+        var progress_listener = ProgressListener{ .progress_ptr = bar };
+        break :blk try evolution.run(
+            allocator,
+            .{
+                .steps = config.steps,
+                .dt = config.dt,
+                .final_time = config.final_time,
+            },
+            .{
+                &snapshot_listener,
+                &progress_listener,
+            },
+        );
+    } else try evolution.run(
+        allocator,
+        .{
+            .steps = config.steps,
+            .dt = config.dt,
+            .final_time = config.final_time,
+        },
+        .{&snapshot_listener},
+    );
+
+    return .{
+        .elapsed_s = run_result.elapsed_s,
+        .snapshot_count = series.count,
+    };
 }
 
 pub fn runSimulationLoop(

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -619,3 +619,34 @@ owns the reusable evolution mechanics underneath them. A single public
 configuration of that center, not separate peer abstractions. This also leaves
 room for `#184`, `#182`, `#185`, and `#183` to extend the same center instead
 of adding more family-local scaffolds.
+
+## 2026-04-11: Evolution listeners are library lifecycle hooks; examples implement IO listeners on top
+
+**Decision:** Attach listener hooks directly to `flux.integrators.evolution.Evolution.run(...)`
+with three lifecycle callbacks:
+- `onRunBegin`
+- `onStep`
+- `onRunEnd`
+
+The library owns dispatch of these lifecycle events, while `examples/common`
+implements snapshot and progress listeners on top of that seam instead of
+keeping a family-independent timestep loop outside the library.
+
+**Alternatives considered:**
+1. Keep the loop in `examples/common` and treat listeners as example-only
+   wiring: rejected because it leaves the library without a first-class
+   observation seam, which is exactly the missing capability `#183` is meant to
+   introduce.
+2. Move snapshot/PVD/progress logic into `src/`: rejected because those remain
+   presentation concerns. The core library should expose lifecycle events, not
+   file formats or CLI display policy.
+3. Use a single per-step callback only: rejected because initial capture and
+   guaranteed finalization become awkward special cases in example code. The
+   begin/step/end split keeps those concerns explicit and bounded.
+
+**Rationale:** The right abstraction is not “the library writes output,” but
+“the library owns evolution lifecycle events.” That lets example-side code
+implement ParaView output, progress bars, and future diagnostics as listeners
+without each family wiring its own timestep loop. It also creates the seam that
+future diagnostics and checkpoints can reuse without hard-coding them into the
+core evolution object.

--- a/src/integrators/evolution.zig
+++ b/src/integrators/evolution.zig
@@ -31,6 +31,26 @@ fn validateStepperType(comptime StepperType: type) void {
     }
 }
 
+fn listenerDeclType(comptime ListenerValueType: type) type {
+    return switch (@typeInfo(ListenerValueType)) {
+        .pointer => |pointer| pointer.child,
+        else => ListenerValueType,
+    };
+}
+
+fn invokeListeners(
+    comptime method_name: []const u8,
+    listeners: anytype,
+    event: anytype,
+) !void {
+    inline for (listeners) |listener| {
+        const ListenerType = comptime listenerDeclType(@TypeOf(listener));
+        if (@hasDecl(ListenerType, method_name)) {
+            try @field(ListenerType, method_name)(listener, event);
+        }
+    }
+}
+
 /// Evolution object for reusable state stepping.
 ///
 /// The caller owns the primary state storage. The evolution object owns the
@@ -46,6 +66,20 @@ pub fn Evolution(
 
     return struct {
         const Self = @This();
+        pub const RunConfig = struct {
+            steps: u32,
+            dt: f64,
+            final_time: f64,
+        };
+        pub const RunResult = struct {
+            elapsed_s: f64,
+        };
+        pub const Event = struct {
+            evolution: *Self,
+            step_index: u32,
+            time: f64,
+            final_time: f64,
+        };
 
         allocator: std.mem.Allocator,
         state: StateType,
@@ -111,6 +145,43 @@ pub fn Evolution(
 
         pub fn stepCount(self: *const Self) u32 {
             return self.step_count;
+        }
+
+        pub fn run(self: *Self, allocator: std.mem.Allocator, config: RunConfig, listeners: anytype) !RunResult {
+            std.debug.assert(config.steps > 0);
+            std.debug.assert(config.dt > 0.0);
+            std.debug.assert(config.final_time > 0.0);
+
+            try invokeListeners("onRunBegin", listeners, Event{
+                .evolution = self,
+                .step_index = 0,
+                .time = 0.0,
+                .final_time = config.final_time,
+            });
+
+            const start_ns = std.time.nanoTimestamp();
+            for (0..config.steps) |step_idx| {
+                try self.step(allocator);
+                const time = config.dt * @as(f64, @floatFromInt(step_idx + 1));
+                try invokeListeners("onStep", listeners, Event{
+                    .evolution = self,
+                    .step_index = @intCast(step_idx + 1),
+                    .time = time,
+                    .final_time = config.final_time,
+                });
+            }
+            const elapsed_ns = std.time.nanoTimestamp() - start_ns;
+
+            try invokeListeners("onRunEnd", listeners, Event{
+                .evolution = self,
+                .step_index = self.step_count,
+                .time = config.final_time,
+                .final_time = config.final_time,
+            });
+
+            return .{
+                .elapsed_s = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0,
+            };
         }
     };
 }
@@ -282,4 +353,54 @@ test "Evolution computes error against the current exact field" {
     evolution.fillExact(0.0);
     try testing.expectEqual(@as(u32, 0), evolution.stepCount());
     try testing.expectApproxEqAbs(2.0, evolution.l2Error(), 1e-15);
+}
+
+test "Evolution run notifies listeners at begin, each step, and end" {
+    const TestEvolution = Evolution([]f64, MockStepper, void);
+    const allocator = testing.allocator;
+    var state = [_]f64{ 1.0, 2.0 };
+    const builder = MockBuilder{ .scratch_len = state.len };
+    const stepper = try builder.initStepper(allocator, state[0..]);
+    var evolution = TestEvolution.init(allocator, state[0..], stepper, {});
+    defer evolution.deinit();
+
+    const Listener = struct {
+        begin_count: u32 = 0,
+        step_count: u32 = 0,
+        end_count: u32 = 0,
+        last_step_index: u32 = 0,
+        last_time: f64 = 0.0,
+
+        pub fn onRunBegin(self: *@This(), event: TestEvolution.Event) !void {
+            self.begin_count += 1;
+            try testing.expectEqual(@as(u32, 0), event.step_index);
+            try testing.expectApproxEqAbs(0.0, event.time, 1e-15);
+        }
+
+        pub fn onStep(self: *@This(), event: TestEvolution.Event) !void {
+            self.step_count += 1;
+            self.last_step_index = event.step_index;
+            self.last_time = event.time;
+        }
+
+        pub fn onRunEnd(self: *@This(), event: TestEvolution.Event) !void {
+            self.end_count += 1;
+            try testing.expectEqual(@as(u32, 2), event.step_index);
+            try testing.expectApproxEqAbs(1.0, event.time, 1e-15);
+        }
+    };
+
+    var listener = Listener{};
+    const result = try evolution.run(allocator, .{
+        .steps = 2,
+        .dt = 0.5,
+        .final_time = 1.0,
+    }, .{&listener});
+
+    try testing.expectEqual(@as(u32, 1), listener.begin_count);
+    try testing.expectEqual(@as(u32, 2), listener.step_count);
+    try testing.expectEqual(@as(u32, 1), listener.end_count);
+    try testing.expectEqual(@as(u32, 2), listener.last_step_index);
+    try testing.expectApproxEqAbs(1.0, listener.last_time, 1e-15);
+    try testing.expect(result.elapsed_s >= 0.0);
 }


### PR DESCRIPTION
Closes #183

## What

Add listener hooks to `flux.integrators.evolution.Evolution.run(...)` and downstream the example runner so snapshot/progress output attaches through the library lifecycle seam instead of a separate example-owned timestep loop.

## Acceptance criterion

A library evolution run can drive multiple listeners without family-specific loop wiring, and at least one example-side output path uses the new listener seam without moving IO code into `src/`.

## Tasks

- [x] Add library-side lifecycle listener hooks for evolution runs
- [x] Support multiple listeners on the same run
- [x] Keep the hook IO-agnostic in `src/`
- [x] Downstream example-side snapshot/progress output onto listeners
- [x] Document the listener boundary honestly
- [x] `zig build ci --summary all` passes

## Notes

- `Evolution.run(...)` now dispatches `onRunBegin`, `onStep`, and `onRunEnd` events.
- Listener dispatch lives in the library, but snapshot/PVD and progress remain example-side listeners in `examples/common/runner.zig`.
- This removes the last example-independent timestep loop from `examples/common`; the library now owns the evolution lifecycle seam.
- This does not yet integrate scalar diagnostics/checkpointing listeners into examples, but the hook surface is now in place for that follow-up work.
