### PR TITLE
feat: add assembled implicit system objects

### DIFF
--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -3,7 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
-const cg = flux.math.cg;
+const implicit_system_mod = flux.operators.implicit_system;
 const operator_context_mod = flux.operators.context;
 const evolution_mod = flux.integrators.evolution;
 
@@ -46,12 +46,10 @@ pub const ConvergenceResultImpl = struct {
 };
 
 const HeatSystem = struct {
-    reduced_matrix: sparse.CsrMatrix(f64),
+    implicit_system: implicit_system_mod.AssembledImplicitSystem,
     reduced_index: []u32,
     interior_vertices: []u32,
     boundary_mask: []bool,
-    diagonal: []f64,
-    scratch: cg.Scratch,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -105,34 +103,26 @@ const HeatSystem = struct {
         var reduced_matrix = try triplets.build(allocator);
         errdefer reduced_matrix.deinit(allocator);
 
-        const diagonal = try allocator.alloc(f64, interior_count);
-        errdefer allocator.free(diagonal);
-        for (0..interior_count) |row_idx_usize| {
-            const row_idx: u32 = @intCast(row_idx_usize);
-            diagonal[row_idx] = diagonalEntry(reduced_matrix, row_idx);
-            std.debug.assert(diagonal[row_idx] > 0.0);
-        }
-
-        var scratch = try cg.Scratch.init(allocator, interior_count);
-        errdefer scratch.deinit(allocator);
+        var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+            allocator,
+            reduced_matrix,
+            .{},
+        );
+        errdefer implicit_system.deinit(allocator);
 
         return .{
-            .reduced_matrix = reduced_matrix,
+            .implicit_system = implicit_system,
             .reduced_index = reduced_index,
             .interior_vertices = interior_vertices,
             .boundary_mask = boundary_mask,
-            .diagonal = diagonal,
-            .scratch = scratch,
         };
     }
 
     pub fn deinit(self: *HeatSystem, allocator: std.mem.Allocator) void {
-        self.scratch.deinit(allocator);
-        allocator.free(self.diagonal);
+        self.implicit_system.deinit(allocator);
         allocator.free(self.boundary_mask);
         allocator.free(self.interior_vertices);
         allocator.free(self.reduced_index);
-        self.reduced_matrix.deinit(allocator);
     }
 };
 
@@ -267,16 +257,8 @@ fn boundaryVertexMask(allocator: std.mem.Allocator, mesh: *const Mesh2D) ![]bool
     return mask;
 }
 
-fn diagonalEntry(matrix: sparse.CsrMatrix(f64), row_idx: u32) f64 {
-    const row = matrix.row(row_idx);
-    for (row.cols, row.vals) |col_idx, value| {
-        if (col_idx == row_idx) return value;
-    }
-    unreachable;
-}
-
 fn seedReducedSolution(
-    heat_system: *const HeatSystem,
+    heat_system: *HeatSystem,
     full_state: []const f64,
     reduced_solution: []f64,
 ) void {
@@ -290,28 +272,27 @@ const HeatStepperBuilder = struct {
     pub const Stepper = HeatStepper;
 
     mesh: *const Mesh2D,
-    heat_system: *const HeatSystem,
+    heat_system: *HeatSystem,
 
     pub fn initStepper(self: @This(), allocator: std.mem.Allocator, state_values: []f64) !Stepper {
-        const len = self.heat_system.interior_vertices.len;
-        const stepper = Stepper{
+        _ = allocator;
+        seedReducedSolution(
+            self.heat_system,
+            state_values,
+            self.heat_system.implicit_system.solutionValues(),
+        );
+        return .{
             .mesh = self.mesh,
             .heat_system = self.heat_system,
             .state_values = state_values,
-            .reduced_rhs = try allocator.alloc(f64, len),
-            .reduced_solution = try allocator.alloc(f64, len),
         };
-        seedReducedSolution(self.heat_system, state_values, stepper.reduced_solution);
-        return stepper;
     }
 };
 
 const HeatStepper = struct {
     mesh: *const Mesh2D,
-    heat_system: *const HeatSystem,
+    heat_system: *HeatSystem,
     state_values: []f64,
-    reduced_rhs: []f64,
-    reduced_solution: []f64,
 
     pub fn step(self: *@This(), allocator: std.mem.Allocator) !void {
         try stepBackwardEuler(
@@ -319,14 +300,12 @@ const HeatStepper = struct {
             self.mesh,
             self.heat_system,
             self.state_values,
-            self.reduced_rhs,
-            self.reduced_solution,
         );
     }
 
     pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-        allocator.free(self.reduced_solution);
-        allocator.free(self.reduced_rhs);
+        _ = self;
+        _ = allocator;
     }
 };
 
@@ -385,13 +364,13 @@ const HeatEvolutionAux = struct {
 fn stepBackwardEuler(
     allocator: std.mem.Allocator,
     mesh: *const Mesh2D,
-    heat_system: *const HeatSystem,
+    heat_system: *HeatSystem,
     state_values: []f64,
-    reduced_rhs: []f64,
-    reduced_solution: []f64,
 ) !void {
     _ = allocator;
     const masses = mesh.vertices.slice().items(.dual_volume);
+    const reduced_rhs = heat_system.implicit_system.rhsValues();
+    const reduced_solution = heat_system.implicit_system.solutionValues();
     std.debug.assert(reduced_rhs.len == heat_system.interior_vertices.len);
     std.debug.assert(reduced_solution.len == heat_system.interior_vertices.len);
 
@@ -399,17 +378,7 @@ fn stepBackwardEuler(
         reduced_rhs[interior_idx] = masses[vertex_idx] * state_values[vertex_idx];
     }
 
-    var preconditioner = cg.DiagonalPreconditioner{ .diagonal = heat_system.diagonal };
-    const solve_result = cg.solve(
-        heat_system.reduced_matrix,
-        reduced_rhs,
-        reduced_solution,
-        1e-10,
-        4000,
-        &preconditioner,
-        heat_system.scratch,
-    );
-    if (!solve_result.converged) return error.ConjugateGradientDidNotConverge;
+    _ = try heat_system.implicit_system.solve();
 
     for (heat_system.boundary_mask, 0..) |is_boundary, vertex_idx| {
         if (is_boundary) state_values[vertex_idx] = 0.0;

--- a/examples/diffusion/sphere.zig
+++ b/examples/diffusion/sphere.zig
@@ -3,7 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
-const cg = flux.math.cg;
+const implicit_system_mod = flux.operators.implicit_system;
 const operator_context_mod = flux.operators.context;
 const evolution_mod = flux.integrators.evolution;
 
@@ -39,10 +39,8 @@ pub const ConvergenceResultImpl = struct {
 
 pub const SurfaceSystem = struct {
     operator_context: *SurfaceOperatorContext,
-    system_matrix: sparse.CsrMatrix(f64),
+    implicit_system: implicit_system_mod.AssembledImplicitSystem,
     masses: []f64,
-    diagonal: []f64,
-    scratch: cg.Scratch,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -71,30 +69,23 @@ pub const SurfaceSystem = struct {
         var system_matrix = try assembler.build(allocator);
         errdefer system_matrix.deinit(allocator);
 
-        const diagonal = try allocator.alloc(f64, masses.len);
-        errdefer allocator.free(diagonal);
-        for (0..masses.len) |row_idx| {
-            diagonal[row_idx] = diagonalEntry(system_matrix, @intCast(row_idx));
-            std.debug.assert(diagonal[row_idx] > 0.0);
-        }
-
-        var scratch = try cg.Scratch.init(allocator, mesh.num_vertices());
-        errdefer scratch.deinit(allocator);
+        var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+            allocator,
+            system_matrix,
+            .{},
+        );
+        errdefer implicit_system.deinit(allocator);
 
         return .{
             .operator_context = operator_context,
-            .system_matrix = system_matrix,
+            .implicit_system = implicit_system,
             .masses = masses,
-            .diagonal = diagonal,
-            .scratch = scratch,
         };
     }
 
     pub fn deinit(self: *SurfaceSystem, allocator: std.mem.Allocator) void {
-        self.scratch.deinit(allocator);
-        allocator.free(self.diagonal);
+        self.implicit_system.deinit(allocator);
         allocator.free(self.masses);
-        self.system_matrix.deinit(allocator);
         self.operator_context.deinit();
     }
 };
@@ -205,20 +196,12 @@ fn convergenceConfig(refinement: u32) ConfigImpl {
     };
 }
 
-fn diagonalEntry(matrix: sparse.CsrMatrix(f64), row_idx: u32) f64 {
-    const row = matrix.row(row_idx);
-    for (row.cols, row.vals) |col_idx, value| {
-        if (col_idx == row_idx) return value;
-    }
-    unreachable;
-}
-
 fn stepBackwardEuler(
     system: *SurfaceSystem,
     state_values: []f64,
-    rhs: []f64,
-    solution: []f64,
 ) !void {
+    const rhs = system.implicit_system.rhsValues();
+    const solution = system.implicit_system.solutionValues();
     std.debug.assert(rhs.len == state_values.len);
     std.debug.assert(solution.len == state_values.len);
 
@@ -226,17 +209,7 @@ fn stepBackwardEuler(
         rhs_value.* = mass * state_value;
     }
 
-    var preconditioner = cg.DiagonalPreconditioner{ .diagonal = system.diagonal };
-    const solve_result = cg.solve(
-        system.system_matrix,
-        rhs,
-        solution,
-        1e-10,
-        4000,
-        &preconditioner,
-        system.scratch,
-    );
-    if (!solve_result.converged) return error.ConjugateGradientDidNotConverge;
+    _ = try system.implicit_system.solve();
 
     @memcpy(state_values, solution);
 }
@@ -244,17 +217,15 @@ fn stepBackwardEuler(
 const SurfaceStepper = struct {
     system: *SurfaceSystem,
     state_values: []f64,
-    rhs: []f64,
-    solution: []f64,
 
     pub fn step(self: *@This(), allocator: std.mem.Allocator) !void {
         _ = allocator;
-        try stepBackwardEuler(self.system, self.state_values, self.rhs, self.solution);
+        try stepBackwardEuler(self.system, self.state_values);
     }
 
     pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-        allocator.free(self.solution);
-        allocator.free(self.rhs);
+        _ = self;
+        _ = allocator;
     }
 };
 
@@ -264,15 +235,12 @@ const SurfaceStepperBuilder = struct {
     system: *SurfaceSystem,
 
     pub fn initStepper(self: @This(), allocator: std.mem.Allocator, state_values: []f64) !Stepper {
-        const len = self.system.masses.len;
-        const stepper = Stepper{
+        _ = allocator;
+        self.system.implicit_system.seedSolution(state_values);
+        return .{
             .system = self.system,
             .state_values = state_values,
-            .rhs = try allocator.alloc(f64, len),
-            .solution = try allocator.alloc(f64, len),
         };
-        @memcpy(stepper.solution, state_values);
-        return stepper;
     }
 };
 

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -650,3 +650,29 @@ implement ParaView output, progress bars, and future diagnostics as listeners
 without each family wiring its own timestep loop. It also creates the seam that
 future diagnostics and checkpoints can reuse without hard-coding them into the
 core evolution object.
+
+## 2026-04-11: Assembled implicit systems own solve workspace, but not constraint policy
+
+**Decision:** Introduce `flux.operators.implicit_system.AssembledImplicitSystem`
+as the library-owned runtime object for one assembled SPD solve. The object owns
+the matrix, Jacobi diagonal, reusable `rhs` and `solution` buffers, and CG
+scratch. Constraint policy stays outside: callers may build either a full system
+or a reduced constrained system, then hand the resulting matrix to the same
+runtime object.
+
+**Alternatives considered:**
+1. Keep exposing only raw `CsrMatrix` + `cg.Scratch`: rejected because every
+   implicit caller then rebuilds the same mini-runtime by hand, which was the
+   exact diffusion and Poisson duplication this issue surfaced.
+2. Bake Dirichlet/constraint elimination into the new object: rejected because
+   issue `#182` is still open and different constraint policies should compose
+   with the solve runtime rather than being frozen into its first implementation.
+3. Put the object in `src/math/`: rejected because the matrix solver primitive
+   already lives in `math`; this new type is the operator-facing packaging layer
+   that binds assembled operator state to a reusable solve lifetime.
+
+**Rationale:** The missing abstraction was not “another solver,” it was the
+owned runtime around an already-assembled operator. Keeping the object matrix-
+agnostic but ownership-aware immediately shrinks both constrained and
+unconstrained diffusion examples, lets Poisson reuse the same packaging, and
+preserves a clean seam for later boundary-constraint composition.

--- a/src/operators/implicit_system.zig
+++ b/src/operators/implicit_system.zig
@@ -23,39 +23,87 @@ pub const AssembledImplicitSystem = struct {
         matrix: sparse.CsrMatrix(f64),
         config: SolveConfig,
     ) !AssembledImplicitSystem {
-        _ = allocator;
-        _ = matrix;
-        _ = config;
-        @panic("not yet implemented");
+        std.debug.assert(matrix.n_rows == matrix.n_cols);
+
+        const diagonal = try diagonalOf(allocator, matrix);
+        errdefer allocator.free(diagonal);
+
+        const rhs = try allocator.alloc(f64, matrix.n_rows);
+        errdefer allocator.free(rhs);
+        @memset(rhs, 0.0);
+
+        const solution = try allocator.alloc(f64, matrix.n_rows);
+        errdefer allocator.free(solution);
+        @memset(solution, 0.0);
+
+        var scratch = try cg.Scratch.init(allocator, @intCast(matrix.n_rows));
+        errdefer scratch.deinit(allocator);
+
+        return .{
+            .matrix = matrix,
+            .diagonal = diagonal,
+            .rhs = rhs,
+            .solution = solution,
+            .scratch = scratch,
+            .config = config,
+        };
     }
 
     pub fn deinit(self: *AssembledImplicitSystem, allocator: std.mem.Allocator) void {
-        _ = self;
-        _ = allocator;
-        @panic("not yet implemented");
+        self.scratch.deinit(allocator);
+        allocator.free(self.solution);
+        allocator.free(self.rhs);
+        allocator.free(self.diagonal);
+        self.matrix.deinit(allocator);
     }
 
     pub fn rhsValues(self: *AssembledImplicitSystem) []f64 {
-        _ = self;
-        @panic("not yet implemented");
+        return self.rhs;
     }
 
     pub fn solutionValues(self: *AssembledImplicitSystem) []f64 {
-        _ = self;
-        @panic("not yet implemented");
+        return self.solution;
     }
 
     pub fn seedSolution(self: *AssembledImplicitSystem, values: []const f64) void {
-        _ = self;
-        _ = values;
-        @panic("not yet implemented");
+        std.debug.assert(values.len == self.solution.len);
+        @memcpy(self.solution, values);
     }
 
     pub fn solve(self: *AssembledImplicitSystem) !cg.SolveResult {
-        _ = self;
-        @panic("not yet implemented");
+        var preconditioner = cg.DiagonalPreconditioner{ .diagonal = self.diagonal };
+        const result = cg.solve(
+            self.matrix,
+            self.rhs,
+            self.solution,
+            self.config.tolerance_relative,
+            self.config.iteration_limit,
+            &preconditioner,
+            self.scratch,
+        );
+        if (!result.converged) return error.ConjugateGradientDidNotConverge;
+        return result;
     }
 };
+
+fn diagonalOf(allocator: std.mem.Allocator, matrix: sparse.CsrMatrix(f64)) ![]f64 {
+    const diagonal = try allocator.alloc(f64, matrix.n_rows);
+    errdefer allocator.free(diagonal);
+    @memset(diagonal, 0.0);
+
+    for (0..matrix.n_rows) |row_idx_usize| {
+        const row_idx: u32 = @intCast(row_idx_usize);
+        const row = matrix.row(row_idx);
+        for (row.cols, row.vals) |col_idx, value| {
+            if (col_idx != row_idx) continue;
+            diagonal[row_idx] = value;
+            break;
+        }
+        std.debug.assert(diagonal[row_idx] > 0.0);
+    }
+
+    return diagonal;
+}
 
 test "assembled implicit system computes matrix diagonal and reuses owned buffers across solves" {
     const allocator = testing.allocator;

--- a/src/operators/implicit_system.zig
+++ b/src/operators/implicit_system.zig
@@ -1,0 +1,101 @@
+//! Reusable assembled implicit linear solves with owned workspace.
+
+const std = @import("std");
+const testing = std.testing;
+const sparse = @import("../math/sparse.zig");
+const cg = @import("../math/cg.zig");
+
+pub const SolveConfig = struct {
+    tolerance_relative: f64 = 1e-10,
+    iteration_limit: u32 = 4000,
+};
+
+pub const AssembledImplicitSystem = struct {
+    matrix: sparse.CsrMatrix(f64),
+    diagonal: []f64,
+    rhs: []f64,
+    solution: []f64,
+    scratch: cg.Scratch,
+    config: SolveConfig,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        matrix: sparse.CsrMatrix(f64),
+        config: SolveConfig,
+    ) !AssembledImplicitSystem {
+        _ = allocator;
+        _ = matrix;
+        _ = config;
+        @panic("not yet implemented");
+    }
+
+    pub fn deinit(self: *AssembledImplicitSystem, allocator: std.mem.Allocator) void {
+        _ = self;
+        _ = allocator;
+        @panic("not yet implemented");
+    }
+
+    pub fn rhsValues(self: *AssembledImplicitSystem) []f64 {
+        _ = self;
+        @panic("not yet implemented");
+    }
+
+    pub fn solutionValues(self: *AssembledImplicitSystem) []f64 {
+        _ = self;
+        @panic("not yet implemented");
+    }
+
+    pub fn seedSolution(self: *AssembledImplicitSystem, values: []const f64) void {
+        _ = self;
+        _ = values;
+        @panic("not yet implemented");
+    }
+
+    pub fn solve(self: *AssembledImplicitSystem) !cg.SolveResult {
+        _ = self;
+        @panic("not yet implemented");
+    }
+};
+
+test "assembled implicit system computes matrix diagonal and reuses owned buffers across solves" {
+    const allocator = testing.allocator;
+
+    var matrix = try sparse.CsrMatrix(f64).init(allocator, 2, 2, 2);
+    matrix.row_ptr[0] = 0;
+    matrix.row_ptr[1] = 1;
+    matrix.row_ptr[2] = 2;
+    matrix.col_idx[0] = 0;
+    matrix.col_idx[1] = 1;
+    matrix.values[0] = 2.0;
+    matrix.values[1] = 4.0;
+
+    var system = try AssembledImplicitSystem.init(allocator, matrix, .{});
+    defer system.deinit(allocator);
+
+    const rhs_ptr = system.rhsValues().ptr;
+    const solution_ptr = system.solutionValues().ptr;
+
+    system.rhsValues()[0] = 4.0;
+    system.rhsValues()[1] = 8.0;
+    @memset(system.solutionValues(), 0.0);
+
+    const first_result = try system.solve();
+    try testing.expect(first_result.converged);
+    try testing.expectApproxEqAbs(@as(f64, 2.0), system.solutionValues()[0], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 2.0), system.solutionValues()[1], 1e-12);
+
+    try testing.expect(rhs_ptr == system.rhsValues().ptr);
+    try testing.expect(solution_ptr == system.solutionValues().ptr);
+
+    system.rhsValues()[0] = 2.0;
+    system.rhsValues()[1] = 4.0;
+
+    const second_result = try system.solve();
+    try testing.expect(second_result.converged);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[0], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[1], 1e-12);
+}
+
+test {
+    testing.refAllDeclsRecursive(@This());
+}

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -11,8 +11,9 @@ const cochain = @import("../forms/cochain.zig");
 const topology = @import("../topology/mesh.zig");
 const obj = @import("../io/obj.zig");
 const sparse = @import("../math/sparse.zig");
-const operator_context_mod = @import("context.zig");
 const conjugate_gradient = @import("../math/cg.zig");
+const operator_context_mod = @import("context.zig");
+const implicit_system_mod = @import("implicit_system.zig");
 
 comptime {
     @setEvalBranchQuota(20000);
@@ -152,30 +153,21 @@ fn solve_dirichlet_reduced_system(
         reduced_rhs[reduced_row] = rhs_value;
     }
 
-    var reduced_matrix = try triplets.build(allocator);
-    defer reduced_matrix.deinit(allocator);
+    const reduced_matrix = try triplets.build(allocator);
 
-    const diagonal = try diagonal_of(allocator, reduced_matrix);
-    defer allocator.free(diagonal);
-
-    var preconditioner = conjugate_gradient.DiagonalPreconditioner{ .diagonal = diagonal };
-    const reduced_solution = try allocator.alloc(f64, free_count);
-    defer allocator.free(reduced_solution);
-    @memset(reduced_solution, 0.0);
-
-    var scratch = try conjugate_gradient.Scratch.init(allocator, free_count);
-    defer scratch.deinit(allocator);
-
-    const cg_result = conjugate_gradient.solve(
+    var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+        allocator,
         reduced_matrix,
-        reduced_rhs,
-        reduced_solution,
-        config.tolerance_relative,
-        config.iteration_limit,
-        &preconditioner,
-        scratch,
+        .{
+            .tolerance_relative = config.tolerance_relative,
+            .iteration_limit = config.iteration_limit,
+        },
     );
-    if (!cg_result.converged) return error.ConjugateGradientDidNotConverge;
+    defer implicit_system.deinit(allocator);
+
+    @memcpy(implicit_system.rhsValues(), reduced_rhs);
+    const cg_result = try implicit_system.solve();
+    const reduced_solution = implicit_system.solutionValues();
 
     const solution = try allocator.alloc(f64, full_matrix.n_rows);
     errdefer allocator.free(solution);
@@ -223,28 +215,6 @@ fn assemble_one_form_matrix(
     }
 
     return triplets.build(allocator);
-}
-
-fn diagonal_of(
-    allocator: std.mem.Allocator,
-    matrix: sparse.CsrMatrix(f64),
-) ![]f64 {
-    const diagonal = try allocator.alloc(f64, matrix.n_rows);
-    errdefer allocator.free(diagonal);
-    @memset(diagonal, 0.0);
-
-    for (0..matrix.n_rows) |row_idx_usize| {
-        const row_idx: u32 = @intCast(row_idx_usize);
-        const row = matrix.row(row_idx);
-        for (row.cols, row.vals) |col_idx, value| {
-            if (col_idx != row_idx) continue;
-            diagonal[row_idx] = value;
-            break;
-        }
-        std.debug.assert(diagonal[row_idx] > 0.0);
-    }
-
-    return diagonal;
 }
 
 fn exact_solution_2d(coords: [2]f64) f64 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -67,6 +67,7 @@ pub const operators = struct {
     pub const context = @import("operators/context.zig");
     pub const exterior_derivative = @import("operators/exterior_derivative.zig");
     pub const hodge_star = @import("operators/hodge_star.zig");
+    pub const implicit_system = @import("operators/implicit_system.zig");
     pub const laplacian = @import("operators/laplacian.zig");
     pub const observers = @import("operators/observers.zig");
     pub const poisson = @import("operators/poisson.zig");


### PR DESCRIPTION
Closes #184

## What

Add `flux.operators.implicit_system.AssembledImplicitSystem` as the library-owned runtime for assembled SPD solves. It owns the matrix, Jacobi diagonal, reusable `rhs`/`solution` buffers, and CG scratch so callers can reuse one solve object across timesteps.

## Acceptance criterion

A caller can construct an assembled implicit system through the library and reuse it across timesteps without manually allocating RHS/solution/scratch buffers in the example layer.

Concrete proof points:
- [x] diffusion examples no longer allocate solver scratch directly in example code
- [x] the abstraction is compatible with both constrained and unconstrained solve paths
- [x] existing example tests and acceptance checks pass unchanged

## Tasks

- [x] Write tests for reusable assembled implicit system behavior
- [x] Design public API and ownership boundary
- [x] Implement library abstraction and downstream diffusion usage
- [x] CI green

## Decisions

- Logged the ownership boundary in `project/epoch_2/decision_log.md`: assembled implicit systems own solve workspace, while constraint policy stays outside for future `#182` composition.

## Limitations

- The new object is SPD/Jacobi/CG-oriented; richer preconditioner policy is still future work.
- Boundary elimination is still performed by callers before system construction rather than by the runtime object itself.
