### PR TITLE
feat: add constrained implicit system solves

### DIFF
--- a/.agents/skills/audit-cleanup/SKILL.md
+++ b/.agents/skills/audit-cleanup/SKILL.md
@@ -18,6 +18,9 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - Public names that leak internal structure instead of presenting one obvious way to do the task
 - APIs that ask the caller for information already encoded in types or available from existing values
 - Transitional interfaces kept only for backward compatibility; pre-release code should delete them
+- Public surfaces whose nouns and verbs do not form a coherent mental model
+- Policy-shaped type names where a stable noun plus a stronger verb would be cleaner
+- Families of near-copy nouns that should likely be one noun with qualifiers/adjectives instead
 
 ### Unnecessary indirection
 - Wrappers that only rename or forward without enforcing a stronger invariant
@@ -50,6 +53,19 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - Parameter lists carrying compile-time or runtime information that can be derived
 - Names that expose mechanics instead of intent
 - Generic-looking entry points whose implementations still force maintainers to touch multiple branches for every new degree/dimension case
+- Abstractions whose qualifiers belong as adjectives on a noun, but were instead split into extra wrapper nouns
+
+## Abstraction language check
+
+For any public surface you flag, ask explicitly:
+- What is the noun: the stable structural object?
+- What is the verb: the meaningful operation on that object?
+- What are the adjectives: the qualifiers that refine the noun without changing what it fundamentally is?
+
+In this repo, adjectives are often `comptime` qualifiers such as dimension,
+degree, primal/dual side, scalar type, or ownership/policy mode. A cleanup
+finding is stronger when it can say "these three nouns should collapse into one
+noun plus one verb and one adjective" instead of only "there is duplication".
 
 ## Judgment rules
 
@@ -60,6 +76,8 @@ Before proposing new issues, check the current open GitHub issues for overlappin
 - Favor moving capability to the layer where it belongs. Example glue in the library is a smell; library workarounds in examples are also a smell.
 - Treat LOC reduction as a proxy, not a goal. Shorter code that weakens invariants is not a win.
 - If an API is sold as generic, ask whether the implementation is generic in the same sense. A disguised lookup table is usually not good enough.
+- Prefer one strong noun with adjectives over a family of shallow wrapper nouns, but only if the implementation stays structurally honest.
+- Prefer a verb on an existing noun over introducing a second noun when the capability is fundamentally "do X to this object".
 - In FEEC/DEC or topology-heavy code, prefer implementations derived from the mathematical object itself (`∂`, incidence, degree recursion, duality relation) over nested switches on `(dimension, degree)`.
 - Before accepting a refactor, ask: if we added one more supported degree/dimension, would this code naturally extend, or would we add another case? If another case is needed, call that out.
 

--- a/.agents/skills/audit-perf/SKILL.md
+++ b/.agents/skills/audit-perf/SKILL.md
@@ -40,6 +40,11 @@ If a component is specified, scope to that component per `project/components.md`
 - Which functions are likely hot paths (called per-timestep, per-cell, per-edge)?
 - Are hot paths free of allocations and assertions that could be `@setRuntimeSafety(false)` in release?
 
+### Abstraction/performance tension
+- Generic-looking surfaces whose adjective space (`dimension`, `degree`, scalar type, layout mode) explodes into manual runtime branching
+- Wrapper layers that hide data movement, allocation, or copies behind tidy API names
+- Policy-specific nouns that prevent reuse of one optimized hot path across several variants
+
 ## Output format
 
 ```
@@ -64,6 +69,11 @@ Date: YYYY-MM-DD
 ```
 
 All findings should be filed as issues, not auto-fixed. Performance changes require benchmarking to verify improvement, which means they need their own PR with before/after measurements.
+
+When a performance issue is really an abstraction issue, say so explicitly:
+- wrong noun: too many concrete wrapper types block one optimized path
+- wrong verb: work is split across multiple steps instead of one fused operation
+- wrong adjective: a qualifier that should be `comptime` or layout-level is handled as dynamic casework
 
 Benchmark hygiene is part of the audit:
 - Flag apples-to-oranges comparisons where a benchmark method changed without a per-benchmark `version` bump.

--- a/.agents/skills/audit-style/SKILL.md
+++ b/.agents/skills/audit-style/SKILL.md
@@ -15,6 +15,8 @@ If a component is specified, scope to that component per `project/components.md`
 - Full words, no abbreviations: `exterior_derivative` not `ext_deriv`
 - Units and qualifiers appended in descending significance
 - Consistent naming patterns across similar constructs
+- Public names should read like a coherent domain language: stable nouns,
+  clear verbs, and qualifiers/adjectives that refine rather than fragment the model
 
 ### Dead code and stale references
 - Unreachable code paths
@@ -38,6 +40,7 @@ If a component is specified, scope to that component per `project/components.md`
 - Public API should be consistent in style (all snake_case, consistent parameter ordering)
 - Nested `switch` / `if` ladders over semantic axes like `(dimension, degree)` that may indicate a missing derived definition or comptime formulation rather than a true need for casework
 - Generic-looking APIs whose implementation style contradicts the abstraction they present
+- Families of type names that differ only by policy adjectives and may want one stronger noun instead
 
 ### Formatting
 - `zig fmt` compliance (should be caught by CI, but verify)
@@ -50,6 +53,7 @@ Before concluding that a style issue is only cosmetic, ask:
 - Is this "generic" function actually generic, or is it a manually enumerated case table?
 - Could the implementation be written once in terms of the native structure (incidence, recursion, comptime relation) instead of today’s supported cases?
 - Does this control flow naturally extend when the next degree/dimension/variant is added, or does it require editing multiple branches?
+- Are these words the right nouns, verbs, and adjectives for the abstraction, or are the names exposing implementation accidents?
 
 ## Output format
 

--- a/.agents/skills/audit-tests/SKILL.md
+++ b/.agents/skills/audit-tests/SKILL.md
@@ -16,6 +16,7 @@ If a component is specified, scope to that component per `project/components.md`
 - Operators without property-based tests on random inputs
 - Edge cases not tested: empty mesh, single element, boundary-only elements, degenerate geometry
 - Error paths: what happens with invalid inputs? Are error returns tested?
+- Public abstractions whose noun/verb/adjective split is untested: e.g. only one adjective combination is covered even though the API claims broader generality
 
 ### Property test quality
 - Property tests should use random inputs, not hand-crafted examples only
@@ -39,6 +40,7 @@ If a component is specified, scope to that component per `project/components.md`
 ### Comptime tests
 - Are there `comptime` blocks that verify type-level properties?
 - Could any runtime test be promoted to a compile-time guarantee?
+- Are important adjectives encoded at `comptime` when they should be, and is that contract tested?
 
 ### Test organization
 - Tests should be in the same file as the code they test (Zig convention)
@@ -77,5 +79,9 @@ For each finding, propose whether it should be:
 - **Filed as an issue** (new property test, convergence test, coverage expansion)
 
 Convergence tests and property tests should always be filed as issues — they require careful mathematical thought, not quick fixes.
+
+If an API presents itself as a generic noun with adjective parameters, ask
+whether the tests actually exercise more than one meaningful adjective
+combination. A generic signature with one trivial instantiation is not strong evidence.
 
 Ask the user which findings to act on.

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -26,6 +26,13 @@ Each agent should:
 - Produce findings in the format defined by its respective skill
 - Return its findings to the parent
 
+Across all five lenses, keep one shared abstraction question in view:
+- What are the nouns?
+- What are the verbs?
+- What are the adjectives/qualifiers?
+
+Use that to distinguish true structural problems from isolated local symptoms.
+
 ## Consolidation
 
 After all four agents complete, consolidate into a single report:

--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -14,6 +14,8 @@ This skill is primarily **agent-invoked during `/tackle`** when a non-obvious de
 - Selecting an algorithm when multiple valid options exist
 - Changing an existing interface to accommodate new requirements
 - Deviating from a pattern established elsewhere in the codebase
+- Choosing whether a concept should be expressed as a noun, a verb on an
+  existing noun, or an adjective/qualifier on a stable abstraction
 
 ## Steps
 

--- a/.agents/skills/ideate/SKILL.md
+++ b/.agents/skills/ideate/SKILL.md
@@ -53,6 +53,9 @@ This is the core of the conversation. For each idea (or cluster of related ideas
 - **Ask for the minimum viable version.** What's the smallest thing that would let you test whether this idea has legs?
 - **Connect to existing work.** Does this relate to something already built, planned, or decided? Name the specific file, issue, or decision.
 - **Challenge scope.** Is this flux's job, or is it a library/tool that flux should integrate with rather than build?
+- **Ask for the abstraction language.** If this idea becomes code, what are the
+  nouns, verbs, and adjectives? If the answer is a pile of near-synonyms or
+  policy-shaped wrapper types, the idea probably is not cooked enough yet.
 
 Do NOT ask all of these for every idea — use judgment. Some ideas need one question, some need several. Keep the conversation moving.
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -77,6 +77,8 @@ These are the findings the user is least likely to catch:
 - Were any non-obvious architectural decisions made? If yes, are they in the decision log?
 - Labels correct: `type/`, `domain/`, `priority/` all set?
 - Does this introduce an interface that conflicts with a known horizon in `project/horizons.md`?
+- Do the public names form a coherent abstraction language: stable nouns,
+  meaningful verbs, and qualifiers/adjectives in the right place?
 - Are there follow-on issues that should be opened before this merges?
 - If review exposes **non-blocking but real** follow-on work that should not bloat the current PR:
   - Check whether it is already tracked

--- a/.agents/skills/tackle/SKILL.md
+++ b/.agents/skills/tackle/SKILL.md
@@ -10,13 +10,14 @@ Find and work the highest-priority open issue to completion — one issue, one b
 1. Read `project/components.md` to understand codebase scope boundaries.
 2. Read `project/epoch_*/roadmap.md` for the current epoch to understand milestone priorities and acceptance criteria.
 3. Read `project/horizons.md` — before writing any interface, check that it does not preclude a known future direction.
-4. Get live state:
+4. Read `project/vision.md` when the work introduces or reshapes a public abstraction. Treat issue wording as the local symptom, not automatically as the correct abstraction boundary.
+5. Get live state:
    ```sh
    gh milestone list --state open
    gh issue list --state open --label "priority/high" --json number,title,labels,milestone
    gh issue list --state open --label "status/blocked" --json number,title,labels,milestone
    ```
-5. Select the best issue to work next using this priority order:
+6. Select the best issue to work next using this priority order:
    - On the current milestone (check which milestone is earliest in the roadmap)
    - `type/invariant` preferred — these are on the critical path for acceptance criteria
    - `priority/high` over `priority/medium`
@@ -24,7 +25,7 @@ Find and work the highest-priority open issue to completion — one issue, one b
    - Skip `status/blocked` issues (they can't be worked until unblocked)
    - Non-epoch bugs (`type/bug`) may take priority if they are breaking something
 
-6. Present the chosen issue to the user: number, title, acceptance criterion, and a one-sentence rationale for why this one. Ask for confirmation or redirection.
+7. Present the chosen issue to the user: number, title, acceptance criterion, and a one-sentence rationale for why this one. Ask for confirmation or redirection.
 
 ## Scope the work
 
@@ -32,7 +33,8 @@ On confirmation:
 
 1. Read the full issue body: `gh issue view <number>`
 2. Identify the **component scope** from `project/components.md` based on the issue's `domain/` label. Name the component and direct dependencies explicitly before opening source files.
-3. Create a branch and immediately open a draft PR:
+3. State the deeper structural concept you expect the issue to touch. If the issue title/body names a policy or one example family, ask whether that is the real abstraction or only the current manifestation.
+4. Create a branch and immediately open a draft PR:
    ```sh
    git checkout main && git pull
    git checkout -b <number>-<short-slug>
@@ -61,7 +63,7 @@ On confirmation:
    ```
    Slug format: lowercase, hyphens, ≤5 words. Example: `42-csr-incidence-matrix`.
 
-4. Read all relevant source files within the component scope before writing any code.
+5. Read all relevant source files within the component scope before writing any code.
    Start with the files named in the issue and the component entry in `project/components.md`. Only expand to additional direct dependencies when the current files prove they are needed. Do not read unrelated modules "for context".
 
 ## Phase 1: Tests
@@ -86,12 +88,18 @@ Design the public interface before implementing internals.
 1. Write function signatures, struct definitions, and type-level constraints as stubs.
 2. Use `@compileError("not yet implemented")` or `unreachable` for function bodies.
 3. Verify the tests compile against the stubs (they should fail at runtime, not compile time).
-4. **Default-forward checkpoint:** present the API surface to the user briefly, but continue without waiting for confirmation unless the design is materially uncertain, introduces a cross-component interface, or would be expensive to unwind if wrong. Ask for confirmation only in those cases.
-5. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
+4. Pressure-test every new public noun against at least one uncomfortable future case from `project/vision.md` / `project/horizons.md`:
+   - a different PDE family
+   - a different dimensionality
+   - a different constraint/policy choice
+   - a solver-graph composition use case
+   If the name or ownership model would obviously need replacement there, redesign before implementing.
+5. **Default-forward checkpoint:** present the API surface to the user briefly, but continue without waiting for confirmation unless the design is materially uncertain, introduces a cross-component interface, or would be expensive to unwind if wrong. Ask for confirmation only in those cases.
+6. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
    - Read the current epoch's `decision_log.md`
    - Append the decision in the standard format (see `/decide`)
    - Commit the decision log alongside the stubs
-6. Commit and push:
+7. Commit and push:
    ```sh
    git add <source files> <decision log if updated>
    git commit -m "feat(domain): stub API for <capability>"
@@ -119,6 +127,8 @@ Fill in the stubs until tests pass.
    - Do **not** expand the current PR to include these unless they are required to finish the issue correctly
    - Before creating anything, check whether the follow-on is already tracked
    - If it is real, untracked, and worth doing later, open a **non-milestone** GitHub issue with the normal labels (`type/`, `domain/`, `priority/`) and explicitly leave milestone unset
+
+10. If the implementation solves the issue by introducing a narrow policy-shaped abstraction, stop and redesign before finalizing. The goal is to remove the symptom by exposing the deeper reusable concept, not by wrapping today's special case in a new public type.
 
 The rhythm is: **write → test → commit → push → repeat**.
 

--- a/.agents/skills/tackle/SKILL.md
+++ b/.agents/skills/tackle/SKILL.md
@@ -94,12 +94,26 @@ Design the public interface before implementing internals.
    - a different constraint/policy choice
    - a solver-graph composition use case
    If the name or ownership model would obviously need replacement there, redesign before implementing.
-5. **Default-forward checkpoint:** present the API surface to the user briefly, but continue without waiting for confirmation unless the design is materially uncertain, introduces a cross-component interface, or would be expensive to unwind if wrong. Ask for confirmation only in those cases.
-6. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
+5. Ask explicitly whether the interface has the right nouns and verbs:
+   - noun: the stable structural object
+   - verb: the meaningful operation on that object
+   Prefer `system.eliminate(...)` over introducing another wrapper type when
+   the operation is fundamentally a transformation of one existing object.
+6. Ask whether any qualifiers belong as adjectives on the noun rather than as
+   new nouns:
+   - `comptime` parameters
+   - scalar type
+   - dimension / degree
+   - primal vs dual side
+   - policy or ownership mode
+   Prefer qualifiers that refine one stable concept over families of near-copy
+   wrapper types, but only when the implementation remains genuinely generic.
+7. **Default-forward checkpoint:** present the API surface to the user briefly, but continue without waiting for confirmation unless the design is materially uncertain, introduces a cross-component interface, or would be expensive to unwind if wrong. Ask for confirmation only in those cases.
+8. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
    - Read the current epoch's `decision_log.md`
    - Append the decision in the standard format (see `/decide`)
    - Commit the decision log alongside the stubs
-7. Commit and push:
+9. Commit and push:
    ```sh
    git add <source files> <decision log if updated>
    git commit -m "feat(domain): stub API for <capability>"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,30 @@ parallel convenience and "real" APIs unless there is a concrete current need.
 The project is pre-release; correctness and coherence matter more than
 backward compatibility with transitional interfaces.
 
+When extracting an abstraction from an issue or a duplicated example pattern,
+do **not** stop at the nearest working seam. Pressure-test the candidate API
+against the project's long-term target shape from `project/vision.md` and
+`project/horizons.md` before committing to public nouns or ownership boundaries.
+In practice:
+- Prefer structural concepts over today's policy labels. A public type name
+  should usually describe the underlying mathematical or computational role
+  (`LinearSystem`, `EliminationMap`, `Integrator`) rather than one current
+  use-case variant (`DirichletSystem`, `HeatRunner`, `PlaneScaffold`).
+- Treat every new public type name as a mathematical claim. If it would feel
+  wrong or embarrassingly narrow for a future example such as a mixed system,
+  a high-dimensional phase-space problem, or a different solver family, the
+  abstraction is probably still too shallow.
+- Use example shrinkage as a quality signal, not the only success criterion.
+  The stronger signal is that *new* examples would be straightforward to write
+  without inventing new framework nouns.
+- If an issue appears to call for a concrete local helper but the deeper
+  structural abstraction is visible, prefer the deeper abstraction even if it
+  requires a harder design pass up front. Local duplication removal is not
+  enough by itself.
+- Before finalizing an interface, ask explicitly: "What are the underlying
+  concepts here? What would this look like for a PDE, discretization, or
+  dimensionality we do not support yet?"
+
 When an API is presented as degree-generic, dimension-generic, or otherwise
 mathematically generic, pressure-test the implementation too — not just the
 signature. A generic public API backed by a hardcoded case table over today's
@@ -103,6 +127,12 @@ project, not just the code.
 Before finalizing any interface, check horizons to ensure the design does not
 preclude a known future direction. When ideation produces a horizon-level
 insight, add it there — not in the epoch roadmap.
+
+Issue acceptance criteria are necessary but not sufficient design guidance.
+They identify the concrete pain to remove, but they do not automatically define
+the right public abstraction. If satisfying an issue literally would introduce
+policy-shaped or example-shaped public nouns, step back and redesign around the
+deeper reusable concept instead.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,22 @@ In practice:
   should usually describe the underlying mathematical or computational role
   (`LinearSystem`, `EliminationMap`, `Integrator`) rather than one current
   use-case variant (`DirichletSystem`, `HeatRunner`, `PlaneScaffold`).
+- Ask explicitly what the core nouns and verbs are before finalizing an API.
+  Good abstractions usually read like a small domain language:
+  nouns are stable structural objects (`Mesh`, `LinearSystem`, `Evolution`);
+  verbs are the meaningful operations on them (`assemble`, `eliminate`,
+  `advance`, `project`, `lift`). If the API reads like a pile of case-specific
+  helper names instead of a coherent language, keep refining.
+- Ask whether important qualifiers are best expressed as adjectives rather than
+  new nouns. In this codebase, adjectives are often `comptime` qualifiers or
+  type parameters that refine a structural noun without replacing it:
+  dimension, degree, primal/dual side, scalar type, or similar. Prefer
+  `Mesh(3, 2)` or a degree-parameterized form over inventing a separate public
+  noun when the concept is still "a mesh" or "a form" with qualifiers.
+- Use adjectives carefully. They should refine a real noun, not disguise a
+  missing abstraction. If adding one more adjective forces manual case tables,
+  duplicated branches, or a new wrapper family, the underlying noun/verb split
+  is probably still wrong.
 - Treat every new public type name as a mathematical claim. If it would feel
   wrong or embarrassingly narrow for a future example such as a mixed system,
   a high-dimensional phase-space problem, or a different solver family, the
@@ -53,6 +69,9 @@ In practice:
 - Before finalizing an interface, ask explicitly: "What are the underlying
   concepts here? What would this look like for a PDE, discretization, or
   dimensionality we do not support yet?"
+- Prefer a strong verb on an existing structural noun over introducing a new
+  wrapper noun when the operation is fundamentally "do X to this object". A
+  second public noun needs stronger justification than a new method.
 
 When an API is presented as degree-generic, dimension-generic, or otherwise
 mathematically generic, pressure-test the implementation too — not just the

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -3,7 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
-const implicit_system_mod = flux.operators.implicit_system;
+const linear_system = flux.math.linear_system;
 const operator_context_mod = flux.operators.context;
 const evolution_mod = flux.integrators.evolution;
 
@@ -46,7 +46,7 @@ pub const ConvergenceResultImpl = struct {
 };
 
 const HeatSystem = struct {
-    constrained_system: implicit_system_mod.DirichletConstrainedSystem,
+    constrained_system: linear_system.EliminatedLinearSystem,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -58,8 +58,7 @@ const HeatSystem = struct {
         const stiffness = laplacian.stiffness;
         const masses = mesh.vertices.slice().items(.dual_volume);
 
-        const boundary_mask = try mesh.boundary_mask(allocator, 0);
-        defer allocator.free(boundary_mask);
+        const elimination_map = try linear_system.EliminationMap.initBoundary(Mesh2D, allocator, mesh, 0);
 
         var triplets = sparse.TripletAssembler(f64).init(mesh.num_vertices(), mesh.num_vertices());
         defer triplets.deinit(allocator);
@@ -76,10 +75,10 @@ const HeatSystem = struct {
         var full_matrix = try triplets.build(allocator);
         errdefer full_matrix.deinit(allocator);
 
-        var constrained_system = try implicit_system_mod.DirichletConstrainedSystem.init(
+        var constrained_system = try linear_system.EliminatedLinearSystem.init(
             allocator,
             full_matrix,
-            boundary_mask,
+            elimination_map,
             .{},
         );
         errdefer constrained_system.deinit(allocator);
@@ -317,7 +316,7 @@ fn stepBackwardEuler(
         rhs_value.* = mass * state_value;
     }
 
-    _ = try heat_system.constrained_system.solveHomogeneousDirichlet(state_values);
+    _ = try heat_system.constrained_system.solveHomogeneous(state_values);
 }
 
 fn initializeState(

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -46,10 +46,7 @@ pub const ConvergenceResultImpl = struct {
 };
 
 const HeatSystem = struct {
-    implicit_system: implicit_system_mod.AssembledImplicitSystem,
-    reduced_index: []u32,
-    interior_vertices: []u32,
-    boundary_mask: []bool,
+    constrained_system: implicit_system_mod.DirichletConstrainedSystem,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -61,68 +58,40 @@ const HeatSystem = struct {
         const stiffness = laplacian.stiffness;
         const masses = mesh.vertices.slice().items(.dual_volume);
 
-        const boundary_mask = try boundaryVertexMask(allocator, mesh);
-        errdefer allocator.free(boundary_mask);
+        const boundary_mask = try mesh.boundary_mask(allocator, 0);
+        defer allocator.free(boundary_mask);
 
-        const reduced_index = try allocator.alloc(u32, mesh.num_vertices());
-        errdefer allocator.free(reduced_index);
-        @memset(reduced_index, std.math.maxInt(u32));
-
-        var interior_count: u32 = 0;
-        for (0..mesh.num_vertices()) |vertex_idx_usize| {
-            const vertex_idx: u32 = @intCast(vertex_idx_usize);
-            if (boundary_mask[vertex_idx]) continue;
-            reduced_index[vertex_idx] = interior_count;
-            interior_count += 1;
-        }
-
-        const interior_vertices = try allocator.alloc(u32, interior_count);
-        errdefer allocator.free(interior_vertices);
-        for (0..mesh.num_vertices()) |vertex_idx_usize| {
-            const vertex_idx: u32 = @intCast(vertex_idx_usize);
-            if (boundary_mask[vertex_idx]) continue;
-            interior_vertices[reduced_index[vertex_idx]] = vertex_idx;
-        }
-
-        var triplets = sparse.TripletAssembler(f64).init(interior_count, interior_count);
+        var triplets = sparse.TripletAssembler(f64).init(mesh.num_vertices(), mesh.num_vertices());
         defer triplets.deinit(allocator);
         for (0..mesh.num_vertices()) |row_idx_usize| {
             const row_idx: u32 = @intCast(row_idx_usize);
-            if (boundary_mask[row_idx]) continue;
-
-            const reduced_row = reduced_index[row_idx];
-            try triplets.addEntry(allocator, reduced_row, reduced_row, masses[row_idx]);
+            try triplets.addEntry(allocator, row_idx, row_idx, masses[row_idx]);
 
             const row = stiffness.row(row_idx);
             for (row.cols, row.vals) |col_idx, value| {
-                if (boundary_mask[col_idx]) continue;
-                try triplets.addEntry(allocator, reduced_row, reduced_index[col_idx], dt * value);
+                try triplets.addEntry(allocator, row_idx, col_idx, dt * value);
             }
         }
 
-        var reduced_matrix = try triplets.build(allocator);
-        errdefer reduced_matrix.deinit(allocator);
+        var full_matrix = try triplets.build(allocator);
+        errdefer full_matrix.deinit(allocator);
 
-        var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+        var constrained_system = try implicit_system_mod.DirichletConstrainedSystem.init(
             allocator,
-            reduced_matrix,
+            full_matrix,
+            boundary_mask,
             .{},
         );
-        errdefer implicit_system.deinit(allocator);
+        errdefer constrained_system.deinit(allocator);
+        full_matrix.deinit(allocator);
 
         return .{
-            .implicit_system = implicit_system,
-            .reduced_index = reduced_index,
-            .interior_vertices = interior_vertices,
-            .boundary_mask = boundary_mask,
+            .constrained_system = constrained_system,
         };
     }
 
     pub fn deinit(self: *HeatSystem, allocator: std.mem.Allocator) void {
-        self.implicit_system.deinit(allocator);
-        allocator.free(self.boundary_mask);
-        allocator.free(self.interior_vertices);
-        allocator.free(self.reduced_index);
+        self.constrained_system.deinit(allocator);
     }
 };
 
@@ -244,30 +213,6 @@ fn convergenceConfig(grid: u32) ConfigImpl {
     };
 }
 
-fn boundaryVertexMask(allocator: std.mem.Allocator, mesh: *const Mesh2D) ![]bool {
-    const mask = try allocator.alloc(bool, mesh.num_vertices());
-    @memset(mask, false);
-
-    const edge_vertices = mesh.simplices(1).items(.vertices);
-    for (mesh.boundary_edges) |edge_idx| {
-        const edge = edge_vertices[edge_idx];
-        mask[edge[0]] = true;
-        mask[edge[1]] = true;
-    }
-    return mask;
-}
-
-fn seedReducedSolution(
-    heat_system: *HeatSystem,
-    full_state: []const f64,
-    reduced_solution: []f64,
-) void {
-    std.debug.assert(reduced_solution.len == heat_system.interior_vertices.len);
-    for (heat_system.interior_vertices, 0..) |vertex_idx, interior_idx| {
-        reduced_solution[interior_idx] = full_state[vertex_idx];
-    }
-}
-
 const HeatStepperBuilder = struct {
     pub const Stepper = HeatStepper;
 
@@ -276,11 +221,7 @@ const HeatStepperBuilder = struct {
 
     pub fn initStepper(self: @This(), allocator: std.mem.Allocator, state_values: []f64) !Stepper {
         _ = allocator;
-        seedReducedSolution(
-            self.heat_system,
-            state_values,
-            self.heat_system.implicit_system.solutionValues(),
-        );
+        self.heat_system.constrained_system.seedSolutionFromFull(state_values);
         return .{
             .mesh = self.mesh,
             .heat_system = self.heat_system,
@@ -369,23 +310,14 @@ fn stepBackwardEuler(
 ) !void {
     _ = allocator;
     const masses = mesh.vertices.slice().items(.dual_volume);
-    const reduced_rhs = heat_system.implicit_system.rhsValues();
-    const reduced_solution = heat_system.implicit_system.solutionValues();
-    std.debug.assert(reduced_rhs.len == heat_system.interior_vertices.len);
-    std.debug.assert(reduced_solution.len == heat_system.interior_vertices.len);
+    const full_rhs = heat_system.constrained_system.fullRhsValues();
+    std.debug.assert(full_rhs.len == state_values.len);
 
-    for (heat_system.interior_vertices, 0..) |vertex_idx, interior_idx| {
-        reduced_rhs[interior_idx] = masses[vertex_idx] * state_values[vertex_idx];
+    for (full_rhs, masses, state_values) |*rhs_value, mass, state_value| {
+        rhs_value.* = mass * state_value;
     }
 
-    _ = try heat_system.implicit_system.solve();
-
-    for (heat_system.boundary_mask, 0..) |is_boundary, vertex_idx| {
-        if (is_boundary) state_values[vertex_idx] = 0.0;
-    }
-    for (heat_system.interior_vertices, 0..) |vertex_idx, interior_idx| {
-        state_values[vertex_idx] = reduced_solution[interior_idx];
-    }
+    _ = try heat_system.constrained_system.solveHomogeneousDirichlet(state_values);
 }
 
 fn initializeState(

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -46,7 +46,7 @@ pub const ConvergenceResultImpl = struct {
 };
 
 const HeatSystem = struct {
-    constrained_system: linear_system.EliminatedLinearSystem,
+    linear_system: linear_system.LinearSystem,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -75,22 +75,22 @@ const HeatSystem = struct {
         var full_matrix = try triplets.build(allocator);
         errdefer full_matrix.deinit(allocator);
 
-        var constrained_system = try linear_system.EliminatedLinearSystem.init(
+        var system_runtime = try linear_system.LinearSystem.eliminate(
             allocator,
             full_matrix,
             elimination_map,
             .{},
         );
-        errdefer constrained_system.deinit(allocator);
+        errdefer system_runtime.deinit(allocator);
         full_matrix.deinit(allocator);
 
         return .{
-            .constrained_system = constrained_system,
+            .linear_system = system_runtime,
         };
     }
 
     pub fn deinit(self: *HeatSystem, allocator: std.mem.Allocator) void {
-        self.constrained_system.deinit(allocator);
+        self.linear_system.deinit(allocator);
     }
 };
 
@@ -220,7 +220,7 @@ const HeatStepperBuilder = struct {
 
     pub fn initStepper(self: @This(), allocator: std.mem.Allocator, state_values: []f64) !Stepper {
         _ = allocator;
-        self.heat_system.constrained_system.seedSolutionFromFull(state_values);
+        self.heat_system.linear_system.seedSolutionFromFull(state_values);
         return .{
             .mesh = self.mesh,
             .heat_system = self.heat_system,
@@ -309,14 +309,14 @@ fn stepBackwardEuler(
 ) !void {
     _ = allocator;
     const masses = mesh.vertices.slice().items(.dual_volume);
-    const full_rhs = heat_system.constrained_system.fullRhsValues();
+    const full_rhs = heat_system.linear_system.fullRhsValues();
     std.debug.assert(full_rhs.len == state_values.len);
 
     for (full_rhs, masses, state_values) |*rhs_value, mass, state_value| {
         rhs_value.* = mass * state_value;
     }
 
-    _ = try heat_system.constrained_system.solveHomogeneous(state_values);
+    _ = try heat_system.linear_system.solveHomogeneous(state_values);
 }
 
 fn initializeState(

--- a/examples/diffusion/sphere.zig
+++ b/examples/diffusion/sphere.zig
@@ -3,7 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
-const implicit_system_mod = flux.operators.implicit_system;
+const linear_system = flux.math.linear_system;
 const operator_context_mod = flux.operators.context;
 const evolution_mod = flux.integrators.evolution;
 
@@ -39,7 +39,7 @@ pub const ConvergenceResultImpl = struct {
 
 pub const SurfaceSystem = struct {
     operator_context: *SurfaceOperatorContext,
-    implicit_system: implicit_system_mod.AssembledImplicitSystem,
+    linear_system: linear_system.LinearSystem,
     masses: []f64,
 
     pub fn init(
@@ -69,22 +69,22 @@ pub const SurfaceSystem = struct {
         var system_matrix = try assembler.build(allocator);
         errdefer system_matrix.deinit(allocator);
 
-        var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+        var system_runtime = try linear_system.LinearSystem.init(
             allocator,
             system_matrix,
             .{},
         );
-        errdefer implicit_system.deinit(allocator);
+        errdefer system_runtime.deinit(allocator);
 
         return .{
             .operator_context = operator_context,
-            .implicit_system = implicit_system,
+            .linear_system = system_runtime,
             .masses = masses,
         };
     }
 
     pub fn deinit(self: *SurfaceSystem, allocator: std.mem.Allocator) void {
-        self.implicit_system.deinit(allocator);
+        self.linear_system.deinit(allocator);
         allocator.free(self.masses);
         self.operator_context.deinit();
     }
@@ -200,8 +200,8 @@ fn stepBackwardEuler(
     system: *SurfaceSystem,
     state_values: []f64,
 ) !void {
-    const rhs = system.implicit_system.rhsValues();
-    const solution = system.implicit_system.solutionValues();
+    const rhs = system.linear_system.rhsValues();
+    const solution = system.linear_system.solutionValues();
     std.debug.assert(rhs.len == state_values.len);
     std.debug.assert(solution.len == state_values.len);
 
@@ -209,7 +209,7 @@ fn stepBackwardEuler(
         rhs_value.* = mass * state_value;
     }
 
-    _ = try system.implicit_system.solve();
+    _ = try system.linear_system.solve();
 
     @memcpy(state_values, solution);
 }
@@ -236,7 +236,7 @@ const SurfaceStepperBuilder = struct {
 
     pub fn initStepper(self: @This(), allocator: std.mem.Allocator, state_values: []f64) !Stepper {
         _ = allocator;
-        self.system.implicit_system.seedSolution(state_values);
+        self.system.linear_system.seedSolution(state_values);
         return .{
             .system = self.system,
             .state_values = state_values,

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -676,3 +676,37 @@ owned runtime around an already-assembled operator. Keeping the object matrix-
 agnostic but ownership-aware immediately shrinks both constrained and
 unconstrained diffusion examples, lets Poisson reuse the same packaging, and
 preserves a clean seam for later boundary-constraint composition.
+
+## 2026-04-11: Constrained implicit systems own reduced solve state and boundary couplings, not the source matrix
+
+**Decision:** Add `flux.operators.implicit_system.DirichletConstrainedSystem`
+as a layer above `AssembledImplicitSystem`. It owns:
+- the constrained/unconstrained mask
+- reduced-index bookkeeping
+- reusable full-size RHS storage
+- the reduced solve runtime
+- a sparse boundary-coupling matrix used to apply Dirichlet values at solve time
+
+It does **not** own the original full matrix after construction.
+
+**Alternatives considered:**
+1. Keep the full matrix inside the constrained object: rejected because some
+   callers, such as Poisson's zero-form path, only have a borrowed assembled
+   matrix from `OperatorContext`. Taking ownership there would either double-
+   free or force an unnecessary deep copy.
+2. Keep only mask/index bookkeeping and make callers apply boundary RHS
+   corrections themselves: rejected because that leaves the core reduced-system
+   orchestration in example code, which is exactly the abstraction gap this
+   issue is meant to close.
+3. Put boundary constraints directly into `AssembledImplicitSystem`: rejected
+   because constrained and unconstrained solves are different layers. The base
+   object should remain the reusable SPD solve runtime; the constrained layer
+   composes on top of it.
+
+**Rationale:** The essential reusable data for a constrained solve is not the
+entire full matrix, but the reduced matrix plus the boundary-coupling terms
+needed to shift the RHS when boundary values are nonzero. Owning just that data
+keeps the API valid for both borrowed and owned assembled matrices, moves the
+packing/unpacking logic into the library, and lets the plane diffusion example
+delete its manual boundary mask and reduced-index machinery without forcing a
+copy of every constrained matrix.

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -710,3 +710,33 @@ keeps the API valid for both borrowed and owned assembled matrices, moves the
 packing/unpacking logic into the library, and lets the plane diffusion example
 delete its manual boundary mask and reduced-index machinery without forcing a
 copy of every constrained matrix.
+
+## 2026-04-11: Linear-system abstractions are structural math concepts, not policy-shaped operator types
+
+**Decision:** Move the assembled-system runtime into `src/math/linear_system.zig`
+and expose structural nouns:
+- `LinearSystem`
+- `EliminationMap`
+- `EliminatedLinearSystem`
+
+Do not expose public types named after today's policy choice such as
+`DirichletConstrainedSystem`.
+
+**Alternatives considered:**
+1. Keep `implicit_system` under `src/operators/` with policy-shaped names:
+   rejected because the real concepts are linear algebra and elimination, not a
+   particular PDE boundary label. The operator layer uses these concepts but
+   does not own them.
+2. Keep only one monolithic constrained runtime type: rejected because it
+   obscures the reusable split between the base linear solve runtime and the
+   elimination map layered on top.
+3. Push all generality into one giant "system" object now: rejected because the
+   immediate structural split is already clear and valuable. We should name the
+   real concepts we understand today without inventing a premature universal
+   solver graph object.
+
+**Rationale:** This project is aiming at a general PDE solver library, not a
+collection of wrappers around today's examples. Structural abstractions should
+describe the underlying mathematical/computational role so they still make
+sense for other PDEs, dimensions, and solver families. `LinearSystem` plus an
+`EliminationMap` is such a split. `DirichletConstrainedSystem` was not.

--- a/src/math/linear_system.zig
+++ b/src/math/linear_system.zig
@@ -1,16 +1,16 @@
-//! Reusable assembled implicit linear solves with owned workspace.
+//! Reusable linear-system runtimes and elimination maps.
 
 const std = @import("std");
 const testing = std.testing;
-const sparse = @import("../math/sparse.zig");
-const cg = @import("../math/cg.zig");
+const sparse = @import("sparse.zig");
+const cg = @import("cg.zig");
 
 pub const SolveConfig = struct {
     tolerance_relative: f64 = 1e-10,
     iteration_limit: u32 = 4000,
 };
 
-pub const AssembledImplicitSystem = struct {
+pub const LinearSystem = struct {
     matrix: sparse.CsrMatrix(f64),
     diagonal: []f64,
     rhs: []f64,
@@ -22,7 +22,7 @@ pub const AssembledImplicitSystem = struct {
         allocator: std.mem.Allocator,
         matrix: sparse.CsrMatrix(f64),
         config: SolveConfig,
-    ) !AssembledImplicitSystem {
+    ) !LinearSystem {
         std.debug.assert(matrix.n_rows == matrix.n_cols);
 
         const diagonal = try diagonalOf(allocator, matrix);
@@ -49,7 +49,7 @@ pub const AssembledImplicitSystem = struct {
         };
     }
 
-    pub fn deinit(self: *AssembledImplicitSystem, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *LinearSystem, allocator: std.mem.Allocator) void {
         self.scratch.deinit(allocator);
         allocator.free(self.solution);
         allocator.free(self.rhs);
@@ -57,20 +57,20 @@ pub const AssembledImplicitSystem = struct {
         self.matrix.deinit(allocator);
     }
 
-    pub fn rhsValues(self: *AssembledImplicitSystem) []f64 {
+    pub fn rhsValues(self: *LinearSystem) []f64 {
         return self.rhs;
     }
 
-    pub fn solutionValues(self: *AssembledImplicitSystem) []f64 {
+    pub fn solutionValues(self: *LinearSystem) []f64 {
         return self.solution;
     }
 
-    pub fn seedSolution(self: *AssembledImplicitSystem, values: []const f64) void {
+    pub fn seedSolution(self: *LinearSystem, values: []const f64) void {
         std.debug.assert(values.len == self.solution.len);
         @memcpy(self.solution, values);
     }
 
-    pub fn solve(self: *AssembledImplicitSystem) !cg.SolveResult {
+    pub fn solve(self: *LinearSystem) !cg.SolveResult {
         var preconditioner = cg.DiagonalPreconditioner{ .diagonal = self.diagonal };
         const result = cg.solve(
             self.matrix,
@@ -86,27 +86,16 @@ pub const AssembledImplicitSystem = struct {
     }
 };
 
-pub const DirichletConstrainedSystem = struct {
-    boundary_coupling: sparse.CsrMatrix(f64),
+pub const EliminationMap = struct {
     constrained_mask: []bool,
     reduced_index: []u32,
     free_indices: []u32,
-    full_rhs: []f64,
-    reduced_system: ?AssembledImplicitSystem,
 
-    pub fn init(
-        allocator: std.mem.Allocator,
-        full_matrix: sparse.CsrMatrix(f64),
-        constrained_mask: []const bool,
-        config: SolveConfig,
-    ) !DirichletConstrainedSystem {
-        std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
-        std.debug.assert(constrained_mask.len == full_matrix.n_rows);
-
+    pub fn init(allocator: std.mem.Allocator, constrained_mask: []const bool) !EliminationMap {
         const owned_mask = try allocator.dupe(bool, constrained_mask);
         errdefer allocator.free(owned_mask);
 
-        const reduced_index = try allocator.alloc(u32, full_matrix.n_rows);
+        const reduced_index = try allocator.alloc(u32, constrained_mask.len);
         errdefer allocator.free(reduced_index);
         @memset(reduced_index, std.math.maxInt(u32));
 
@@ -124,16 +113,91 @@ pub const DirichletConstrainedSystem = struct {
             free_indices[reduced_index[idx]] = @intCast(idx);
         }
 
+        return .{
+            .constrained_mask = owned_mask,
+            .reduced_index = reduced_index,
+            .free_indices = free_indices,
+        };
+    }
+
+    pub fn initBoundary(
+        comptime MeshType: type,
+        allocator: std.mem.Allocator,
+        mesh: *const MeshType,
+        comptime k: comptime_int,
+    ) !EliminationMap {
+        const mask = try mesh.boundary_mask(allocator, k);
+        defer allocator.free(mask);
+        return init(allocator, mask);
+    }
+
+    pub fn deinit(self: *EliminationMap, allocator: std.mem.Allocator) void {
+        allocator.free(self.free_indices);
+        allocator.free(self.reduced_index);
+        allocator.free(self.constrained_mask);
+    }
+
+    pub fn fullCount(self: EliminationMap) usize {
+        return self.constrained_mask.len;
+    }
+
+    pub fn freeCount(self: EliminationMap) usize {
+        return self.free_indices.len;
+    }
+
+    pub fn constrainedMask(self: EliminationMap) []const bool {
+        return self.constrained_mask;
+    }
+
+    pub fn projectFree(self: EliminationMap, full_values: []const f64, reduced_values: []f64) void {
+        std.debug.assert(full_values.len == self.fullCount());
+        std.debug.assert(reduced_values.len == self.freeCount());
+        for (self.free_indices, 0..) |full_idx, reduced_idx| {
+            reduced_values[reduced_idx] = full_values[full_idx];
+        }
+    }
+
+    pub fn liftFree(
+        self: EliminationMap,
+        reduced_values: []const f64,
+        constrained_values: []const f64,
+        full_values: []f64,
+    ) void {
+        std.debug.assert(reduced_values.len == self.freeCount());
+        std.debug.assert(constrained_values.len == self.fullCount());
+        std.debug.assert(full_values.len == self.fullCount());
+        for (self.constrained_mask, 0..) |is_constrained, idx| {
+            full_values[idx] = if (is_constrained)
+                constrained_values[idx]
+            else
+                reduced_values[self.reduced_index[idx]];
+        }
+    }
+};
+
+pub const EliminatedLinearSystem = struct {
+    elimination_map: EliminationMap,
+    boundary_coupling: sparse.CsrMatrix(f64),
+    full_rhs: []f64,
+    reduced_system: ?LinearSystem,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        full_matrix: sparse.CsrMatrix(f64),
+        elimination_map: EliminationMap,
+        config: SolveConfig,
+    ) !EliminatedLinearSystem {
+        std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
+        std.debug.assert(full_matrix.n_rows == elimination_map.fullCount());
+
         const full_rhs = try allocator.alloc(f64, full_matrix.n_rows);
         errdefer allocator.free(full_rhs);
         @memset(full_rhs, 0.0);
 
-        const reduced_parts = try initReducedSystem(
+        const reduced_parts = try buildReducedParts(
             allocator,
             full_matrix,
-            owned_mask,
-            reduced_index,
-            free_count,
+            elimination_map,
             config,
         );
         errdefer {
@@ -142,83 +206,73 @@ pub const DirichletConstrainedSystem = struct {
         }
 
         return .{
+            .elimination_map = elimination_map,
             .boundary_coupling = reduced_parts.boundary_coupling,
-            .constrained_mask = owned_mask,
-            .reduced_index = reduced_index,
-            .free_indices = free_indices,
             .full_rhs = full_rhs,
             .reduced_system = reduced_parts.reduced_system,
         };
     }
 
-    pub fn deinit(self: *DirichletConstrainedSystem, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *EliminatedLinearSystem, allocator: std.mem.Allocator) void {
         if (self.reduced_system) |*system| system.deinit(allocator);
         allocator.free(self.full_rhs);
-        allocator.free(self.free_indices);
-        allocator.free(self.reduced_index);
-        allocator.free(self.constrained_mask);
         self.boundary_coupling.deinit(allocator);
+        self.elimination_map.deinit(allocator);
     }
 
-    pub fn fullRhsValues(self: *DirichletConstrainedSystem) []f64 {
+    pub fn fullRhsValues(self: *EliminatedLinearSystem) []f64 {
         return self.full_rhs;
     }
 
-    pub fn seedSolutionFromFull(self: *DirichletConstrainedSystem, full_values: []const f64) void {
-        std.debug.assert(full_values.len == self.full_rhs.len);
+    pub fn seedSolutionFromFull(self: *EliminatedLinearSystem, full_values: []const f64) void {
+        std.debug.assert(full_values.len == self.elimination_map.fullCount());
         if (self.reduced_system) |*system| {
-            for (self.free_indices, 0..) |full_idx, reduced_idx| {
-                system.solutionValues()[reduced_idx] = full_values[full_idx];
-            }
+            self.elimination_map.projectFree(full_values, system.solutionValues());
         }
     }
 
-    pub fn solveDirichlet(
-        self: *DirichletConstrainedSystem,
-        boundary_values: []const f64,
+    pub fn solveWithConstrainedValues(
+        self: *EliminatedLinearSystem,
+        constrained_values: []const f64,
         full_solution: []f64,
     ) !cg.SolveResult {
-        std.debug.assert(boundary_values.len == self.full_rhs.len);
-        std.debug.assert(full_solution.len == self.full_rhs.len);
+        std.debug.assert(constrained_values.len == self.elimination_map.fullCount());
+        std.debug.assert(full_solution.len == self.elimination_map.fullCount());
 
         if (self.reduced_system) |*system| {
             const reduced_rhs = system.rhsValues();
-            for (self.free_indices, 0..) |full_row_idx, reduced_row_idx| {
+            for (self.elimination_map.free_indices, 0..) |full_row_idx, reduced_row_idx| {
                 var rhs_value = self.full_rhs[full_row_idx];
                 const row = self.boundary_coupling.row(@intCast(reduced_row_idx));
                 for (row.cols, row.vals) |col_idx, value| {
-                    rhs_value -= value * boundary_values[col_idx];
+                    rhs_value -= value * constrained_values[col_idx];
                 }
                 reduced_rhs[reduced_row_idx] = rhs_value;
             }
 
             const result = try system.solve();
-            scatterSolution(self, boundary_values, full_solution);
+            self.elimination_map.liftFree(system.solutionValues(), constrained_values, full_solution);
             return result;
         }
 
-        @memcpy(full_solution, boundary_values);
+        @memcpy(full_solution, constrained_values);
         return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
     }
 
-    pub fn solveHomogeneousDirichlet(
-        self: *DirichletConstrainedSystem,
+    pub fn solveHomogeneous(
+        self: *EliminatedLinearSystem,
         full_solution: []f64,
     ) !cg.SolveResult {
-        std.debug.assert(full_solution.len == self.full_rhs.len);
+        std.debug.assert(full_solution.len == self.elimination_map.fullCount());
 
         if (self.reduced_system) |*system| {
-            const reduced_rhs = system.rhsValues();
-            for (self.free_indices, 0..) |full_row_idx, reduced_row_idx| {
-                reduced_rhs[reduced_row_idx] = self.full_rhs[full_row_idx];
-            }
-
+            self.elimination_map.projectFree(self.full_rhs, system.rhsValues());
             const result = try system.solve();
-            for (self.constrained_mask, 0..) |is_constrained, idx| {
+            for (self.elimination_map.constrained_mask, 0..) |is_constrained, idx| {
                 full_solution[idx] = if (is_constrained)
                     0.0
                 else
-                    system.solutionValues()[self.reduced_index[idx]];
+                    system.solutionValues()[self.elimination_map.reduced_index[idx]];
             }
             return result;
         }
@@ -228,45 +282,49 @@ pub const DirichletConstrainedSystem = struct {
     }
 };
 
-fn initReducedSystem(
+fn buildReducedParts(
     allocator: std.mem.Allocator,
     full_matrix: sparse.CsrMatrix(f64),
-    constrained_mask: []const bool,
-    reduced_index: []const u32,
-    free_count: u32,
+    elimination_map: EliminationMap,
     config: SolveConfig,
 ) !struct {
     boundary_coupling: sparse.CsrMatrix(f64),
-    reduced_system: ?AssembledImplicitSystem,
+    reduced_system: ?LinearSystem,
 } {
-    var boundary_triplets = sparse.TripletAssembler(f64).init(free_count, full_matrix.n_cols);
+    var boundary_triplets = sparse.TripletAssembler(f64).init(
+        @intCast(elimination_map.freeCount()),
+        full_matrix.n_cols,
+    );
     defer boundary_triplets.deinit(allocator);
 
-    if (free_count == 0) {
+    if (elimination_map.freeCount() == 0) {
         return .{
             .boundary_coupling = try boundary_triplets.build(allocator),
             .reduced_system = null,
         };
     }
 
-    var triplets = sparse.TripletAssembler(f64).init(free_count, free_count);
-    defer triplets.deinit(allocator);
+    var reduced_triplets = sparse.TripletAssembler(f64).init(
+        @intCast(elimination_map.freeCount()),
+        @intCast(elimination_map.freeCount()),
+    );
+    defer reduced_triplets.deinit(allocator);
 
     for (0..full_matrix.n_rows) |row_idx_usize| {
-        if (constrained_mask[row_idx_usize]) continue;
+        if (elimination_map.constrained_mask[row_idx_usize]) continue;
 
-        const reduced_row = reduced_index[row_idx_usize];
+        const reduced_row = elimination_map.reduced_index[row_idx_usize];
         const row = full_matrix.row(@intCast(row_idx_usize));
         for (row.cols, row.vals) |col_idx, value| {
-            if (constrained_mask[col_idx]) {
+            if (elimination_map.constrained_mask[col_idx]) {
                 try boundary_triplets.addEntry(allocator, reduced_row, col_idx, value);
             } else {
-                try triplets.addEntry(allocator, reduced_row, reduced_index[col_idx], value);
+                try reduced_triplets.addEntry(allocator, reduced_row, elimination_map.reduced_index[col_idx], value);
             }
         }
     }
 
-    var reduced_matrix = try triplets.build(allocator);
+    var reduced_matrix = try reduced_triplets.build(allocator);
     errdefer reduced_matrix.deinit(allocator);
 
     var boundary_coupling = try boundary_triplets.build(allocator);
@@ -274,22 +332,8 @@ fn initReducedSystem(
 
     return .{
         .boundary_coupling = boundary_coupling,
-        .reduced_system = try AssembledImplicitSystem.init(allocator, reduced_matrix, config),
+        .reduced_system = try LinearSystem.init(allocator, reduced_matrix, config),
     };
-}
-
-fn scatterSolution(
-    self: *DirichletConstrainedSystem,
-    boundary_values: []const f64,
-    full_solution: []f64,
-) void {
-    const system = &(self.reduced_system orelse unreachable);
-    for (self.constrained_mask, 0..) |is_constrained, idx| {
-        full_solution[idx] = if (is_constrained)
-            boundary_values[idx]
-        else
-            system.solutionValues()[self.reduced_index[idx]];
-    }
 }
 
 fn diagonalOf(allocator: std.mem.Allocator, matrix: sparse.CsrMatrix(f64)) ![]f64 {
@@ -311,7 +355,7 @@ fn diagonalOf(allocator: std.mem.Allocator, matrix: sparse.CsrMatrix(f64)) ![]f6
     return diagonal;
 }
 
-test "assembled implicit system computes matrix diagonal and reuses owned buffers across solves" {
+test "linear system computes matrix diagonal and reuses owned buffers across solves" {
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 2, 2, 2);
@@ -323,7 +367,7 @@ test "assembled implicit system computes matrix diagonal and reuses owned buffer
     matrix.values[0] = 2.0;
     matrix.values[1] = 4.0;
 
-    var system = try AssembledImplicitSystem.init(allocator, matrix, .{});
+    var system = try LinearSystem.init(allocator, matrix, .{});
     defer system.deinit(allocator);
 
     const rhs_ptr = system.rhsValues().ptr;
@@ -350,7 +394,7 @@ test "assembled implicit system computes matrix diagonal and reuses owned buffer
     try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[1], 1e-12);
 }
 
-test "Dirichlet constrained system scatters boundary values and corrects reduced rhs" {
+test "eliminated linear system scatters constrained values and corrects reduced rhs" {
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 7);
@@ -374,29 +418,25 @@ test "Dirichlet constrained system scatters boundary values and corrects reduced
     matrix.values[5] = -1.0;
     matrix.values[6] = 2.0;
 
-    var system = try DirichletConstrainedSystem.init(
-        allocator,
-        matrix,
-        &[_]bool{ true, false, true },
-        .{},
-    );
+    const elimination_map = try EliminationMap.init(allocator, &[_]bool{ true, false, true });
+    var system = try EliminatedLinearSystem.init(allocator, matrix, elimination_map, .{});
     defer system.deinit(allocator);
 
     system.fullRhsValues()[0] = 0.0;
     system.fullRhsValues()[1] = 0.0;
     system.fullRhsValues()[2] = 0.0;
 
-    const boundary_values = [_]f64{ 10.0, 0.0, 20.0 };
+    const constrained_values = [_]f64{ 10.0, 0.0, 20.0 };
     var solution = [_]f64{ 0.0, 0.0, 0.0 };
 
-    const result = try system.solveDirichlet(&boundary_values, &solution);
+    const result = try system.solveWithConstrainedValues(&constrained_values, &solution);
     try testing.expect(result.converged);
     try testing.expectApproxEqAbs(@as(f64, 10.0), solution[0], 1e-12);
     try testing.expectApproxEqAbs(@as(f64, 15.0), solution[1], 1e-12);
     try testing.expectApproxEqAbs(@as(f64, 20.0), solution[2], 1e-12);
 }
 
-test "Dirichlet constrained system reuses full rhs buffer and seeds from full state" {
+test "eliminated linear system reuses full rhs buffer and seeds from full state" {
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 3);
@@ -412,12 +452,8 @@ test "Dirichlet constrained system reuses full rhs buffer and seeds from full st
     matrix.values[1] = 5.0;
     matrix.values[2] = 6.0;
 
-    var system = try DirichletConstrainedSystem.init(
-        allocator,
-        matrix,
-        &[_]bool{ true, false, false },
-        .{},
-    );
+    const elimination_map = try EliminationMap.init(allocator, &[_]bool{ true, false, false });
+    var system = try EliminatedLinearSystem.init(allocator, matrix, elimination_map, .{});
     defer system.deinit(allocator);
 
     const rhs_ptr = system.fullRhsValues().ptr;
@@ -427,7 +463,7 @@ test "Dirichlet constrained system reuses full rhs buffer and seeds from full st
     system.fullRhsValues()[2] = 18.0;
 
     var solution = [_]f64{ 0.0, 0.0, 0.0 };
-    const result = try system.solveHomogeneousDirichlet(&solution);
+    const result = try system.solveHomogeneous(&solution);
     try testing.expect(result.converged);
     try testing.expect(rhs_ptr == system.fullRhsValues().ptr);
     try testing.expectApproxEqAbs(@as(f64, 0.0), solution[0], 1e-12);

--- a/src/math/linear_system.zig
+++ b/src/math/linear_system.zig
@@ -17,6 +17,9 @@ pub const LinearSystem = struct {
     solution: []f64,
     scratch: cg.Scratch,
     config: SolveConfig,
+    elimination_map: ?EliminationMap = null,
+    boundary_coupling: ?sparse.CsrMatrix(f64) = null,
+    full_rhs: ?[]f64 = null,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -49,12 +52,70 @@ pub const LinearSystem = struct {
         };
     }
 
+    pub fn eliminate(
+        allocator: std.mem.Allocator,
+        full_matrix: sparse.CsrMatrix(f64),
+        elimination_map: EliminationMap,
+        config: SolveConfig,
+    ) !LinearSystem {
+        std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
+        std.debug.assert(full_matrix.n_rows == elimination_map.fullCount());
+
+        const full_rhs = try allocator.alloc(f64, full_matrix.n_rows);
+        errdefer allocator.free(full_rhs);
+        @memset(full_rhs, 0.0);
+
+        var reduced_parts = try buildReducedParts(
+            allocator,
+            full_matrix,
+            elimination_map,
+            config,
+        );
+        errdefer {
+            reduced_parts.boundary_coupling.deinit(allocator);
+            if (reduced_parts.reduced_system) |*system| system.deinit(allocator);
+        }
+
+        if (reduced_parts.reduced_system) |system| {
+            return .{
+                .matrix = system.matrix,
+                .diagonal = system.diagonal,
+                .rhs = system.rhs,
+                .solution = system.solution,
+                .scratch = system.scratch,
+                .config = system.config,
+                .elimination_map = elimination_map,
+                .boundary_coupling = reduced_parts.boundary_coupling,
+                .full_rhs = full_rhs,
+            };
+        }
+
+        var scratch = try cg.Scratch.init(allocator, 0);
+        errdefer scratch.deinit(allocator);
+        var empty_matrix = try sparse.CsrMatrix(f64).init(allocator, 0, 0, 0);
+        errdefer empty_matrix.deinit(allocator);
+        const diagonal = try allocator.alloc(f64, 0);
+        errdefer allocator.free(diagonal);
+        const rhs = try allocator.alloc(f64, 0);
+        errdefer allocator.free(rhs);
+        const solution = try allocator.alloc(f64, 0);
+        errdefer allocator.free(solution);
+
+        return .{
+            .matrix = empty_matrix,
+            .diagonal = diagonal,
+            .rhs = rhs,
+            .solution = solution,
+            .scratch = scratch,
+            .config = config,
+            .elimination_map = elimination_map,
+            .boundary_coupling = reduced_parts.boundary_coupling,
+            .full_rhs = full_rhs,
+        };
+    }
+
     pub fn deinit(self: *LinearSystem, allocator: std.mem.Allocator) void {
-        self.scratch.deinit(allocator);
-        allocator.free(self.solution);
-        allocator.free(self.rhs);
-        allocator.free(self.diagonal);
-        self.matrix.deinit(allocator);
+        self.deinitCore(allocator, true);
     }
 
     pub fn rhsValues(self: *LinearSystem) []f64 {
@@ -70,6 +131,16 @@ pub const LinearSystem = struct {
         @memcpy(self.solution, values);
     }
 
+    pub fn seedSolutionFromFull(self: *LinearSystem, full_values: []const f64) void {
+        const elimination_map = self.eliminationMap();
+        std.debug.assert(full_values.len == elimination_map.fullCount());
+        elimination_map.projectFree(full_values, self.solutionValues());
+    }
+
+    pub fn fullRhsValues(self: *LinearSystem) []f64 {
+        return self.full_rhs orelse @panic("fullRhsValues requires an eliminated linear system");
+    }
+
     pub fn solve(self: *LinearSystem) !cg.SolveResult {
         var preconditioner = cg.DiagonalPreconditioner{ .diagonal = self.diagonal };
         const result = cg.solve(
@@ -83,6 +154,76 @@ pub const LinearSystem = struct {
         );
         if (!result.converged) return error.ConjugateGradientDidNotConverge;
         return result;
+    }
+
+    pub fn solveWithConstrainedValues(
+        self: *LinearSystem,
+        constrained_values: []const f64,
+        full_solution: []f64,
+    ) !cg.SolveResult {
+        const elimination_map = self.eliminationMap();
+        const boundary_coupling = self.boundaryCoupling();
+        const full_rhs = self.fullRhsValues();
+        std.debug.assert(constrained_values.len == elimination_map.fullCount());
+        std.debug.assert(full_solution.len == elimination_map.fullCount());
+
+        if (elimination_map.freeCount() == 0) {
+            @memcpy(full_solution, constrained_values);
+            return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
+        }
+
+        const reduced_rhs = self.rhsValues();
+        for (elimination_map.free_indices, 0..) |full_row_idx, reduced_row_idx| {
+            var rhs_value = full_rhs[full_row_idx];
+            const row = boundary_coupling.row(@intCast(reduced_row_idx));
+            for (row.cols, row.vals) |col_idx, value| {
+                rhs_value -= value * constrained_values[col_idx];
+            }
+            reduced_rhs[reduced_row_idx] = rhs_value;
+        }
+
+        const result = try self.solve();
+        elimination_map.liftFree(self.solutionValues(), constrained_values, full_solution);
+        return result;
+    }
+
+    pub fn solveHomogeneous(self: *LinearSystem, full_solution: []f64) !cg.SolveResult {
+        const elimination_map = self.eliminationMap();
+        std.debug.assert(full_solution.len == elimination_map.fullCount());
+
+        if (elimination_map.freeCount() == 0) {
+            @memset(full_solution, 0.0);
+            return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
+        }
+
+        elimination_map.projectFree(self.fullRhsValues(), self.rhsValues());
+        const result = try self.solve();
+        for (elimination_map.constrained_mask, 0..) |is_constrained, idx| {
+            full_solution[idx] = if (is_constrained)
+                0.0
+            else
+                self.solutionValues()[elimination_map.reduced_index[idx]];
+        }
+        return result;
+    }
+
+    fn eliminationMap(self: *LinearSystem) EliminationMap {
+        return self.elimination_map orelse @panic("operation requires an eliminated linear system");
+    }
+
+    fn boundaryCoupling(self: *LinearSystem) sparse.CsrMatrix(f64) {
+        return self.boundary_coupling orelse @panic("operation requires an eliminated linear system");
+    }
+
+    fn deinitCore(self: *LinearSystem, allocator: std.mem.Allocator, deinit_matrix: bool) void {
+        self.scratch.deinit(allocator);
+        allocator.free(self.solution);
+        allocator.free(self.rhs);
+        allocator.free(self.diagonal);
+        if (deinit_matrix) self.matrix.deinit(allocator);
+        if (self.full_rhs) |full_rhs| allocator.free(full_rhs);
+        if (self.boundary_coupling) |*boundary_coupling| boundary_coupling.deinit(allocator);
+        if (self.elimination_map) |*elimination_map| elimination_map.deinit(allocator);
     }
 };
 
@@ -172,113 +313,6 @@ pub const EliminationMap = struct {
             else
                 reduced_values[self.reduced_index[idx]];
         }
-    }
-};
-
-pub const EliminatedLinearSystem = struct {
-    elimination_map: EliminationMap,
-    boundary_coupling: sparse.CsrMatrix(f64),
-    full_rhs: []f64,
-    reduced_system: ?LinearSystem,
-
-    pub fn init(
-        allocator: std.mem.Allocator,
-        full_matrix: sparse.CsrMatrix(f64),
-        elimination_map: EliminationMap,
-        config: SolveConfig,
-    ) !EliminatedLinearSystem {
-        std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
-        std.debug.assert(full_matrix.n_rows == elimination_map.fullCount());
-
-        const full_rhs = try allocator.alloc(f64, full_matrix.n_rows);
-        errdefer allocator.free(full_rhs);
-        @memset(full_rhs, 0.0);
-
-        const reduced_parts = try buildReducedParts(
-            allocator,
-            full_matrix,
-            elimination_map,
-            config,
-        );
-        errdefer {
-            reduced_parts.boundary_coupling.deinit(allocator);
-            if (reduced_parts.reduced_system) |*system| system.deinit(allocator);
-        }
-
-        return .{
-            .elimination_map = elimination_map,
-            .boundary_coupling = reduced_parts.boundary_coupling,
-            .full_rhs = full_rhs,
-            .reduced_system = reduced_parts.reduced_system,
-        };
-    }
-
-    pub fn deinit(self: *EliminatedLinearSystem, allocator: std.mem.Allocator) void {
-        if (self.reduced_system) |*system| system.deinit(allocator);
-        allocator.free(self.full_rhs);
-        self.boundary_coupling.deinit(allocator);
-        self.elimination_map.deinit(allocator);
-    }
-
-    pub fn fullRhsValues(self: *EliminatedLinearSystem) []f64 {
-        return self.full_rhs;
-    }
-
-    pub fn seedSolutionFromFull(self: *EliminatedLinearSystem, full_values: []const f64) void {
-        std.debug.assert(full_values.len == self.elimination_map.fullCount());
-        if (self.reduced_system) |*system| {
-            self.elimination_map.projectFree(full_values, system.solutionValues());
-        }
-    }
-
-    pub fn solveWithConstrainedValues(
-        self: *EliminatedLinearSystem,
-        constrained_values: []const f64,
-        full_solution: []f64,
-    ) !cg.SolveResult {
-        std.debug.assert(constrained_values.len == self.elimination_map.fullCount());
-        std.debug.assert(full_solution.len == self.elimination_map.fullCount());
-
-        if (self.reduced_system) |*system| {
-            const reduced_rhs = system.rhsValues();
-            for (self.elimination_map.free_indices, 0..) |full_row_idx, reduced_row_idx| {
-                var rhs_value = self.full_rhs[full_row_idx];
-                const row = self.boundary_coupling.row(@intCast(reduced_row_idx));
-                for (row.cols, row.vals) |col_idx, value| {
-                    rhs_value -= value * constrained_values[col_idx];
-                }
-                reduced_rhs[reduced_row_idx] = rhs_value;
-            }
-
-            const result = try system.solve();
-            self.elimination_map.liftFree(system.solutionValues(), constrained_values, full_solution);
-            return result;
-        }
-
-        @memcpy(full_solution, constrained_values);
-        return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
-    }
-
-    pub fn solveHomogeneous(
-        self: *EliminatedLinearSystem,
-        full_solution: []f64,
-    ) !cg.SolveResult {
-        std.debug.assert(full_solution.len == self.elimination_map.fullCount());
-
-        if (self.reduced_system) |*system| {
-            self.elimination_map.projectFree(self.full_rhs, system.rhsValues());
-            const result = try system.solve();
-            for (self.elimination_map.constrained_mask, 0..) |is_constrained, idx| {
-                full_solution[idx] = if (is_constrained)
-                    0.0
-                else
-                    system.solutionValues()[self.elimination_map.reduced_index[idx]];
-            }
-            return result;
-        }
-
-        @memset(full_solution, 0.0);
-        return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
     }
 };
 
@@ -394,7 +428,7 @@ test "linear system computes matrix diagonal and reuses owned buffers across sol
     try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[1], 1e-12);
 }
 
-test "eliminated linear system scatters constrained values and corrects reduced rhs" {
+test "linear system scatters constrained values and corrects reduced rhs" {
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 7);
@@ -419,7 +453,7 @@ test "eliminated linear system scatters constrained values and corrects reduced 
     matrix.values[6] = 2.0;
 
     const elimination_map = try EliminationMap.init(allocator, &[_]bool{ true, false, true });
-    var system = try EliminatedLinearSystem.init(allocator, matrix, elimination_map, .{});
+    var system = try LinearSystem.eliminate(allocator, matrix, elimination_map, .{});
     defer system.deinit(allocator);
 
     system.fullRhsValues()[0] = 0.0;
@@ -436,7 +470,7 @@ test "eliminated linear system scatters constrained values and corrects reduced 
     try testing.expectApproxEqAbs(@as(f64, 20.0), solution[2], 1e-12);
 }
 
-test "eliminated linear system reuses full rhs buffer and seeds from full state" {
+test "linear system reuses full rhs buffer and seeds from full state" {
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 3);
@@ -453,7 +487,7 @@ test "eliminated linear system reuses full rhs buffer and seeds from full state"
     matrix.values[2] = 6.0;
 
     const elimination_map = try EliminationMap.init(allocator, &[_]bool{ true, false, false });
-    var system = try EliminatedLinearSystem.init(allocator, matrix, elimination_map, .{});
+    var system = try LinearSystem.eliminate(allocator, matrix, elimination_map, .{});
     defer system.deinit(allocator);
 
     const rhs_ptr = system.fullRhsValues().ptr;

--- a/src/operators/implicit_system.zig
+++ b/src/operators/implicit_system.zig
@@ -87,34 +87,90 @@ pub const AssembledImplicitSystem = struct {
 };
 
 pub const DirichletConstrainedSystem = struct {
+    boundary_coupling: sparse.CsrMatrix(f64),
+    constrained_mask: []bool,
+    reduced_index: []u32,
+    free_indices: []u32,
+    full_rhs: []f64,
+    reduced_system: ?AssembledImplicitSystem,
+
     pub fn init(
         allocator: std.mem.Allocator,
         full_matrix: sparse.CsrMatrix(f64),
         constrained_mask: []const bool,
         config: SolveConfig,
     ) !DirichletConstrainedSystem {
-        _ = allocator;
-        _ = full_matrix;
-        _ = constrained_mask;
-        _ = config;
-        @panic("not yet implemented");
+        std.debug.assert(full_matrix.n_rows == full_matrix.n_cols);
+        std.debug.assert(constrained_mask.len == full_matrix.n_rows);
+
+        const owned_mask = try allocator.dupe(bool, constrained_mask);
+        errdefer allocator.free(owned_mask);
+
+        const reduced_index = try allocator.alloc(u32, full_matrix.n_rows);
+        errdefer allocator.free(reduced_index);
+        @memset(reduced_index, std.math.maxInt(u32));
+
+        var free_count: u32 = 0;
+        for (owned_mask, 0..) |is_constrained, idx| {
+            if (is_constrained) continue;
+            reduced_index[idx] = free_count;
+            free_count += 1;
+        }
+
+        const free_indices = try allocator.alloc(u32, free_count);
+        errdefer allocator.free(free_indices);
+        for (owned_mask, 0..) |is_constrained, idx| {
+            if (is_constrained) continue;
+            free_indices[reduced_index[idx]] = @intCast(idx);
+        }
+
+        const full_rhs = try allocator.alloc(f64, full_matrix.n_rows);
+        errdefer allocator.free(full_rhs);
+        @memset(full_rhs, 0.0);
+
+        const reduced_parts = try initReducedSystem(
+            allocator,
+            full_matrix,
+            owned_mask,
+            reduced_index,
+            free_count,
+            config,
+        );
+        errdefer {
+            reduced_parts.boundary_coupling.deinit(allocator);
+            if (reduced_parts.reduced_system) |*system| system.deinit(allocator);
+        }
+
+        return .{
+            .boundary_coupling = reduced_parts.boundary_coupling,
+            .constrained_mask = owned_mask,
+            .reduced_index = reduced_index,
+            .free_indices = free_indices,
+            .full_rhs = full_rhs,
+            .reduced_system = reduced_parts.reduced_system,
+        };
     }
 
     pub fn deinit(self: *DirichletConstrainedSystem, allocator: std.mem.Allocator) void {
-        _ = self;
-        _ = allocator;
-        @panic("not yet implemented");
+        if (self.reduced_system) |*system| system.deinit(allocator);
+        allocator.free(self.full_rhs);
+        allocator.free(self.free_indices);
+        allocator.free(self.reduced_index);
+        allocator.free(self.constrained_mask);
+        self.boundary_coupling.deinit(allocator);
     }
 
     pub fn fullRhsValues(self: *DirichletConstrainedSystem) []f64 {
-        _ = self;
-        @panic("not yet implemented");
+        return self.full_rhs;
     }
 
     pub fn seedSolutionFromFull(self: *DirichletConstrainedSystem, full_values: []const f64) void {
-        _ = self;
-        _ = full_values;
-        @panic("not yet implemented");
+        std.debug.assert(full_values.len == self.full_rhs.len);
+        if (self.reduced_system) |*system| {
+            for (self.free_indices, 0..) |full_idx, reduced_idx| {
+                system.solutionValues()[reduced_idx] = full_values[full_idx];
+            }
+        }
     }
 
     pub fn solveDirichlet(
@@ -122,21 +178,119 @@ pub const DirichletConstrainedSystem = struct {
         boundary_values: []const f64,
         full_solution: []f64,
     ) !cg.SolveResult {
-        _ = self;
-        _ = boundary_values;
-        _ = full_solution;
-        @panic("not yet implemented");
+        std.debug.assert(boundary_values.len == self.full_rhs.len);
+        std.debug.assert(full_solution.len == self.full_rhs.len);
+
+        if (self.reduced_system) |*system| {
+            const reduced_rhs = system.rhsValues();
+            for (self.free_indices, 0..) |full_row_idx, reduced_row_idx| {
+                var rhs_value = self.full_rhs[full_row_idx];
+                const row = self.boundary_coupling.row(@intCast(reduced_row_idx));
+                for (row.cols, row.vals) |col_idx, value| {
+                    rhs_value -= value * boundary_values[col_idx];
+                }
+                reduced_rhs[reduced_row_idx] = rhs_value;
+            }
+
+            const result = try system.solve();
+            scatterSolution(self, boundary_values, full_solution);
+            return result;
+        }
+
+        @memcpy(full_solution, boundary_values);
+        return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
     }
 
     pub fn solveHomogeneousDirichlet(
         self: *DirichletConstrainedSystem,
         full_solution: []f64,
     ) !cg.SolveResult {
-        _ = self;
-        _ = full_solution;
-        @panic("not yet implemented");
+        std.debug.assert(full_solution.len == self.full_rhs.len);
+
+        if (self.reduced_system) |*system| {
+            const reduced_rhs = system.rhsValues();
+            for (self.free_indices, 0..) |full_row_idx, reduced_row_idx| {
+                reduced_rhs[reduced_row_idx] = self.full_rhs[full_row_idx];
+            }
+
+            const result = try system.solve();
+            for (self.constrained_mask, 0..) |is_constrained, idx| {
+                full_solution[idx] = if (is_constrained)
+                    0.0
+                else
+                    system.solutionValues()[self.reduced_index[idx]];
+            }
+            return result;
+        }
+
+        @memset(full_solution, 0.0);
+        return .{ .iterations = 0, .relative_residual = 0.0, .converged = true };
     }
 };
+
+fn initReducedSystem(
+    allocator: std.mem.Allocator,
+    full_matrix: sparse.CsrMatrix(f64),
+    constrained_mask: []const bool,
+    reduced_index: []const u32,
+    free_count: u32,
+    config: SolveConfig,
+) !struct {
+    boundary_coupling: sparse.CsrMatrix(f64),
+    reduced_system: ?AssembledImplicitSystem,
+} {
+    var boundary_triplets = sparse.TripletAssembler(f64).init(free_count, full_matrix.n_cols);
+    defer boundary_triplets.deinit(allocator);
+
+    if (free_count == 0) {
+        return .{
+            .boundary_coupling = try boundary_triplets.build(allocator),
+            .reduced_system = null,
+        };
+    }
+
+    var triplets = sparse.TripletAssembler(f64).init(free_count, free_count);
+    defer triplets.deinit(allocator);
+
+    for (0..full_matrix.n_rows) |row_idx_usize| {
+        if (constrained_mask[row_idx_usize]) continue;
+
+        const reduced_row = reduced_index[row_idx_usize];
+        const row = full_matrix.row(@intCast(row_idx_usize));
+        for (row.cols, row.vals) |col_idx, value| {
+            if (constrained_mask[col_idx]) {
+                try boundary_triplets.addEntry(allocator, reduced_row, col_idx, value);
+            } else {
+                try triplets.addEntry(allocator, reduced_row, reduced_index[col_idx], value);
+            }
+        }
+    }
+
+    var reduced_matrix = try triplets.build(allocator);
+    errdefer reduced_matrix.deinit(allocator);
+
+    var boundary_coupling = try boundary_triplets.build(allocator);
+    errdefer boundary_coupling.deinit(allocator);
+
+    return .{
+        .boundary_coupling = boundary_coupling,
+        .reduced_system = try AssembledImplicitSystem.init(allocator, reduced_matrix, config),
+    };
+}
+
+fn scatterSolution(
+    self: *DirichletConstrainedSystem,
+    boundary_values: []const f64,
+    full_solution: []f64,
+) void {
+    const system = &(self.reduced_system orelse unreachable);
+    for (self.constrained_mask, 0..) |is_constrained, idx| {
+        full_solution[idx] = if (is_constrained)
+            boundary_values[idx]
+        else
+            system.solutionValues()[self.reduced_index[idx]];
+    }
+}
 
 fn diagonalOf(allocator: std.mem.Allocator, matrix: sparse.CsrMatrix(f64)) ![]f64 {
     const diagonal = try allocator.alloc(f64, matrix.n_rows);
@@ -200,6 +354,7 @@ test "Dirichlet constrained system scatters boundary values and corrects reduced
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 7);
+    defer matrix.deinit(allocator);
     matrix.row_ptr[0] = 0;
     matrix.row_ptr[1] = 2;
     matrix.row_ptr[2] = 5;
@@ -245,6 +400,7 @@ test "Dirichlet constrained system reuses full rhs buffer and seeds from full st
     const allocator = testing.allocator;
 
     var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 3);
+    defer matrix.deinit(allocator);
     matrix.row_ptr[0] = 0;
     matrix.row_ptr[1] = 1;
     matrix.row_ptr[2] = 2;

--- a/src/operators/implicit_system.zig
+++ b/src/operators/implicit_system.zig
@@ -86,6 +86,58 @@ pub const AssembledImplicitSystem = struct {
     }
 };
 
+pub const DirichletConstrainedSystem = struct {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        full_matrix: sparse.CsrMatrix(f64),
+        constrained_mask: []const bool,
+        config: SolveConfig,
+    ) !DirichletConstrainedSystem {
+        _ = allocator;
+        _ = full_matrix;
+        _ = constrained_mask;
+        _ = config;
+        @panic("not yet implemented");
+    }
+
+    pub fn deinit(self: *DirichletConstrainedSystem, allocator: std.mem.Allocator) void {
+        _ = self;
+        _ = allocator;
+        @panic("not yet implemented");
+    }
+
+    pub fn fullRhsValues(self: *DirichletConstrainedSystem) []f64 {
+        _ = self;
+        @panic("not yet implemented");
+    }
+
+    pub fn seedSolutionFromFull(self: *DirichletConstrainedSystem, full_values: []const f64) void {
+        _ = self;
+        _ = full_values;
+        @panic("not yet implemented");
+    }
+
+    pub fn solveDirichlet(
+        self: *DirichletConstrainedSystem,
+        boundary_values: []const f64,
+        full_solution: []f64,
+    ) !cg.SolveResult {
+        _ = self;
+        _ = boundary_values;
+        _ = full_solution;
+        @panic("not yet implemented");
+    }
+
+    pub fn solveHomogeneousDirichlet(
+        self: *DirichletConstrainedSystem,
+        full_solution: []f64,
+    ) !cg.SolveResult {
+        _ = self;
+        _ = full_solution;
+        @panic("not yet implemented");
+    }
+};
+
 fn diagonalOf(allocator: std.mem.Allocator, matrix: sparse.CsrMatrix(f64)) ![]f64 {
     const diagonal = try allocator.alloc(f64, matrix.n_rows);
     errdefer allocator.free(diagonal);
@@ -142,6 +194,89 @@ test "assembled implicit system computes matrix diagonal and reuses owned buffer
     try testing.expect(second_result.converged);
     try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[0], 1e-12);
     try testing.expectApproxEqAbs(@as(f64, 1.0), system.solutionValues()[1], 1e-12);
+}
+
+test "Dirichlet constrained system scatters boundary values and corrects reduced rhs" {
+    const allocator = testing.allocator;
+
+    var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 7);
+    matrix.row_ptr[0] = 0;
+    matrix.row_ptr[1] = 2;
+    matrix.row_ptr[2] = 5;
+    matrix.row_ptr[3] = 7;
+    matrix.col_idx[0] = 0;
+    matrix.col_idx[1] = 1;
+    matrix.col_idx[2] = 0;
+    matrix.col_idx[3] = 1;
+    matrix.col_idx[4] = 2;
+    matrix.col_idx[5] = 1;
+    matrix.col_idx[6] = 2;
+    matrix.values[0] = 2.0;
+    matrix.values[1] = -1.0;
+    matrix.values[2] = -1.0;
+    matrix.values[3] = 2.0;
+    matrix.values[4] = -1.0;
+    matrix.values[5] = -1.0;
+    matrix.values[6] = 2.0;
+
+    var system = try DirichletConstrainedSystem.init(
+        allocator,
+        matrix,
+        &[_]bool{ true, false, true },
+        .{},
+    );
+    defer system.deinit(allocator);
+
+    system.fullRhsValues()[0] = 0.0;
+    system.fullRhsValues()[1] = 0.0;
+    system.fullRhsValues()[2] = 0.0;
+
+    const boundary_values = [_]f64{ 10.0, 0.0, 20.0 };
+    var solution = [_]f64{ 0.0, 0.0, 0.0 };
+
+    const result = try system.solveDirichlet(&boundary_values, &solution);
+    try testing.expect(result.converged);
+    try testing.expectApproxEqAbs(@as(f64, 10.0), solution[0], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 15.0), solution[1], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 20.0), solution[2], 1e-12);
+}
+
+test "Dirichlet constrained system reuses full rhs buffer and seeds from full state" {
+    const allocator = testing.allocator;
+
+    var matrix = try sparse.CsrMatrix(f64).init(allocator, 3, 3, 3);
+    matrix.row_ptr[0] = 0;
+    matrix.row_ptr[1] = 1;
+    matrix.row_ptr[2] = 2;
+    matrix.row_ptr[3] = 3;
+    matrix.col_idx[0] = 0;
+    matrix.col_idx[1] = 1;
+    matrix.col_idx[2] = 2;
+    matrix.values[0] = 4.0;
+    matrix.values[1] = 5.0;
+    matrix.values[2] = 6.0;
+
+    var system = try DirichletConstrainedSystem.init(
+        allocator,
+        matrix,
+        &[_]bool{ true, false, false },
+        .{},
+    );
+    defer system.deinit(allocator);
+
+    const rhs_ptr = system.fullRhsValues().ptr;
+    system.seedSolutionFromFull(&[_]f64{ 100.0, 10.0, 18.0 });
+    system.fullRhsValues()[0] = 0.0;
+    system.fullRhsValues()[1] = 10.0;
+    system.fullRhsValues()[2] = 18.0;
+
+    var solution = [_]f64{ 0.0, 0.0, 0.0 };
+    const result = try system.solveHomogeneousDirichlet(&solution);
+    try testing.expect(result.converged);
+    try testing.expect(rhs_ptr == system.fullRhsValues().ptr);
+    try testing.expectApproxEqAbs(@as(f64, 0.0), solution[0], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 2.0), solution[1], 1e-12);
+    try testing.expectApproxEqAbs(@as(f64, 3.0), solution[2], 1e-12);
 }
 
 test {

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -110,73 +110,21 @@ fn solve_dirichlet_reduced_system(
     std.debug.assert(boundary_mask.len == full_matrix.n_rows);
     std.debug.assert(boundary_values.len == full_matrix.n_rows);
 
-    const reduced_index = try allocator.alloc(u32, full_matrix.n_rows);
-    defer allocator.free(reduced_index);
-    @memset(reduced_index, std.math.maxInt(u32));
-
-    var free_count: u32 = 0;
-    for (boundary_mask, 0..) |is_boundary, cell_idx_usize| {
-        if (is_boundary) continue;
-        reduced_index[cell_idx_usize] = free_count;
-        free_count += 1;
-    }
-
-    if (free_count == 0) {
-        const solution = try allocator.dupe(f64, boundary_values);
-        return .{
-            .solution = solution,
-            .cg_result = .{ .iterations = 0, .relative_residual = 0.0, .converged = true },
-        };
-    }
-
-    var triplets = sparse.TripletAssembler(f64).init(free_count, free_count);
-    defer triplets.deinit(allocator);
-
-    const reduced_rhs = try allocator.alloc(f64, free_count);
-    defer allocator.free(reduced_rhs);
-    @memset(reduced_rhs, 0.0);
-
-    for (0..full_matrix.n_rows) |row_idx_usize| {
-        if (boundary_mask[row_idx_usize]) continue;
-
-        const row_idx: u32 = @intCast(row_idx_usize);
-        const reduced_row = reduced_index[row_idx_usize];
-        var rhs_value = full_rhs[row_idx_usize];
-        const row = full_matrix.row(row_idx);
-        for (row.cols, row.vals) |col_idx, value| {
-            if (boundary_mask[col_idx]) {
-                rhs_value -= value * boundary_values[col_idx];
-            } else {
-                try triplets.addEntry(allocator, reduced_row, reduced_index[col_idx], value);
-            }
-        }
-        reduced_rhs[reduced_row] = rhs_value;
-    }
-
-    const reduced_matrix = try triplets.build(allocator);
-
-    var implicit_system = try implicit_system_mod.AssembledImplicitSystem.init(
+    var constrained_system = try implicit_system_mod.DirichletConstrainedSystem.init(
         allocator,
-        reduced_matrix,
+        full_matrix,
+        boundary_mask,
         .{
             .tolerance_relative = config.tolerance_relative,
             .iteration_limit = config.iteration_limit,
         },
     );
-    defer implicit_system.deinit(allocator);
-
-    @memcpy(implicit_system.rhsValues(), reduced_rhs);
-    const cg_result = try implicit_system.solve();
-    const reduced_solution = implicit_system.solutionValues();
+    defer constrained_system.deinit(allocator);
 
     const solution = try allocator.alloc(f64, full_matrix.n_rows);
     errdefer allocator.free(solution);
-    for (boundary_mask, 0..) |is_boundary, cell_idx_usize| {
-        solution[cell_idx_usize] = if (is_boundary)
-            boundary_values[cell_idx_usize]
-        else
-            reduced_solution[reduced_index[cell_idx_usize]];
-    }
+    @memcpy(constrained_system.fullRhsValues(), full_rhs);
+    const cg_result = try constrained_system.solveDirichlet(boundary_values, solution);
 
     return .{
         .solution = solution,

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -12,8 +12,8 @@ const topology = @import("../topology/mesh.zig");
 const obj = @import("../io/obj.zig");
 const sparse = @import("../math/sparse.zig");
 const conjugate_gradient = @import("../math/cg.zig");
+const linear_system = @import("../math/linear_system.zig");
 const operator_context_mod = @import("context.zig");
-const implicit_system_mod = @import("implicit_system.zig");
 
 comptime {
     @setEvalBranchQuota(20000);
@@ -110,10 +110,11 @@ fn solve_dirichlet_reduced_system(
     std.debug.assert(boundary_mask.len == full_matrix.n_rows);
     std.debug.assert(boundary_values.len == full_matrix.n_rows);
 
-    var constrained_system = try implicit_system_mod.DirichletConstrainedSystem.init(
+    const elimination_map = try linear_system.EliminationMap.init(allocator, boundary_mask);
+    var constrained_system = try linear_system.EliminatedLinearSystem.init(
         allocator,
         full_matrix,
-        boundary_mask,
+        elimination_map,
         .{
             .tolerance_relative = config.tolerance_relative,
             .iteration_limit = config.iteration_limit,
@@ -124,7 +125,7 @@ fn solve_dirichlet_reduced_system(
     const solution = try allocator.alloc(f64, full_matrix.n_rows);
     errdefer allocator.free(solution);
     @memcpy(constrained_system.fullRhsValues(), full_rhs);
-    const cg_result = try constrained_system.solveDirichlet(boundary_values, solution);
+    const cg_result = try constrained_system.solveWithConstrainedValues(boundary_values, solution);
 
     return .{
         .solution = solution,

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -111,21 +111,16 @@ fn solve_dirichlet_reduced_system(
     std.debug.assert(boundary_values.len == full_matrix.n_rows);
 
     const elimination_map = try linear_system.EliminationMap.init(allocator, boundary_mask);
-    var constrained_system = try linear_system.EliminatedLinearSystem.init(
-        allocator,
-        full_matrix,
-        elimination_map,
-        .{
-            .tolerance_relative = config.tolerance_relative,
-            .iteration_limit = config.iteration_limit,
-        },
-    );
-    defer constrained_system.deinit(allocator);
+    var reduced_system = try linear_system.LinearSystem.eliminate(allocator, full_matrix, elimination_map, .{
+        .tolerance_relative = config.tolerance_relative,
+        .iteration_limit = config.iteration_limit,
+    });
+    defer reduced_system.deinit(allocator);
 
     const solution = try allocator.alloc(f64, full_matrix.n_rows);
     errdefer allocator.free(solution);
-    @memcpy(constrained_system.fullRhsValues(), full_rhs);
-    const cg_result = try constrained_system.solveWithConstrainedValues(boundary_values, solution);
+    @memcpy(reduced_system.fullRhsValues(), full_rhs);
+    const cg_result = try reduced_system.solveWithConstrainedValues(boundary_values, solution);
 
     return .{
         .solution = solution,

--- a/src/root.zig
+++ b/src/root.zig
@@ -59,6 +59,7 @@ pub const io = @import("io/root.zig");
 pub const math = struct {
     pub const sparse = @import("math/sparse.zig");
     pub const cg = @import("math/cg.zig");
+    pub const linear_system = @import("math/linear_system.zig");
 };
 pub const operators = struct {
     pub const boundary_conditions = @import("operators/boundary_conditions.zig");
@@ -67,7 +68,6 @@ pub const operators = struct {
     pub const context = @import("operators/context.zig");
     pub const exterior_derivative = @import("operators/exterior_derivative.zig");
     pub const hodge_star = @import("operators/hodge_star.zig");
-    pub const implicit_system = @import("operators/implicit_system.zig");
     pub const laplacian = @import("operators/laplacian.zig");
     pub const observers = @import("operators/observers.zig");
     pub const poisson = @import("operators/poisson.zig");


### PR DESCRIPTION
Closes #182

## What

Replace the policy-shaped constrained-solve API with structural linear-algebra concepts in `flux.math.linear_system`:
- `LinearSystem`
- `EliminationMap`
- `EliminatedLinearSystem`

This keeps the reusable solve runtime in `math`, treats boundary constraints as one application of elimination rather than the public abstraction itself, and removes plane diffusion's manual reduced-system bookkeeping.

## Acceptance criterion

A caller can assemble and solve a constrained implicit system through a reusable library abstraction without manually building boundary masks or reduced index maps in the example layer.

Concrete proof points:
- [x] the plane diffusion example deletes its manual reduced-system orchestration
- [x] constrained solve bookkeeping lives in the library rather than in the example
- [x] existing diffusion tests and acceptance checks pass unchanged

## Tasks

- [x] Write tests for constrained implicit solve bookkeeping
- [x] Design public API and ownership boundary
- [x] Implement library constrained-solve path and migrate plane diffusion
- [x] CI green

## Decisions

- Logged the abstraction shift in `project/epoch_2/decision_log.md`: linear-system runtimes and elimination maps are structural math concepts, not policy-shaped operator types.
- Updated `AGENTS.md` and `.agents/skills/tackle/SKILL.md` so future abstraction work is explicitly pressure-tested against `vision.md` and `horizons.md` instead of overfitting to issue-local symptoms.

## Limitations

- `EliminationMap` currently models elimination-style constraints; richer non-elimination constraint families remain future work.
- Exact/reference convergence contracts are still left to `#185`.
