### PR TITLE
Introduce reference evolution verification contract

### DIFF
--- a/examples/acceptance.zig
+++ b/examples/acceptance.zig
@@ -111,13 +111,16 @@ test "M3 acceptance: heat equation reaches expected spatial convergence rate" {
     const grids = [_]u32{ 8, 16 };
     const results = try diffusion.runConvergenceStudy(.plane, allocator, &grids);
     defer allocator.free(results);
+    const errors = [_]f64{ results[0].l2_error, results[1].l2_error };
+    const rates = try flux.integrators.evolution.empiricalRates(allocator, &errors, 2.0);
+    defer allocator.free(rates);
 
     try testing.expectEqual(grids.len, results.len);
-    const rate = std.math.log(f64, 2.0, results[0].l2_error / results[1].l2_error);
+    try testing.expectEqual(@as(usize, 1), rates.len);
     // Backward-Euler heat solve is second order in space; require ≥ 1.75 to
     // accept asymptotic noise on the small-grid pair while still failing if
     // the operator stack regresses to first order.
-    try testing.expect(rate > 1.75);
+    try testing.expect(rates[0] > 1.75);
 }
 
 test "M3 acceptance: diffusion-surface solution matches the analytic eigenmode under refinement" {

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -157,15 +157,15 @@ fn simulateCase(
         .heat_system = &heat_system,
     };
     const stepper = try stepper_builder.initStepper(allocator, state.values);
-    const aux = try HeatEvolutionAux.init(
+    const aux = try HeatReferenceAux.init(
         allocator,
         &mesh,
+        state.values.len,
         HeatExactInitializer{ .initial_condition = initial_condition },
         HeatErrorMeasure{},
-        state.values.len,
     );
 
-    const Evolution = evolution_mod.Evolution([]f64, HeatStepper, HeatEvolutionAux);
+    const Evolution = evolution_mod.Evolution([]f64, HeatStepper, HeatReferenceAux);
     var evolution = Evolution.init(
         allocator,
         state.values,
@@ -262,44 +262,7 @@ const HeatExactInitializer = struct {
         initializeState(mesh, values, self.initial_condition, time);
     }
 };
-
-const HeatEvolutionAux = struct {
-    mesh: *const Mesh2D,
-    exact_values: []f64,
-    exact_initializer: HeatExactInitializer,
-    error_measure: HeatErrorMeasure,
-
-    pub fn init(
-        allocator: std.mem.Allocator,
-        mesh: *const Mesh2D,
-        exact_initializer: HeatExactInitializer,
-        error_measure: HeatErrorMeasure,
-        len: usize,
-    ) !@This() {
-        return .{
-            .mesh = mesh,
-            .exact_values = try allocator.alloc(f64, len),
-            .exact_initializer = exact_initializer,
-            .error_measure = error_measure,
-        };
-    }
-
-    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-        allocator.free(self.exact_values);
-    }
-
-    pub fn fillExact(self: *@This(), time: f64) void {
-        self.exact_initializer.fill(self.mesh, self.exact_values, time);
-    }
-
-    pub fn exactValues(self: *@This()) []f64 {
-        return self.exact_values;
-    }
-
-    pub fn l2Error(self: *const @This(), state_values: []const f64) f64 {
-        return self.error_measure.compute(self.mesh, state_values, self.exact_values);
-    }
-};
+const HeatReferenceAux = evolution_mod.ReferenceAux(Mesh2D, HeatExactInitializer, HeatErrorMeasure);
 
 fn stepBackwardEuler(
     allocator: std.mem.Allocator,

--- a/examples/diffusion/sphere.zig
+++ b/examples/diffusion/sphere.zig
@@ -143,15 +143,15 @@ fn simulateCase(
 
     const stepper_builder = SurfaceStepperBuilder{ .system = &system };
     const stepper = try stepper_builder.initStepper(allocator, state.values);
-    const aux = try SurfaceEvolutionAux.init(
+    const aux = try SurfaceReferenceAux.init(
         allocator,
         &mesh,
+        state.values.len,
         ExactInitializer{},
         SurfaceErrorMeasure{},
-        state.values.len,
     );
 
-    const Evolution = evolution_mod.Evolution([]f64, SurfaceStepper, SurfaceEvolutionAux);
+    const Evolution = evolution_mod.Evolution([]f64, SurfaceStepper, SurfaceReferenceAux);
     var evolution = Evolution.init(
         allocator,
         state.values,
@@ -255,44 +255,7 @@ const SurfaceErrorMeasure = struct {
         return weightedL2Error(mesh, approx, exact);
     }
 };
-
-const SurfaceEvolutionAux = struct {
-    mesh: *const SurfaceMesh,
-    exact_values: []f64,
-    exact_initializer: ExactInitializer,
-    error_measure: SurfaceErrorMeasure,
-
-    pub fn init(
-        allocator: std.mem.Allocator,
-        mesh: *const SurfaceMesh,
-        exact_initializer: ExactInitializer,
-        error_measure: SurfaceErrorMeasure,
-        len: usize,
-    ) !@This() {
-        return .{
-            .mesh = mesh,
-            .exact_values = try allocator.alloc(f64, len),
-            .exact_initializer = exact_initializer,
-            .error_measure = error_measure,
-        };
-    }
-
-    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-        allocator.free(self.exact_values);
-    }
-
-    pub fn fillExact(self: *@This(), time: f64) void {
-        self.exact_initializer.fill(self.mesh, self.exact_values, time);
-    }
-
-    pub fn exactValues(self: *@This()) []f64 {
-        return self.exact_values;
-    }
-
-    pub fn l2Error(self: *const @This(), state_values: []const f64) f64 {
-        return self.error_measure.compute(self.mesh, state_values, self.exact_values);
-    }
-};
+const SurfaceReferenceAux = evolution_mod.ReferenceAux(SurfaceMesh, ExactInitializer, SurfaceErrorMeasure);
 
 fn assembleLumpedSurfaceMasses(
     allocator: std.mem.Allocator,

--- a/examples/diffusion/tests.zig
+++ b/examples/diffusion/tests.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const testing = std.testing;
+const flux = @import("flux");
 const diffusion = @import("root.zig");
 
 test "surface diffusion error decreases under sphere refinement" {
@@ -20,10 +21,16 @@ test "heat convergence study reaches second-order spatial rate" {
     const grids = [_]u32{ 8, 16, 32 };
     const results = try diffusion.runConvergenceStudy(.plane, allocator, &grids);
     defer allocator.free(results);
+    var errors = [_]f64{0} ** grids.len;
+    for (results, 0..) |result, idx| {
+        errors[idx] = result.l2_error;
+    }
+    const rates = try flux.integrators.evolution.empiricalRates(allocator, &errors, 2.0);
+    defer allocator.free(rates);
 
     try testing.expectEqual(grids.len, results.len);
-    for (0..results.len - 1) |idx| {
-        const rate = std.math.log(f64, 2.0, results[idx].l2_error / results[idx + 1].l2_error);
+    try testing.expectEqual(results.len - 1, rates.len);
+    for (rates) |rate| {
         try testing.expect(rate > 1.75);
     }
 }

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -244,6 +244,35 @@ data model and with the project's "one obvious way" rule. The topology layer
 now owns canonical sphere construction, examples and benches reuse it directly,
 and future geometries remain tracked under the broader constructor issue.
 
+## 2026-04-12: Reference-evolution verification reuses one auxiliary contract
+
+**Decision:** Keep exact/reference verification support as a generic helper
+inside `src/integrators/evolution.zig`: `ReferenceAux(mesh, initializer,
+error_measure)` owns the exact buffer and delegates exact-field filling and
+error evaluation, while a small `empiricalRates(...)` helper reports pairwise
+convergence rates. Example families provide the analytic solution and norm; the
+library owns the orchestration contract.
+
+**Alternatives considered:**
+1. Leave each example family to define its own `*EvolutionAux` struct:
+   rejected because plane and sphere diffusion were already duplicating the
+   same ownership and method shape, and future examples would repeat it again.
+2. Introduce a new top-level `verification` or `testing` module immediately:
+   rejected for now because the reusable concept is still tightly coupled to
+   `Evolution`'s auxiliary contract. A separate module would add one more noun
+   before we have more than this single integration seam.
+3. Move analytic initializers and error norms into the library: rejected
+   because those remain problem-local mathematical data, not shared framework
+   mechanics.
+
+**Rationale:** The stable structural object here is not an "analytic solution
+runner" or an example-specific helper. It is auxiliary state attached to an
+evolution that knows how to materialize reference values and compare the
+current state against them. Keeping that contract next to `Evolution` makes the
+ownership model obvious, removes duplicated example-local buffer management,
+and stays compatible with future problem families that use different exact
+solutions or norms but the same orchestration.
+
 **Rationale:** The real question in issue #48 is empirical: does smaller
 incidence storage make boundary-operator application faster on large meshes?
 Separating the storage experiment from mesh/operator integration keeps the API

--- a/src/integrators/evolution.zig
+++ b/src/integrators/evolution.zig
@@ -355,6 +355,37 @@ test "Evolution computes error against the current exact field" {
     try testing.expectApproxEqAbs(2.0, evolution.l2Error(), 1e-15);
 }
 
+test "ReferenceAux owns exact buffer and computes error generically" {
+    const allocator = testing.allocator;
+    var mesh = MockMesh{};
+    var state = [_]f64{ 1.0, 2.0 };
+
+    const Aux = ReferenceAux(MockMesh, MockExactInitializer, MockErrorMeasure);
+    var aux = try Aux.init(
+        allocator,
+        &mesh,
+        state.len,
+        MockExactInitializer{},
+        MockErrorMeasure{},
+    );
+    defer aux.deinit(allocator);
+
+    aux.fillExact(0.0);
+    try testing.expectEqual(state.len, aux.exactValues().len);
+    try testing.expectApproxEqAbs(2.0, aux.l2Error(state[0..]), 1e-15);
+}
+
+test "empiricalRates returns pairwise convergence rates" {
+    const allocator = testing.allocator;
+    const errors = [_]f64{ 4.0, 1.0, 0.25 };
+    const rates = try empiricalRates(allocator, &errors, 2.0);
+    defer allocator.free(rates);
+
+    try testing.expectEqual(@as(usize, 2), rates.len);
+    try testing.expectApproxEqAbs(2.0, rates[0], 1e-12);
+    try testing.expectApproxEqAbs(2.0, rates[1], 1e-12);
+}
+
 test "Evolution run notifies listeners at begin, each step, and end" {
     const TestEvolution = Evolution([]f64, MockStepper, void);
     const allocator = testing.allocator;

--- a/src/integrators/evolution.zig
+++ b/src/integrators/evolution.zig
@@ -51,6 +51,75 @@ fn invokeListeners(
     }
 }
 
+pub fn ReferenceAux(
+    comptime MeshType: type,
+    comptime InitializerType: type,
+    comptime ErrorMeasureType: type,
+) type {
+    return struct {
+        mesh: *const MeshType,
+        exact_values: []f64,
+        initializer: InitializerType,
+        error_measure: ErrorMeasureType,
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            mesh: *const MeshType,
+            len: usize,
+            initializer: InitializerType,
+            error_measure: ErrorMeasureType,
+        ) !@This() {
+            return .{
+                .mesh = mesh,
+                .exact_values = try allocator.alloc(f64, len),
+                .initializer = initializer,
+                .error_measure = error_measure,
+            };
+        }
+
+        pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+            allocator.free(self.exact_values);
+        }
+
+        pub fn fillExact(self: *@This(), time: f64) void {
+            self.initializer.fill(self.mesh, self.exact_values, time);
+        }
+
+        pub fn exactValues(self: *@This()) []f64 {
+            return self.exact_values;
+        }
+
+        pub fn l2Error(self: *const @This(), state_values: []const f64) f64 {
+            return self.error_measure.compute(self.mesh, state_values, self.exact_values);
+        }
+    };
+}
+
+pub fn empiricalRates(
+    allocator: std.mem.Allocator,
+    errors: []const f64,
+    refinement_ratio: f64,
+) ![]f64 {
+    std.debug.assert(refinement_ratio > 1.0);
+
+    if (errors.len < 2) {
+        return allocator.alloc(f64, 0);
+    }
+
+    const rates = try allocator.alloc(f64, errors.len - 1);
+    errdefer allocator.free(rates);
+
+    for (0..errors.len - 1) |idx| {
+        const coarse = errors[idx];
+        const fine = errors[idx + 1];
+        std.debug.assert(coarse > 0.0);
+        std.debug.assert(fine > 0.0);
+        rates[idx] = std.math.log(f64, refinement_ratio, coarse / fine);
+    }
+
+    return rates;
+}
+
 /// Evolution object for reusable state stepping.
 ///
 /// The caller owns the primary state storage. The evolution object owns the


### PR DESCRIPTION
Closes #185

## What

Introduce a shared reference-evolution verification contract in `flux.integrators.evolution` so time-stepped verification code can reuse exact-buffer ownership and empirical-rate estimation instead of re-implementing it in each example family.

## Acceptance criterion

At least two existing verification paths can use the shared library/testing contract for exact/reference evolution, and the resulting public/testing API is smaller than the current example-local wiring.

Concrete proof points:
- [x] diffusion plane uses the shared contract
- [x] diffusion sphere uses the shared contract
- [x] existing acceptance checks pass unchanged

## Tasks

- [x] Write property/tests encoding the acceptance criterion
- [x] Design public API (stubs)
- [x] Implement
- [x] CI green

## Decisions

- Keep reference verification attached to `integrators/evolution` via `ReferenceAux(...)` instead of creating a separate top-level testing module immediately.
- Keep analytic initializers and error measures problem-local; the library owns only the orchestration contract and empirical-rate helper.

## Limitations

- This PR does not move the generic parameter-sweep utility out of `examples/common`; it focuses on the exact/reference auxiliary contract and rate estimation layer.
- The new empirical-rate helper reports pairwise rates from provided errors and refinement ratio; it does not yet package richer study metadata or reporting.
