### PR TITLE
Add canonical geometry constructors

### DIFF
--- a/bench/main.zig
+++ b/bench/main.zig
@@ -250,7 +250,7 @@ const BenchmarkContext = struct {
         }
         const cavity_mesh = try allocator.create(Mesh2D);
         errdefer allocator.destroy(cavity_mesh);
-        cavity_mesh.* = try Mesh2D.uniform_grid(allocator, cavity_grid, cavity_grid, cavity_domain, cavity_domain);
+        cavity_mesh.* = try Mesh2D.plane(allocator, cavity_grid, cavity_grid, cavity_domain, cavity_domain);
         errdefer cavity_mesh.deinit(allocator);
         var cavity_state = try MaxwellState2D.init(allocator, cavity_mesh);
         errdefer cavity_state.deinit(allocator);
@@ -1419,7 +1419,7 @@ pub fn main() !void {
     const stderr = stderrWriter();
     try stderr.print("  Building {d}x{d} mesh...\n", .{ grid_nx, grid_ny });
 
-    var mesh = try Mesh2D.uniform_grid(allocator, grid_nx, grid_ny, grid_width, grid_height);
+    var mesh = try Mesh2D.plane(allocator, grid_nx, grid_ny, grid_width, grid_height);
     defer mesh.deinit(allocator);
 
     try stderr.print("  Mesh: {d} vertices, {d} edges, {d} faces\n", .{

--- a/examples/acceptance.zig
+++ b/examples/acceptance.zig
@@ -62,7 +62,7 @@ test "M3 acceptance: Maxwell 3D enforces ∇·B = 0 to machine precision over a 
 test "M3 acceptance: Euler 2D conserves total circulation to machine precision over a short dipole run" {
     const allocator = testing.allocator;
 
-    var mesh = try euler.Mesh(2).uniform_grid(allocator, 16, 16, 1.0, 1.0);
+    var mesh = try euler.Mesh(2).plane(allocator, 16, 16, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var state = try euler.State(2).init(allocator, &mesh);

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -137,7 +137,7 @@ fn simulateCase(
     std.debug.assert(config.domain > 0.0);
     std.debug.assert(config.dt_scale > 0.0);
 
-    var mesh = try Mesh2D.uniform_grid(allocator, config.grid, config.grid, config.domain, config.domain);
+    var mesh = try Mesh2D.plane(allocator, config.grid, config.grid, config.domain, config.domain);
     defer mesh.deinit(allocator);
 
     const operator_context = try operator_context_mod.OperatorContext(Mesh2D).init(allocator, &mesh);

--- a/examples/euler/two_dimensional.zig
+++ b/examples/euler/two_dimensional.zig
@@ -100,7 +100,7 @@ pub fn runImpl(
     config: ConfigImpl,
     writer: anytype,
 ) !RunResultImpl {
-    var mesh = try Mesh.uniform_grid(allocator, config.grid, config.grid, config.domain, config.domain);
+    var mesh = try Mesh.plane(allocator, config.grid, config.grid, config.domain, config.domain);
     defer mesh.deinit(allocator);
 
     var state = try StateImpl.init(allocator, &mesh);

--- a/examples/maxwell/reference.zig
+++ b/examples/maxwell/reference.zig
@@ -60,7 +60,7 @@ pub fn run_cavity_energy_drift(allocator: std.mem.Allocator, grid_n: u32, final_
     const dt = 0.1 * (domain_length / @as(f64, @floatFromInt(grid_n)));
     const num_steps: u32 = @intFromFloat(@round(final_time / dt));
 
-    var mesh = try runtime.Mesh2D.uniform_grid(allocator, grid_n, grid_n, domain_length, domain_length);
+    var mesh = try runtime.Mesh2D.plane(allocator, grid_n, grid_n, domain_length, domain_length);
     defer mesh.deinit(allocator);
 
     var state = try runtime.MaxwellState2D.init(allocator, &mesh);
@@ -79,7 +79,7 @@ pub fn run_cavity_energy_drift(allocator: std.mem.Allocator, grid_n: u32, final_
 }
 
 pub fn compute_te10_eigenvalue(allocator: std.mem.Allocator, grid_n: u32, domain_length: f64) !f64 {
-    var mesh = try runtime.Mesh2D.uniform_grid(allocator, grid_n, grid_n, domain_length, domain_length);
+    var mesh = try runtime.Mesh2D.plane(allocator, grid_n, grid_n, domain_length, domain_length);
     defer mesh.deinit(allocator);
     const operator_context = try operator_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();

--- a/examples/maxwell/root.zig
+++ b/examples/maxwell/root.zig
@@ -88,7 +88,7 @@ fn simulate2D(allocator: std.mem.Allocator, state: *runtime.MaxwellState2D, sour
 fn run2D(allocator: std.mem.Allocator, config: Config2D, writer: anytype) !RunResult2D {
     const h = config.spacing();
     const dt = config.dt();
-    var mesh = try runtime.Mesh2D.uniform_grid(allocator, config.grid, config.grid, config.domain, config.domain);
+    var mesh = try runtime.Mesh2D.plane(allocator, config.grid, config.grid, config.domain, config.domain);
     defer mesh.deinit(allocator);
     var state = try runtime.MaxwellState2D.init(allocator, &mesh);
     defer state.deinit(allocator);
@@ -252,7 +252,7 @@ pub fn run(comptime dim: u8, allocator: std.mem.Allocator, config: Config(dim), 
 
 pub fn makeMesh(comptime dim: u8, allocator: std.mem.Allocator, config: Config(dim)) !Mesh(dim) {
     return switch (dim) {
-        2 => try runtime.Mesh2D.uniform_grid(allocator, config.grid, config.grid, config.domain, config.domain),
+        2 => try runtime.Mesh2D.plane(allocator, config.grid, config.grid, config.domain, config.domain),
         3 => try makeCavityMesh(allocator, config),
         else => unreachable,
     };

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -273,6 +273,34 @@ ownership model obvious, removes duplicated example-local buffer management,
 and stays compatible with future problem families that use different exact
 solutions or norms but the same orchestration.
 
+## 2026-04-12: Canonical geometries live under `topology.geometries` with mesh-typed entrypoints
+
+**Decision:** Add `src/topology/geometries.zig` as the canonical constructor
+layer for reusable shapes (`plane`, `disk`, `sphere`, `torus`). Keep
+mesh-typed entrypoints such as `Mesh(2, 2).disk(...)` and `Mesh(3, 2).torus(...)`
+as thin forwards into that layer, while existing `uniform_grid` and `sphere`
+continue to provide the same mesh-typed surface.
+
+**Alternatives considered:**
+1. Leave all constructors embedded directly in `Mesh` with no geometry module:
+   rejected because the issue is specifically about establishing geometry as a
+   coherent setup layer rather than accreting shape-specific methods inside one
+   large mesh file.
+2. Move entirely to free functions and remove mesh methods immediately:
+   rejected for this issue because it would create avoidable churn across
+   existing examples, docs, and tests without changing the underlying
+   abstraction.
+3. Introduce special wrapper types per geometry (`DiskMesh`, `SphereMesh`,
+   etc.): rejected because the stable noun is still "mesh"; geometry family is
+   a constructor choice, not a different topological object.
+
+**Rationale:** The geometry layer should be visible as its own concept, but the
+result is still an ordinary `Mesh(...)`. A dedicated `topology.geometries`
+namespace makes the constructor catalog explicit and reusable, while thin mesh
+forwards preserve the simplest typed entrypoint for current consumers. This
+keeps the API aligned with the project's "one obvious way" preference without
+forcing a larger constructor-surface rewrite into the same PR.
+
 **Rationale:** The real question in issue #48 is empirical: does smaller
 incidence storage make boundary-operator application faster on large meshes?
 Separating the storage experiment from mesh/operator integration keeps the API

--- a/project/horizons.md
+++ b/project/horizons.md
@@ -179,6 +179,31 @@ distinction between embedded geometry and coordinate/chart metadata.
 
 ---
 
+## Dimension-generic canonical geometry families
+
+**Layer:** architecture
+**Constraint on current work:** Today's canonical constructors may use honest
+current names such as `Mesh(2, 2).plane(...)` and `Mesh(3, 2).torus(...)`, but
+do not let those names harden into a design that blocks higher-dimensional
+families. We will likely want constructor nouns that describe the structural
+geometry family rather than one current dimension-specific instance:
+
+- rectangular / box-like product domains rather than only `plane`
+- spherical embeddings beyond the current triangulated 2-sphere
+- toroidal families beyond the current embedded surface torus
+
+The practical constraint now is to keep constructor implementation details and
+call sites easy to rename or regroup later. Avoid attaching extra semantics to
+`plane`, `sphere`, or `torus` that would make a later shift to
+`rectangular(...)`, `spherical(...)`, or `toroidal(...)` painful.
+
+**Enablers:** Stable canonical constructors, clearer support for `Mesh(n, n)`
+and `Mesh(n + 1, n)` families, and more examples that exercise geometry setup
+outside today's 2D surface cases.
+**Source:** Review note 2026-04-12
+
+---
+
 ## Schwarz-type domain decomposition
 
 **Layer:** architecture

--- a/src/forms/cochain.zig
+++ b/src/forms/cochain.zig
@@ -244,7 +244,7 @@ const Mesh2D = topology.Mesh(2, 2);
 
 test "Cochain(Mesh, 0) has one value per vertex" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 4, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 0, Primal).init(allocator, &mesh);
@@ -255,7 +255,7 @@ test "Cochain(Mesh, 0) has one value per vertex" {
 
 test "Cochain(Mesh, 1) has one value per edge" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 4, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 1, Primal).init(allocator, &mesh);
@@ -266,7 +266,7 @@ test "Cochain(Mesh, 1) has one value per edge" {
 
 test "Cochain(Mesh, 2) has one value per face" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 4, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 2, Primal).init(allocator, &mesh);
@@ -277,7 +277,7 @@ test "Cochain(Mesh, 2) has one value per face" {
 
 test "Cochain initializes to zero" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 1, Primal).init(allocator, &mesh);
@@ -331,7 +331,7 @@ test "Cochain degree bounded by mesh dimension" {
 
 test "add two 0-cochains" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var a = try Cochain(Mesh2D, 0, Primal).init(allocator, &mesh);
@@ -352,7 +352,7 @@ test "add two 0-cochains" {
 
 test "sub two 1-cochains" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var a = try Cochain(Mesh2D, 1, Primal).init(allocator, &mesh);
@@ -373,7 +373,7 @@ test "sub two 1-cochains" {
 
 test "scale a cochain" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 0, Primal).init(allocator, &mesh);
@@ -390,7 +390,7 @@ test "scale a cochain" {
 
 test "negate a cochain" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var c = try Cochain(Mesh2D, 1, Primal).init(allocator, &mesh);
@@ -407,7 +407,7 @@ test "negate a cochain" {
 
 test "inner product and norm" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     // 1×1 grid has 4 vertices
@@ -530,7 +530,7 @@ test "SIMD inner product kernel matches scalar reference for tail lengths" {
 test "add is commutative for random 0-cochains (1000 trials)" {
     // a + b = b + a for all cochains a, b.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_ADD_00);
@@ -572,7 +572,7 @@ test "add is commutative for random 0-cochains (1000 trials)" {
 test "add is associative for random 1-cochains (1000 trials)" {
     // (a + b) + c = a + (b + c) for all cochains a, b, c.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_A55_01);
@@ -620,7 +620,7 @@ test "add is associative for random 1-cochains (1000 trials)" {
 test "scale distributes over add for random cochains (1000 trials)" {
     // α(a + b) = αa + αb for all cochains a, b and scalar α.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 2.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 2, 2.0, 1.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_D15_02);
@@ -664,7 +664,7 @@ test "scale distributes over add for random cochains (1000 trials)" {
 test "negate is self-inverse for random cochains (1000 trials)" {
     // negate(negate(a)) = a for all cochains a.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_4E9_03);
@@ -694,7 +694,7 @@ test "negate is self-inverse for random cochains (1000 trials)" {
 test "inner product is symmetric for random cochains (1000 trials)" {
     // ⟨a, b⟩ = ⟨b, a⟩ for all cochains a, b.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_1F5_04);
@@ -717,7 +717,7 @@ test "inner product is symmetric for random cochains (1000 trials)" {
 test "norm_squared is non-negative for random cochains (1000 trials)" {
     // ‖a‖² ≥ 0 for all cochains a, with equality iff a = 0.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xC0C_402_05);

--- a/src/io/vtk.zig
+++ b/src/io/vtk.zig
@@ -216,7 +216,7 @@ fn writeDataArray(writer: anytype, name: []const u8, values: []const f64, num_co
 
 test "vtu output contains valid XML structure for minimal mesh" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var output = std.ArrayListUnmanaged(u8){};
@@ -245,7 +245,7 @@ test "vtu output contains valid XML structure for minimal mesh" {
 
 test "vtu vertex coordinates round-trip to machine precision" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 2, 2, 3.0, 5.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 2, 2, 3.0, 5.0);
     defer mesh.deinit(allocator);
 
     var output = std.ArrayListUnmanaged(u8){};
@@ -290,7 +290,7 @@ test "vtu vertex coordinates round-trip to machine precision" {
 
 test "vtu 0-form PointData round-trips to machine precision" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     // Create a 0-form: f(v) = x² + y at each vertex.
@@ -325,7 +325,7 @@ test "vtu 0-form PointData round-trips to machine precision" {
 
 test "vtu 2-form CellData round-trips to machine precision" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     // Create a 2-form: assign face index as value (distinct values for verification).
@@ -359,7 +359,7 @@ test "vtu 2-form CellData round-trips to machine precision" {
 
 test "vtu with both PointData and CellData" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const point_values = try allocator.alloc(f64, mesh.num_vertices());
@@ -390,7 +390,7 @@ test "vtu with both PointData and CellData" {
 
 test "vtu triangle connectivity matches mesh face vertices" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var output = std.ArrayListUnmanaged(u8){};
@@ -428,7 +428,7 @@ test "vtu triangle connectivity matches mesh face vertices" {
 
 test "vtu all cell types are triangle (type 5)" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 3, 2, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 3, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var output = std.ArrayListUnmanaged(u8){};
@@ -709,7 +709,7 @@ test "vtu 0-form PointData round-trips with random data across grid sizes" {
     };
 
     for (sizes) |size| {
-        var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, size[0], size[1], 3.0, 2.0);
+        var mesh = try topology.Mesh(2, 2).plane(allocator, size[0], size[1], 3.0, 2.0);
         defer mesh.deinit(allocator);
 
         const values = try allocator.alloc(f64, mesh.num_vertices());
@@ -743,7 +743,7 @@ test "vtu 2-form CellData round-trips with random data across grid sizes" {
     };
 
     for (sizes) |size| {
-        var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, size[0], size[1], 2.0, 1.0);
+        var mesh = try topology.Mesh(2, 2).plane(allocator, size[0], size[1], 2.0, 1.0);
         defer mesh.deinit(allocator);
 
         const values = try allocator.alloc(f64, mesh.num_faces());

--- a/src/io/vtk_fields.zig
+++ b/src/io/vtk_fields.zig
@@ -60,7 +60,7 @@ pub fn write_fields(
 
 test "project_edges_to_faces averages absolute edge values per face" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const edge_values = try allocator.alloc(f64, mesh.num_edges());
@@ -89,7 +89,7 @@ test "project_edges_to_faces averages absolute edge values per face" {
 
 test "project_edges_to_faces takes absolute values" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const edge_values = try allocator.alloc(f64, mesh.num_edges());
@@ -106,7 +106,7 @@ test "project_edges_to_faces takes absolute values" {
 
 test "write_fields produces vtu with E_intensity and B_flux CellData" {
     const allocator = testing.allocator;
-    var mesh = try topology.Mesh(2, 2).uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try topology.Mesh(2, 2).plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const e_values = try allocator.alloc(f64, mesh.num_edges());

--- a/src/math/cg.zig
+++ b/src/math/cg.zig
@@ -430,7 +430,7 @@ test "CG solves Whitney mass matrix system" {
 
     const allocator = testing.allocator;
     const Mesh2D = topology.Mesh(2, 2);
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 4, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 4, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var mass = try whitney.assemble_whitney_mass(1, allocator, &mesh);

--- a/src/operators/boundary_conditions.zig
+++ b/src/operators/boundary_conditions.zig
@@ -251,7 +251,7 @@ test "boundary condition concept accepts Dirichlet and periodic on cochains" {
 
 test "boundary selection marks boundary vertices on 2D mesh" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var selection = try BoundarySelection(Primal0_2D).initBoundary(allocator, &mesh);
@@ -287,7 +287,7 @@ test "boundary selection marks boundary edges on 3D mesh" {
 
 test "Dirichlet is idempotent on boundary vertices" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var field = try Primal0_2D.init(allocator, &mesh);
@@ -318,7 +318,7 @@ test "Dirichlet is idempotent on boundary vertices" {
 
 test "PEC is idempotent on boundary edges" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var field = try Primal1_2D.init(allocator, &mesh);
@@ -343,7 +343,7 @@ test "PEC is idempotent on boundary edges" {
 
 test "periodic averages paired boundary vertices and is idempotent" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var field = try Primal0_2D.init(allocator, &mesh);
@@ -375,7 +375,7 @@ test "periodic averages paired boundary vertices and is idempotent" {
 
 test "Dirichlet composed with exterior derivative zeros boundary-edge gradient for constant boundary data" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var field = try Primal0_2D.init(allocator, &mesh);

--- a/src/operators/compose.zig
+++ b/src/operators/compose.zig
@@ -114,7 +114,7 @@ test "compile-time: chain type deduction for ★⁻¹ ∘ d ∘ ★ (codifferent
 
 test "chain with single operator equals direct call" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC0.init(allocator, &mesh);
@@ -135,7 +135,7 @@ test "chain with single operator equals direct call" {
 
 test "codifferential δ₁ via chain matches manual ★⁻¹ ∘ d ∘ ★" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_C047);
@@ -172,7 +172,7 @@ test "δd via chain matches laplacian on 0-forms" {
     // Verify the chain produces the same result as the assembled context path.
     const context_mod = @import("context.zig");
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     const operator_context = try context_mod.OperatorContext(Mesh2D).init(allocator, &mesh);

--- a/src/operators/context.zig
+++ b/src/operators/context.zig
@@ -298,7 +298,7 @@ test "OperatorContext deinit releases assembled operator storage" {
     const allocator = gpa.allocator();
 
     {
-        var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+        var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
         defer mesh.deinit(allocator);
 
         const operator_context = try OperatorContext(Mesh2D).init(allocator, &mesh);

--- a/src/operators/exterior_derivative.zig
+++ b/src/operators/exterior_derivative.zig
@@ -161,7 +161,7 @@ const DualC3D3 = cochain.Cochain(Mesh3D, 3, cochain.Dual);
 test "d₀ of constant function is zero" {
     // A constant 0-form has zero gradient everywhere.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try C0.init(allocator, &mesh);
@@ -182,7 +182,7 @@ test "d₀ on linear function f(x,y) = x" {
     const allocator = testing.allocator;
     const nx: u32 = 3;
     const ny: u32 = 2;
-    var mesh = try Mesh2D.uniform_grid(allocator, nx, ny, 3.0, 2.0);
+    var mesh = try Mesh2D.plane(allocator, nx, ny, 3.0, 2.0);
     defer mesh.deinit(allocator);
 
     var omega = try C0.init(allocator, &mesh);
@@ -208,7 +208,7 @@ test "d₀ on linear function f(x,y) = x" {
 test "d₁ of d₀ is zero on a specific function" {
     // dd = 0: applying d₁ after d₀ to any 0-form yields the zero 2-form.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var omega = try C0.init(allocator, &mesh);
@@ -236,7 +236,7 @@ test "dd = 0 for random 0-forms on triangular mesh (1000 trials)" {
     // This is the cohomological identity — it must hold exactly because
     // boundary₂ · boundary₁ = 0 as integer matrices.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_DD_00);
@@ -270,7 +270,7 @@ test "dd = 0 for random 1-forms on triangular mesh (1000 trials)" {
     // 1-form (one that is d₀ of something) yields zero — which is the
     // same dd=0 identity tested from the 1-form side.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 6, 5, 3.0, 2.0);
+    var mesh = try Mesh2D.plane(allocator, 6, 5, 3.0, 2.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_DD_01);
@@ -464,7 +464,7 @@ test "d̃₀ on constant dual 0-form is zero at interior edges" {
     // two faces with opposite signs). Boundary edges have only one
     // adjacent face, so d̃₀ is nonzero there — this is expected.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try DualC0.init(allocator, &mesh);
@@ -505,7 +505,7 @@ test "d̃d̃ = 0 for random dual 0-forms (1000 trials)" {
     // d̃₁(d̃₀(ω)) = boundary(1)ᵀ · boundary(2)ᵀ · ω = (boundary(2) · boundary(1))ᵀ · ω = 0
     // because ∂∂ = 0.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_DD_D0);

--- a/src/operators/hodge_star.zig
+++ b/src/operators/hodge_star.zig
@@ -669,7 +669,7 @@ test "compile-time: ★⁻¹ maps 3D dual k-forms back to primal (3-k)-forms" {
 
 test "★₀ scales by dual vertex area" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC0.init(allocator, &mesh);
@@ -689,7 +689,7 @@ test "★₁ applies Whitney mass matrix (not diagonal)" {
     // The Whitney mass matrix is not diagonal — ★₁ applied to a unit
     // 1-form should differ from the diagonal dual_length/length scaling.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC1.init(allocator, &mesh);
@@ -712,7 +712,7 @@ test "★₁ applies Whitney mass matrix (not diagonal)" {
 
 test "★₂ scales by 1 / face area" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 2.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 2, 2.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC2.init(allocator, &mesh);
@@ -730,7 +730,7 @@ test "★₂ scales by 1 / face area" {
 
 test "Metric(.flat) reproduces Euclidean Hodge star exactly for all 2D degrees" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 3, 2, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     const metric = Metric(Mesh2D, .flat){};
@@ -832,7 +832,7 @@ test "Metric(.riemannian) on a constant tensor matches Euclidean star on the pul
 
 test "Metric(.riemannian) preserves ★⁻¹ ∘ ★ = id for 2D primal 1-forms" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const face_count = mesh.num_faces();
@@ -962,7 +962,7 @@ test "★⁻¹ ∘ ★ = identity for all degrees on random inputs" {
     // exact (diagonal multiply + divide). For k=1, the round-trip goes
     // through SpMV + CG solve — tolerance is set by CG convergence.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     // k=0,2: two floating-point ops → 1e-14 relative tolerance.
@@ -1067,7 +1067,7 @@ test "★★⁻¹ = id for all degrees on random 3D tetrahedral meshes" {
 
 test "★⁻¹ returns error when Whitney CG solve exhausts iteration limit" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC1.init(allocator, &mesh);

--- a/src/operators/laplacian.zig
+++ b/src/operators/laplacian.zig
@@ -243,7 +243,7 @@ const PrimalC0 = cochain.Cochain(Mesh2D, 0, cochain.Primal);
 
 test "Δ₀ of constant 0-form is zero" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -268,7 +268,7 @@ test "Δ₀ of linear function f(x,y) = x is zero at interior vertices" {
     const allocator = testing.allocator;
     const nx: u32 = 5;
     const ny: u32 = 4;
-    var mesh = try Mesh2D.uniform_grid(allocator, nx, ny, 3.0, 2.0);
+    var mesh = try Mesh2D.plane(allocator, nx, ny, 3.0, 2.0);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -296,7 +296,7 @@ test "Δ₀ of linear function f(x,y) = x is zero at interior vertices" {
 test "Δ₀ is positive-semidefinite on random 0-forms (1000 trials)" {
     // ⟨ω, Δ₀ω⟩_★₀ = ωᵀ ★₀ Δ₀ω = ωᵀ D₀ᵀ ★₁ D₀ ω = ‖D₀ω‖²_★₁ ≥ 0
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -326,7 +326,7 @@ test "Δ₀ is positive-semidefinite on random 0-forms (1000 trials)" {
 test "Δ₀ is symmetric in ★₀-weighted inner product (1000 trials)" {
     // Self-adjointness: ⟨Δ₀f, g⟩_★₀ = ⟨f, Δ₀g⟩_★₀
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -364,7 +364,7 @@ test "Δ₀ kernel is exactly the constant functions on connected mesh" {
     // On a connected mesh, the only 0-forms with Δ₀ω = 0 are constants.
     // Test: random non-constant 0-form has ‖Δ₀ω‖ > 0.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -389,7 +389,7 @@ test "Δ₀ kernel is exactly the constant functions on connected mesh" {
 
 test "assembled Δ₀ apply matches compose-on-the-fly Laplacian" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC0.init(allocator, &mesh);
@@ -418,7 +418,7 @@ test "assembled Δ₀ apply matches compose-on-the-fly Laplacian" {
 
 test "assembled Δ₀ apply is stable across repeated applications" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 6, 5, 3.0, 2.0);
+    var mesh = try Mesh2D.plane(allocator, 6, 5, 3.0, 2.0);
     defer mesh.deinit(allocator);
 
     var omega = try PrimalC0.init(allocator, &mesh);
@@ -510,7 +510,7 @@ test "Δ₁ of exact 1-form d₀f has dδ component zero" {
     // and the dδ term applied to d₀f reduces to d₀(Δ₀f). This test
     // verifies Δ₁ acts correctly on exact forms.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -532,7 +532,7 @@ test "Δ₁ is positive-semidefinite on random 1-forms (500 trials)" {
     // ⟨ω, Δ₁ω⟩_★₁ = ‖d₁ω‖²_★₂ + ‖δ₀ω‖²_★₀ ≥ 0
     // The ★₁-weighted inner product uses dual_length/length ratios.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -565,7 +565,7 @@ test "Δ₁ is symmetric in ★₁-weighted inner product (500 trials)" {
     const allocator = testing.allocator;
     const sparse_mod = @import("../math/sparse.zig");
 
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -622,7 +622,7 @@ test "Δ₂ of constant 2-form: ⟨Δ₂c, c⟩_★₂ ≥ 0" {
     // the pointwise inverse was local. With the Whitney ★₁⁻¹ (global CG
     // solve), boundary effects propagate to interior faces.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 5, 4, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 5, 4, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -648,7 +648,7 @@ test "Δ₂ is positive-semidefinite on random 2-forms (500 trials)" {
     // ⟨ω, Δ₂ω⟩_★₂ = ‖δ₁ω‖²_★₁ ≥ 0
     // The ★₂-weighted inner product uses 1/area ratios.
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
@@ -677,7 +677,7 @@ test "Δ₂ is positive-semidefinite on random 2-forms (500 trials)" {
 test "Δ₂ is symmetric in ★₂-weighted inner product (500 trials)" {
     // Self-adjointness: ⟨Δ₂f, g⟩_★₂ = ⟨f, Δ₂g⟩_★₂
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
     const operator_context = try context.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();

--- a/src/operators/observers.zig
+++ b/src/operators/observers.zig
@@ -287,7 +287,7 @@ fn selectVelocity(state: *const MockState3D) *const Primal1_3D {
 
 test "evaluateAll composes energy, L2, and max observers on a mock state" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var scalar = try Primal0_2D.init(allocator, &mesh);
@@ -332,7 +332,7 @@ test "evaluateAll composes energy, L2, and max observers on a mock state" {
 
 test "circulation observer sums an oriented loop through a 1-cochain" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var scalar = try Primal0_2D.init(allocator, &mesh);
@@ -365,7 +365,7 @@ test "circulation observer sums an oriented loop through a 1-cochain" {
 
 test "divergence norm observer vanishes on exact top-degree derivative by dd = 0" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var potential = try Primal0_2D.init(allocator, &mesh);
@@ -424,7 +424,7 @@ test "helicity observer matches manual sum of u wedge du on tetrahedral mesh" {
 
 test "divergence observer matches manual exterior-derivative norm" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var scalar = try Primal0_2D.init(allocator, &mesh);

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -289,7 +289,7 @@ test "Poisson solve converges at second order on 2D uniform grids" {
     var errors: [levels.len]f64 = undefined;
 
     for (levels, 0..) |n, level_idx| {
-        var mesh = try Mesh2D.uniform_grid(allocator, n, n, 1.0, 1.0);
+        var mesh = try Mesh2D.plane(allocator, n, n, 1.0, 1.0);
         defer mesh.deinit(allocator);
 
         var operator_context = try operator_context_mod.OperatorContext(Mesh2D).init(allocator, &mesh);

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -238,7 +238,7 @@ test "compile-time: wedge degree arithmetic yields the sum degree" {
 
 test "wedge of 0-forms is pointwise multiplication" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var alpha = try C0.init(allocator, &mesh);
@@ -263,7 +263,7 @@ test "wedge of 0-forms is pointwise multiplication" {
 
 test "wedge of 0-form and 1-form averages the endpoint values" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var scalar = try C0.init(allocator, &mesh);
@@ -358,7 +358,7 @@ test "associativity holds for random closed 1-forms on tetrahedral meshes" {
 
 test "Leibniz rule holds on random 2D 0- and 1-forms" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xA11CE_84_03);

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -623,7 +623,7 @@ const Mesh3D = topology.Mesh(3, 3);
 
 test "Whitney mass matrix is square with n_edges dimension" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var mass = try assemble_whitney_mass(1, allocator, &mesh);
@@ -635,7 +635,7 @@ test "Whitney mass matrix is square with n_edges dimension" {
 
 test "Whitney mass matrix is symmetric" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     var mass = try assemble_whitney_mass(1, allocator, &mesh);
@@ -676,7 +676,7 @@ test "Whitney mass matrix is symmetric" {
 
 test "Whitney mass matrix is positive definite (xᵀMx > 0 for random x)" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var mass = try assemble_whitney_mass(1, allocator, &mesh);
@@ -703,7 +703,7 @@ test "Whitney mass matrix is positive definite (xᵀMx > 0 for random x)" {
 
 test "Whitney mass matrix has nonzero diagonal and at least one entry per row" {
     const allocator = testing.allocator;
-    var mesh = try Mesh2D.uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     var mass = try assemble_whitney_mass(1, allocator, &mesh);

--- a/src/root.zig
+++ b/src/root.zig
@@ -12,7 +12,7 @@
 //!
 //! // Build a mesh
 //! const Mesh2D = flux.topology.Mesh(2, 2);
-//! var mesh = try Mesh2D.uniform_grid(allocator, 4, 3, 2.0, 1.5);
+//! var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
 //! const operators = try flux.operators.context.OperatorContext(Mesh2D).init(allocator, &mesh);
 //! defer operators.deinit();
 //!

--- a/src/topology/geometries.zig
+++ b/src/topology/geometries.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+pub fn plane(
+    comptime MeshType: type,
+    allocator: std.mem.Allocator,
+    nx: u32,
+    ny: u32,
+    width: f64,
+    height: f64,
+) !MeshType {
+    return MeshType.uniform_grid(allocator, nx, ny, width, height);
+}
+
+pub fn sphere(
+    comptime MeshType: type,
+    allocator: std.mem.Allocator,
+    radius: f64,
+    refinement: u32,
+) !MeshType {
+    return MeshType.sphere(allocator, radius, refinement);
+}
+
+pub fn disk(
+    comptime MeshType: type,
+    allocator: std.mem.Allocator,
+    radius: f64,
+    radial_segments: u32,
+    angular_segments: u32,
+) !MeshType {
+    _ = allocator;
+    _ = radius;
+    _ = radial_segments;
+    _ = angular_segments;
+    @panic("not yet implemented");
+}
+
+pub fn torus(
+    comptime MeshType: type,
+    allocator: std.mem.Allocator,
+    major_radius: f64,
+    minor_radius: f64,
+    major_segments: u32,
+    minor_segments: u32,
+) !MeshType {
+    _ = allocator;
+    _ = major_radius;
+    _ = minor_radius;
+    _ = major_segments;
+    _ = minor_segments;
+    @panic("not yet implemented");
+}

--- a/src/topology/geometries.zig
+++ b/src/topology/geometries.zig
@@ -27,11 +27,62 @@ pub fn disk(
     radial_segments: u32,
     angular_segments: u32,
 ) !MeshType {
-    _ = allocator;
-    _ = radius;
-    _ = radial_segments;
-    _ = angular_segments;
-    @panic("not yet implemented");
+    comptime {
+        if (MeshType.embedding_dimension != 2 or MeshType.topological_dimension != 2) {
+            @compileError("disk is only available for Mesh(2, 2)");
+        }
+    }
+    std.debug.assert(radius > 0.0);
+    std.debug.assert(radial_segments > 0);
+    std.debug.assert(angular_segments >= 3);
+
+    const vertex_count: usize = 1 + radial_segments * angular_segments;
+    const face_count: usize = angular_segments + (radial_segments - 1) * angular_segments * 2;
+
+    var vertex_coords = try std.ArrayList([MeshType.embedding_dimension]f64).initCapacity(allocator, vertex_count);
+    defer vertex_coords.deinit(allocator);
+
+    var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
+    defer face_vertices.deinit(allocator);
+
+    vertex_coords.appendAssumeCapacity(.{ 0.0, 0.0 });
+    for (1..radial_segments + 1) |ring_usize| {
+        const ring: u32 = @intCast(ring_usize);
+        const ring_radius = radius * @as(f64, @floatFromInt(ring)) / @as(f64, @floatFromInt(radial_segments));
+        for (0..angular_segments) |sector_usize| {
+            const sector: u32 = @intCast(sector_usize);
+            const theta = 2.0 * std.math.pi * @as(f64, @floatFromInt(sector)) / @as(f64, @floatFromInt(angular_segments));
+            vertex_coords.appendAssumeCapacity(.{
+                ring_radius * @cos(theta),
+                ring_radius * @sin(theta),
+            });
+        }
+    }
+
+    for (0..angular_segments) |sector_usize| {
+        const sector: u32 = @intCast(sector_usize);
+        face_vertices.appendAssumeCapacity(.{
+            0,
+            diskVertexIndex(1, sector, angular_segments),
+            diskVertexIndex(1, (sector + 1) % angular_segments, angular_segments),
+        });
+    }
+
+    for (1..radial_segments) |ring_usize| {
+        const ring: u32 = @intCast(ring_usize);
+        for (0..angular_segments) |sector_usize| {
+            const sector: u32 = @intCast(sector_usize);
+            const inner_0 = diskVertexIndex(ring, sector, angular_segments);
+            const inner_1 = diskVertexIndex(ring, (sector + 1) % angular_segments, angular_segments);
+            const outer_0 = diskVertexIndex(ring + 1, sector, angular_segments);
+            const outer_1 = diskVertexIndex(ring + 1, (sector + 1) % angular_segments, angular_segments);
+
+            face_vertices.appendAssumeCapacity(.{ inner_0, outer_0, outer_1 });
+            face_vertices.appendAssumeCapacity(.{ inner_0, outer_1, inner_1 });
+        }
+    }
+
+    return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
 }
 
 pub fn torus(
@@ -42,10 +93,70 @@ pub fn torus(
     major_segments: u32,
     minor_segments: u32,
 ) !MeshType {
-    _ = allocator;
-    _ = major_radius;
-    _ = minor_radius;
-    _ = major_segments;
-    _ = minor_segments;
-    @panic("not yet implemented");
+    comptime {
+        if (MeshType.embedding_dimension != 3 or MeshType.topological_dimension != 2) {
+            @compileError("torus is only available for Mesh(3, 2)");
+        }
+    }
+    std.debug.assert(major_radius > 0.0);
+    std.debug.assert(minor_radius > 0.0);
+    std.debug.assert(major_radius > minor_radius);
+    std.debug.assert(major_segments >= 3);
+    std.debug.assert(minor_segments >= 3);
+
+    const vertex_count: usize = major_segments * minor_segments;
+    const face_count: usize = 2 * major_segments * minor_segments;
+
+    var vertex_coords = try std.ArrayList([MeshType.embedding_dimension]f64).initCapacity(allocator, vertex_count);
+    defer vertex_coords.deinit(allocator);
+
+    var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
+    defer face_vertices.deinit(allocator);
+
+    for (0..major_segments) |major_usize| {
+        const major: u32 = @intCast(major_usize);
+        const u = 2.0 * std.math.pi * @as(f64, @floatFromInt(major)) / @as(f64, @floatFromInt(major_segments));
+        const cos_u = @cos(u);
+        const sin_u = @sin(u);
+
+        for (0..minor_segments) |minor_usize| {
+            const minor: u32 = @intCast(minor_usize);
+            const v = 2.0 * std.math.pi * @as(f64, @floatFromInt(minor)) / @as(f64, @floatFromInt(minor_segments));
+            const cos_v = @cos(v);
+            const sin_v = @sin(v);
+            const ring_radius = major_radius + minor_radius * cos_v;
+            vertex_coords.appendAssumeCapacity(.{
+                ring_radius * cos_u,
+                ring_radius * sin_u,
+                minor_radius * sin_v,
+            });
+        }
+    }
+
+    for (0..major_segments) |major_usize| {
+        const major: u32 = @intCast(major_usize);
+        const major_next = (major + 1) % major_segments;
+        for (0..minor_segments) |minor_usize| {
+            const minor: u32 = @intCast(minor_usize);
+            const minor_next = (minor + 1) % minor_segments;
+            const v00 = torusVertexIndex(major, minor, minor_segments);
+            const v10 = torusVertexIndex(major_next, minor, minor_segments);
+            const v11 = torusVertexIndex(major_next, minor_next, minor_segments);
+            const v01 = torusVertexIndex(major, minor_next, minor_segments);
+
+            face_vertices.appendAssumeCapacity(.{ v00, v10, v11 });
+            face_vertices.appendAssumeCapacity(.{ v00, v11, v01 });
+        }
+    }
+
+    return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
+}
+
+fn diskVertexIndex(ring: u32, sector: u32, angular_segments: u32) u32 {
+    std.debug.assert(ring >= 1);
+    return 1 + (ring - 1) * angular_segments + sector;
+}
+
+fn torusVertexIndex(major: u32, minor: u32, minor_segments: u32) u32 {
+    return major * minor_segments + minor;
 }

--- a/src/topology/geometries.zig
+++ b/src/topology/geometries.zig
@@ -8,7 +8,51 @@ pub fn plane(
     width: f64,
     height: f64,
 ) !MeshType {
-    return MeshType.uniform_grid(allocator, nx, ny, width, height);
+    comptime {
+        if (MeshType.embedding_dimension != 2 or MeshType.topological_dimension != 2) {
+            @compileError("plane is only available for Mesh(2, 2)");
+        }
+    }
+    std.debug.assert(nx > 0);
+    std.debug.assert(ny > 0);
+    std.debug.assert(width > 0.0);
+    std.debug.assert(height > 0.0);
+
+    const vertex_count: usize = (nx + 1) * (ny + 1);
+    const face_count: usize = 2 * nx * ny;
+    var vertex_coords = try std.ArrayList([2]f64).initCapacity(allocator, vertex_count);
+    defer vertex_coords.deinit(allocator);
+    var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
+    defer face_vertices.deinit(allocator);
+
+    const dx = width / @as(f64, @floatFromInt(nx));
+    const dy = height / @as(f64, @floatFromInt(ny));
+
+    for (0..nx + 1) |i_usize| {
+        const i: u32 = @intCast(i_usize);
+        for (0..ny + 1) |j_usize| {
+            const j: u32 = @intCast(j_usize);
+            vertex_coords.appendAssumeCapacity(.{
+                @as(f64, @floatFromInt(i)) * dx,
+                @as(f64, @floatFromInt(j)) * dy,
+            });
+        }
+    }
+
+    for (0..nx) |i_usize| {
+        const i: u32 = @intCast(i_usize);
+        for (0..ny) |j_usize| {
+            const j: u32 = @intCast(j_usize);
+            const sw = planeVertexIndex(i, j, ny);
+            const se = planeVertexIndex(i + 1, j, ny);
+            const nw = planeVertexIndex(i, j + 1, ny);
+            const ne = planeVertexIndex(i + 1, j + 1, ny);
+            face_vertices.appendAssumeCapacity(.{ sw, se, ne });
+            face_vertices.appendAssumeCapacity(.{ sw, ne, nw });
+        }
+    }
+
+    return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
 }
 
 pub fn sphere(
@@ -17,7 +61,21 @@ pub fn sphere(
     radius: f64,
     refinement: u32,
 ) !MeshType {
-    return MeshType.sphere(allocator, radius, refinement);
+    comptime {
+        if (MeshType.embedding_dimension != 3 or MeshType.topological_dimension != 2) {
+            @compileError("sphere is only available for Mesh(3, 2)");
+        }
+    }
+    std.debug.assert(radius > 0.0);
+
+    var polyhedron = try buildRefinedSphereOctahedron(allocator, radius, refinement);
+    defer polyhedron.deinit(allocator);
+
+    const oriented_faces = try allocator.dupe([3]u32, polyhedron.faces);
+    defer allocator.free(oriented_faces);
+    orientSphereFacesOutward(polyhedron.vertices, oriented_faces);
+
+    return MeshType.from_triangles(allocator, polyhedron.vertices, oriented_faces);
 }
 
 pub fn disk(
@@ -39,7 +97,7 @@ pub fn disk(
     const vertex_count: usize = 1 + radial_segments * angular_segments;
     const face_count: usize = angular_segments + (radial_segments - 1) * angular_segments * 2;
 
-    var vertex_coords = try std.ArrayList([MeshType.embedding_dimension]f64).initCapacity(allocator, vertex_count);
+    var vertex_coords = try std.ArrayList([2]f64).initCapacity(allocator, vertex_count);
     defer vertex_coords.deinit(allocator);
 
     var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
@@ -107,7 +165,7 @@ pub fn torus(
     const vertex_count: usize = major_segments * minor_segments;
     const face_count: usize = 2 * major_segments * minor_segments;
 
-    var vertex_coords = try std.ArrayList([MeshType.embedding_dimension]f64).initCapacity(allocator, vertex_count);
+    var vertex_coords = try std.ArrayList([3]f64).initCapacity(allocator, vertex_count);
     defer vertex_coords.deinit(allocator);
 
     var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
@@ -152,6 +210,10 @@ pub fn torus(
     return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
 }
 
+fn planeVertexIndex(i: u32, j: u32, ny: u32) u32 {
+    return i * (ny + 1) + j;
+}
+
 fn diskVertexIndex(ring: u32, sector: u32, angular_segments: u32) u32 {
     std.debug.assert(ring >= 1);
     return 1 + (ring - 1) * angular_segments + sector;
@@ -160,3 +222,151 @@ fn diskVertexIndex(ring: u32, sector: u32, angular_segments: u32) u32 {
 fn torusVertexIndex(major: u32, minor: u32, minor_segments: u32) u32 {
     return major * minor_segments + minor;
 }
+
+const SpherePolyhedron = struct {
+    vertices: [][3]f64,
+    faces: [][3]u32,
+
+    fn deinit(self: *SpherePolyhedron, allocator: std.mem.Allocator) void {
+        allocator.free(self.faces);
+        allocator.free(self.vertices);
+    }
+};
+
+fn buildRefinedSphereOctahedron(allocator: std.mem.Allocator, radius: f64, refinement: u32) !SpherePolyhedron {
+    var polyhedron = SpherePolyhedron{
+        .vertices = try allocator.dupe([3]f64, &initialSphereOctahedronVertices),
+        .faces = try allocator.dupe([3]u32, &initialSphereOctahedronFaces),
+    };
+    errdefer polyhedron.deinit(allocator);
+
+    scaleSphereVertices(polyhedron.vertices, radius);
+    for (0..refinement) |_| {
+        const next = try refineSpherePolyhedron(allocator, polyhedron, radius);
+        polyhedron.deinit(allocator);
+        polyhedron = next;
+    }
+    return polyhedron;
+}
+
+fn refineSpherePolyhedron(allocator: std.mem.Allocator, polyhedron: SpherePolyhedron, radius: f64) !SpherePolyhedron {
+    var vertices = try std.ArrayList([3]f64).initCapacity(allocator, polyhedron.vertices.len + polyhedron.faces.len);
+    defer vertices.deinit(allocator);
+    try vertices.appendSlice(allocator, polyhedron.vertices);
+
+    var faces = try std.ArrayList([3]u32).initCapacity(allocator, polyhedron.faces.len * 4);
+    defer faces.deinit(allocator);
+
+    var midpoint_map = std.AutoHashMap([2]u32, u32).init(allocator);
+    defer midpoint_map.deinit();
+
+    for (polyhedron.faces) |face| {
+        const ab = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[0], face[1], radius);
+        const bc = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[1], face[2], radius);
+        const ca = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[2], face[0], radius);
+
+        try faces.append(allocator, .{ face[0], ab, ca });
+        try faces.append(allocator, .{ face[1], bc, ab });
+        try faces.append(allocator, .{ face[2], ca, bc });
+        try faces.append(allocator, .{ ab, bc, ca });
+    }
+
+    return .{
+        .vertices = try vertices.toOwnedSlice(allocator),
+        .faces = try faces.toOwnedSlice(allocator),
+    };
+}
+
+fn sphereMidpointIndex(
+    allocator: std.mem.Allocator,
+    vertices: *std.ArrayList([3]f64),
+    midpoint_map: *std.AutoHashMap([2]u32, u32),
+    a: u32,
+    b: u32,
+    radius: f64,
+) !u32 {
+    const key = canonicalEdgeKey(a, b);
+    const gop = try midpoint_map.getOrPut(key);
+    if (gop.found_existing) return gop.value_ptr.*;
+
+    const midpoint = normalizeSpherePoint(scaleSpherePoint(addSpherePoints(vertices.items[a], vertices.items[b]), 0.5), radius);
+    const new_index: u32 = @intCast(vertices.items.len);
+    try vertices.append(allocator, midpoint);
+    gop.value_ptr.* = new_index;
+    return new_index;
+}
+
+fn orientSphereFacesOutward(embedded_vertices: []const [3]f64, faces: [][3]u32) void {
+    for (faces) |*face| {
+        const a = embedded_vertices[face.*[0]];
+        const b = embedded_vertices[face.*[1]];
+        const c = embedded_vertices[face.*[2]];
+        const normal = cross3(subSpherePoints(b, a), subSpherePoints(c, a));
+        const centroid = normalizeSpherePoint(scaleSpherePoint(addSpherePoints(addSpherePoints(a, b), c), 1.0 / 3.0), 1.0);
+        if (dot3(normal, centroid) < 0.0) {
+            std.mem.swap(u32, &face.*[1], &face.*[2]);
+        }
+    }
+}
+
+fn scaleSphereVertices(vertices: [][3]f64, radius: f64) void {
+    for (vertices) |*vertex| {
+        vertex.* = scaleSpherePoint(vertex.*, radius);
+    }
+}
+
+fn addSpherePoints(a: [3]f64, b: [3]f64) [3]f64 {
+    return .{ a[0] + b[0], a[1] + b[1], a[2] + b[2] };
+}
+
+fn subSpherePoints(a: [3]f64, b: [3]f64) [3]f64 {
+    return .{ a[0] - b[0], a[1] - b[1], a[2] - b[2] };
+}
+
+fn scaleSpherePoint(a: [3]f64, scale: f64) [3]f64 {
+    return .{ a[0] * scale, a[1] * scale, a[2] * scale };
+}
+
+fn dot3(a: [3]f64, b: [3]f64) f64 {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+fn norm3(a: [3]f64) f64 {
+    return @sqrt(dot3(a, a));
+}
+
+fn normalizeSpherePoint(a: [3]f64, radius: f64) [3]f64 {
+    return scaleSpherePoint(a, radius / norm3(a));
+}
+
+fn cross3(a: [3]f64, b: [3]f64) [3]f64 {
+    return .{
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    };
+}
+
+fn canonicalEdgeKey(a: u32, b: u32) [2]u32 {
+    return if (a < b) .{ a, b } else .{ b, a };
+}
+
+const initialSphereOctahedronVertices = [_][3]f64{
+    .{ 1.0, 0.0, 0.0 },
+    .{ -1.0, 0.0, 0.0 },
+    .{ 0.0, 1.0, 0.0 },
+    .{ 0.0, -1.0, 0.0 },
+    .{ 0.0, 0.0, 1.0 },
+    .{ 0.0, 0.0, -1.0 },
+};
+
+const initialSphereOctahedronFaces = [_][3]u32{
+    .{ 0, 2, 4 },
+    .{ 2, 1, 4 },
+    .{ 1, 3, 4 },
+    .{ 3, 0, 4 },
+    .{ 2, 0, 5 },
+    .{ 1, 2, 5 },
+    .{ 3, 1, 5 },
+    .{ 0, 3, 5 },
+};

--- a/src/topology/geometries.zig
+++ b/src/topology/geometries.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
+const sparse = @import("../math/sparse.zig");
 
 pub fn plane(
     comptime MeshType: type,
+    comptime Api: type,
     allocator: std.mem.Allocator,
     nx: u32,
     ny: u32,
@@ -18,41 +20,274 @@ pub fn plane(
     std.debug.assert(width > 0.0);
     std.debug.assert(height > 0.0);
 
-    const vertex_count: usize = (nx + 1) * (ny + 1);
-    const face_count: usize = 2 * nx * ny;
-    var vertex_coords = try std.ArrayList([2]f64).initCapacity(allocator, vertex_count);
-    defer vertex_coords.deinit(allocator);
-    var face_vertices = try std.ArrayList([3]u32).initCapacity(allocator, face_count);
-    defer face_vertices.deinit(allocator);
-
     const dx = width / @as(f64, @floatFromInt(nx));
     const dy = height / @as(f64, @floatFromInt(ny));
 
-    for (0..nx + 1) |i_usize| {
-        const i: u32 = @intCast(i_usize);
-        for (0..ny + 1) |j_usize| {
-            const j: u32 = @intCast(j_usize);
-            vertex_coords.appendAssumeCapacity(.{
-                @as(f64, @floatFromInt(i)) * dx,
-                @as(f64, @floatFromInt(j)) * dy,
+    const vertex_count: u32 = (nx + 1) * (ny + 1);
+    const horizontal_edge_count: u32 = nx * (ny + 1);
+    const vertical_edge_count: u32 = (nx + 1) * ny;
+    const diagonal_edge_count: u32 = nx * ny;
+    const edge_count: u32 = horizontal_edge_count + vertical_edge_count + diagonal_edge_count;
+    const face_count: u32 = 2 * nx * ny;
+
+    var vertices: Api.VerticesStorage = .{};
+    try vertices.ensureTotalCapacity(allocator, vertex_count);
+    errdefer vertices.deinit(allocator);
+
+    var edges_list: Api.EdgeStorage = .{};
+    try edges_list.ensureTotalCapacity(allocator, edge_count);
+    errdefer edges_list.deinit(allocator);
+
+    var faces_list: Api.FaceStorage = .{};
+    try faces_list.ensureTotalCapacity(allocator, face_count);
+    errdefer faces_list.deinit(allocator);
+
+    for (0..nx + 1) |i_u| {
+        const fi: f64 = @floatFromInt(i_u);
+        for (0..ny + 1) |j_u| {
+            const fj: f64 = @floatFromInt(j_u);
+            var coords: [MeshType.embedding_dimension]f64 = @splat(0);
+            coords[0] = fi * dx;
+            coords[1] = fj * dy;
+            vertices.appendAssumeCapacity(.{ .coords = coords, .dual_volume = 0 });
+        }
+    }
+
+    for (0..ny + 1) |j_u| {
+        for (0..nx) |i_u| {
+            const i: u32 = @intCast(i_u);
+            const j: u32 = @intCast(j_u);
+            edges_list.appendAssumeCapacity(.{
+                .vertices = .{ Api.vertexIndex(i, j, ny), Api.vertexIndex(i + 1, j, ny) },
+                .volume = 0,
+                .barycenter = @splat(0),
+            });
+        }
+    }
+    for (0..nx + 1) |i_u| {
+        for (0..ny) |j_u| {
+            const i: u32 = @intCast(i_u);
+            const j: u32 = @intCast(j_u);
+            edges_list.appendAssumeCapacity(.{
+                .vertices = .{ Api.vertexIndex(i, j, ny), Api.vertexIndex(i, j + 1, ny) },
+                .volume = 0,
+                .barycenter = @splat(0),
+            });
+        }
+    }
+    for (0..nx) |i_u| {
+        for (0..ny) |j_u| {
+            const i: u32 = @intCast(i_u);
+            const j: u32 = @intCast(j_u);
+            edges_list.appendAssumeCapacity(.{
+                .vertices = .{ Api.vertexIndex(i, j, ny), Api.vertexIndex(i + 1, j + 1, ny) },
+                .volume = 0,
+                .barycenter = @splat(0),
             });
         }
     }
 
-    for (0..nx) |i_usize| {
-        const i: u32 = @intCast(i_usize);
-        for (0..ny) |j_usize| {
-            const j: u32 = @intCast(j_usize);
-            const sw = planeVertexIndex(i, j, ny);
-            const se = planeVertexIndex(i + 1, j, ny);
-            const nw = planeVertexIndex(i, j + 1, ny);
-            const ne = planeVertexIndex(i + 1, j + 1, ny);
-            face_vertices.appendAssumeCapacity(.{ sw, se, ne });
-            face_vertices.appendAssumeCapacity(.{ sw, ne, nw });
+    for (0..nx) |i_u| {
+        const i: u32 = @intCast(i_u);
+        for (0..ny) |j_u| {
+            const j: u32 = @intCast(j_u);
+            const sw = Api.vertexIndex(i, j, ny);
+            const se = Api.vertexIndex(i + 1, j, ny);
+            const nw = Api.vertexIndex(i, j + 1, ny);
+            const ne = Api.vertexIndex(i + 1, j + 1, ny);
+            const zero_barycenter: [MeshType.embedding_dimension]f64 = @splat(0);
+
+            faces_list.appendAssumeCapacity(.{ .vertices = .{ sw, se, ne }, .volume = 0, .barycenter = zero_barycenter });
+            faces_list.appendAssumeCapacity(.{ .vertices = .{ sw, ne, nw }, .volume = 0, .barycenter = zero_barycenter });
         }
     }
 
-    return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
+    var boundary_1: sparse.PackedIncidenceMatrix = undefined;
+    {
+        var dense = try sparse.CsrMatrix(i8).init(allocator, edge_count, vertex_count, 2 * edge_count);
+        errdefer dense.deinit(allocator);
+        const edge_verts = edges_list.slice().items(.vertices);
+        for (0..edge_count) |edge_idx| {
+            dense.row_ptr[edge_idx] = @intCast(2 * edge_idx);
+            dense.col_idx[2 * edge_idx] = edge_verts[edge_idx][0];
+            dense.values[2 * edge_idx] = -1;
+            dense.col_idx[2 * edge_idx + 1] = edge_verts[edge_idx][1];
+            dense.values[2 * edge_idx + 1] = 1;
+        }
+        dense.row_ptr[edge_count] = 2 * edge_count;
+
+        boundary_1 = try sparse.PackedIncidenceMatrix.fromBoundaryCsr(allocator, 1, dense);
+        dense.deinit(allocator);
+    }
+    errdefer boundary_1.deinit(allocator);
+
+    var boundary_2: sparse.PackedIncidenceMatrix = undefined;
+    {
+        var dense = try sparse.CsrMatrix(i8).init(allocator, face_count, edge_count, 3 * face_count);
+        errdefer dense.deinit(allocator);
+        var face_idx: u32 = 0;
+        for (0..nx) |i_u| {
+            const i: u32 = @intCast(i_u);
+            for (0..ny) |j_u| {
+                const j: u32 = @intCast(j_u);
+                const h_ij = Api.horizontalEdgeIndex(i, j, nx);
+                const h_i_jp1 = Api.horizontalEdgeIndex(i, j + 1, nx);
+                const v_ip1_j = Api.verticalEdgeIndex(i + 1, j, ny, horizontal_edge_count);
+                const v_i_j = Api.verticalEdgeIndex(i, j, ny, horizontal_edge_count);
+                const d_ij = Api.diagonalEdgeIndex(i, j, ny, horizontal_edge_count, vertical_edge_count);
+
+                dense.row_ptr[face_idx] = 3 * face_idx;
+                dense.col_idx[3 * face_idx] = h_ij;
+                dense.values[3 * face_idx] = 1;
+                dense.col_idx[3 * face_idx + 1] = v_ip1_j;
+                dense.values[3 * face_idx + 1] = 1;
+                dense.col_idx[3 * face_idx + 2] = d_ij;
+                dense.values[3 * face_idx + 2] = -1;
+                face_idx += 1;
+
+                dense.row_ptr[face_idx] = 3 * face_idx;
+                dense.col_idx[3 * face_idx] = h_i_jp1;
+                dense.values[3 * face_idx] = -1;
+                dense.col_idx[3 * face_idx + 1] = v_i_j;
+                dense.values[3 * face_idx + 1] = -1;
+                dense.col_idx[3 * face_idx + 2] = d_ij;
+                dense.values[3 * face_idx + 2] = 1;
+                face_idx += 1;
+            }
+        }
+        dense.row_ptr[face_count] = 3 * face_count;
+
+        boundary_2 = try sparse.PackedIncidenceMatrix.fromBoundaryCsr(allocator, 2, dense);
+        dense.deinit(allocator);
+    }
+    errdefer boundary_2.deinit(allocator);
+
+    const coords = vertices.slice().items(.coords);
+
+    {
+        const edge_slice = edges_list.slice();
+        const edge_verts = edge_slice.items(.vertices);
+        const edge_volumes = edge_slice.items(.volume);
+        const edge_barycenters = edge_slice.items(.barycenter);
+        for (0..edge_count) |edge_idx| {
+            edge_volumes[edge_idx] = Api.euclideanDistance(coords[edge_verts[edge_idx][0]], coords[edge_verts[edge_idx][1]]);
+            edge_barycenters[edge_idx] = Api.pointMidpoint(coords[edge_verts[edge_idx][0]], coords[edge_verts[edge_idx][1]]);
+        }
+    }
+
+    {
+        const face_slice = faces_list.slice();
+        const face_verts = face_slice.items(.vertices);
+        const face_volumes = face_slice.items(.volume);
+        const face_barycenters = face_slice.items(.barycenter);
+        for (0..face_count) |face_idx| {
+            const p0 = coords[face_verts[face_idx][0]];
+            const p1 = coords[face_verts[face_idx][1]];
+            const p2 = coords[face_verts[face_idx][2]];
+            face_volumes[face_idx] = Api.triangleArea(p0, p1, p2);
+            face_barycenters[face_idx] = Api.triangleBarycenter(p0, p1, p2);
+        }
+    }
+
+    const dual_edge_volumes = try allocator.alloc(f64, edge_count);
+    errdefer allocator.free(dual_edge_volumes);
+    var boundary_edges: []u32 = &.{};
+    {
+        const scratch = try allocator.alloc(u32, 3 * edge_count);
+        defer allocator.free(scratch);
+        const edge_face_count = scratch[0..edge_count];
+        const edge_face_0 = scratch[edge_count .. 2 * edge_count];
+        const edge_face_1 = scratch[2 * edge_count .. 3 * edge_count];
+        @memset(edge_face_count, 0);
+
+        for (0..face_count) |face_idx| {
+            const face_edges = boundary_2.row(@intCast(face_idx));
+            for (face_edges.cols) |edge_idx| {
+                const count = edge_face_count[edge_idx];
+                if (count == 0) {
+                    edge_face_0[edge_idx] = @intCast(face_idx);
+                } else {
+                    edge_face_1[edge_idx] = @intCast(face_idx);
+                }
+                edge_face_count[edge_idx] = count + 1;
+            }
+        }
+
+        const barycenters = faces_list.slice().items(.barycenter);
+        const edge_verts = edges_list.slice().items(.vertices);
+        var boundary_count: u32 = 0;
+        for (0..edge_count) |edge_idx| {
+            if (edge_face_count[edge_idx] == 2) {
+                dual_edge_volumes[edge_idx] = Api.euclideanDistance(barycenters[edge_face_0[edge_idx]], barycenters[edge_face_1[edge_idx]]);
+            } else if (edge_face_count[edge_idx] == 1) {
+                const midpoint = Api.pointMidpoint(coords[edge_verts[edge_idx][0]], coords[edge_verts[edge_idx][1]]);
+                dual_edge_volumes[edge_idx] = Api.euclideanDistance(barycenters[edge_face_0[edge_idx]], midpoint);
+                boundary_count += 1;
+            } else {
+                return error.NonManifoldEdge;
+            }
+        }
+
+        boundary_edges = try allocator.alloc(u32, boundary_count);
+        var boundary_write: u32 = 0;
+        for (0..edge_count) |edge_idx| {
+            if (edge_face_count[edge_idx] != 1) continue;
+            boundary_edges[boundary_write] = @intCast(edge_idx);
+            boundary_write += 1;
+        }
+        std.debug.assert(boundary_write == boundary_count);
+    }
+
+    {
+        const dual_volumes = vertices.slice().items(.dual_volume);
+        @memset(dual_volumes, 0);
+
+        const face_verts = faces_list.slice().items(.vertices);
+        for (0..face_count) |face_idx| {
+            const vs = face_verts[face_idx];
+            const p0 = coords[vs[0]];
+            const p1 = coords[vs[1]];
+            const p2 = coords[vs[2]];
+
+            const l01_sq = Api.distanceSquared(p0, p1);
+            const l12_sq = Api.distanceSquared(p1, p2);
+            const l20_sq = Api.distanceSquared(p2, p0);
+
+            const area_4 = 4.0 * Api.triangleArea(p0, p1, p2);
+            if (!(area_4 > 0.0)) return error.DegenerateTriangle;
+
+            const cot0 = (l01_sq + l20_sq - l12_sq) / area_4;
+            const cot1 = (l01_sq + l12_sq - l20_sq) / area_4;
+            const cot2 = (l12_sq + l20_sq - l01_sq) / area_4;
+
+            dual_volumes[vs[0]] += (cot1 * l20_sq + cot2 * l01_sq) / 8.0;
+            dual_volumes[vs[1]] += (cot2 * l01_sq + cot0 * l12_sq) / 8.0;
+            dual_volumes[vs[2]] += (cot0 * l12_sq + cot1 * l20_sq) / 8.0;
+        }
+    }
+
+    var mesh = MeshType{
+        .vertices = vertices,
+        .simplex_lists = .{ edges_list, faces_list },
+        .boundaries = .{ boundary_1, boundary_2 },
+        .dual_edge_volumes = dual_edge_volumes,
+        .boundary_edges = boundary_edges,
+        .whitney_operators = undefined,
+    };
+    errdefer {
+        allocator.free(mesh.boundary_edges);
+        allocator.free(mesh.dual_edge_volumes);
+        mesh.vertices.deinit(allocator);
+        inline for (0..MeshType.topological_dimension) |simplex_idx| {
+            mesh.simplex_lists[simplex_idx].deinit(allocator);
+        }
+        for (&mesh.boundaries) |*boundary| {
+            boundary.deinit(allocator);
+        }
+    }
+
+    mesh.whitney_operators = try Api.assembleWhitneyOperators(allocator, &mesh);
+    return mesh;
 }
 
 pub fn sphere(
@@ -208,10 +443,6 @@ pub fn torus(
     }
 
     return MeshType.from_triangles(allocator, vertex_coords.items, face_vertices.items);
-}
-
-fn planeVertexIndex(i: u32, j: u32, ny: u32) u32 {
-    return i * (ny + 1) + j;
 }
 
 fn diskVertexIndex(ring: u32, sector: u32, angular_segments: u32) u32 {

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -1731,6 +1731,82 @@ test "sphere constructor refinement preserves spherical geometry and Euler chara
     }
 }
 
+test "disk constructor produces a triangulated topological disk" {
+    const allocator = testing.allocator;
+    const radius = 2.0;
+    const radial_segments: u32 = 3;
+    const angular_segments: u32 = 12;
+    var mesh = try Mesh(2, 2).disk(allocator, radius, radial_segments, angular_segments);
+    defer mesh.deinit(allocator);
+
+    try testing.expectEqual(@as(u32, 1) + radial_segments * angular_segments, mesh.num_vertices());
+    try testing.expectEqual(radial_segments * angular_segments * 2 - angular_segments, mesh.num_faces());
+
+    const euler_characteristic = @as(i64, mesh.num_vertices()) - @as(i64, mesh.num_edges()) + @as(i64, mesh.num_faces());
+    try testing.expectEqual(@as(i64, 1), euler_characteristic);
+
+    const coords = mesh.vertices.slice().items(.coords);
+    for (coords) |coord| {
+        const norm = @sqrt(coord[0] * coord[0] + coord[1] * coord[1]);
+        try testing.expect(norm <= radius + 1e-12);
+    }
+}
+
+test "torus constructor produces an oriented embedded torus" {
+    const allocator = testing.allocator;
+    const major_radius = 3.0;
+    const minor_radius = 1.0;
+    const major_segments: u32 = 8;
+    const minor_segments: u32 = 6;
+    var mesh = try Mesh(3, 2).torus(allocator, major_radius, minor_radius, major_segments, minor_segments);
+    defer mesh.deinit(allocator);
+
+    try testing.expectEqual(major_segments * minor_segments, mesh.num_vertices());
+    try testing.expectEqual(2 * major_segments * minor_segments, mesh.num_faces());
+
+    const euler_characteristic = @as(i64, mesh.num_vertices()) - @as(i64, mesh.num_edges()) + @as(i64, mesh.num_faces());
+    try testing.expectEqual(@as(i64, 0), euler_characteristic);
+
+    const coords = mesh.vertices.slice().items(.coords);
+    for (coords) |coord| {
+        const radial_xy = @sqrt(coord[0] * coord[0] + coord[1] * coord[1]);
+        const tube_radius = @sqrt((radial_xy - major_radius) * (radial_xy - major_radius) + coord[2] * coord[2]);
+        try testing.expectApproxEqAbs(minor_radius, tube_radius, 1e-12);
+    }
+
+    const faces = mesh.simplices(2).items(.vertices);
+    for (faces) |face| {
+        const a = coords[face[0]];
+        const b = coords[face[1]];
+        const c = coords[face[2]];
+        const ab = [3]f64{ b[0] - a[0], b[1] - a[1], b[2] - a[2] };
+        const ac = [3]f64{ c[0] - a[0], c[1] - a[1], c[2] - a[2] };
+        const normal = [3]f64{
+            ab[1] * ac[2] - ab[2] * ac[1],
+            ab[2] * ac[0] - ab[0] * ac[2],
+            ab[0] * ac[1] - ab[1] * ac[0],
+        };
+        const centroid = [3]f64{
+            (a[0] + b[0] + c[0]) / 3.0,
+            (a[1] + b[1] + c[1]) / 3.0,
+            (a[2] + b[2] + c[2]) / 3.0,
+        };
+        const radial_xy = @sqrt(centroid[0] * centroid[0] + centroid[1] * centroid[1]);
+        const ring_center = [3]f64{
+            major_radius * centroid[0] / radial_xy,
+            major_radius * centroid[1] / radial_xy,
+            0.0,
+        };
+        const outward = [3]f64{
+            centroid[0] - ring_center[0],
+            centroid[1] - ring_center[1],
+            centroid[2] - ring_center[2],
+        };
+        const orientation = normal[0] * outward[0] + normal[1] * outward[1] + normal[2] * outward[2];
+        try testing.expect(orientation > 0.0);
+    }
+}
+
 test "boundary operator ∂₁ has exactly 2 nonzeros per row" {
     const allocator = testing.allocator;
     var mesh = try Mesh(2, 2).uniform_grid(allocator, 4, 3, 2.0, 1.5);

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -10,6 +10,7 @@ const testing = std.testing;
 const flux = @import("../root.zig");
 const sparse = @import("../math/sparse.zig");
 const whitney = @import("../operators/whitney_mass.zig");
+pub const geometries = @import("geometries.zig");
 
 pub const WhitneyMassOperator = struct {
     mass: sparse.CsrMatrix(f64),
@@ -767,6 +768,25 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             orientSphereFacesOutward(polyhedron.vertices, oriented_faces);
 
             return Self.from_triangles(allocator, polyhedron.vertices, oriented_faces);
+        }
+
+        pub fn disk(
+            allocator: std.mem.Allocator,
+            radius: f64,
+            radial_segments: u32,
+            angular_segments: u32,
+        ) !Self {
+            return geometries.disk(Self, allocator, radius, radial_segments, angular_segments);
+        }
+
+        pub fn torus(
+            allocator: std.mem.Allocator,
+            major_radius: f64,
+            minor_radius: f64,
+            major_segments: u32,
+            minor_segments: u32,
+        ) !Self {
+            return geometries.torus(Self, allocator, major_radius, minor_radius, major_segments, minor_segments);
         }
 
         /// Construct a 2D simplicial mesh from explicit triangle connectivity.

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -10,7 +10,7 @@ const testing = std.testing;
 const flux = @import("../root.zig");
 const sparse = @import("../math/sparse.zig");
 const whitney = @import("../operators/whitney_mass.zig");
-pub const geometries = @import("geometries.zig");
+const geometries = @import("geometries.zig");
 
 pub const WhitneyMassOperator = struct {
     mass: sparse.CsrMatrix(f64),
@@ -392,7 +392,7 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
         }
 
         // ───────────────────────────────────────────────────────────────────
-        // Uniform grid constructor
+        // Plane constructor
         // ───────────────────────────────────────────────────────────────────
 
         /// Construct a uniform triangulated rectangular grid on `[0, width] × [0, height]`.
@@ -409,337 +409,14 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
         /// centroids rather than circumcenters. This avoids the degeneracy where
         /// right triangles sharing a hypotenuse have coincident circumcenters,
         /// ensuring every edge has nonzero dual length and ★₁ is non-singular.
-        pub fn uniform_grid(
+        pub fn plane(
             allocator: std.mem.Allocator,
             nx: u32,
             ny: u32,
             width: f64,
             height: f64,
         ) !Self {
-            comptime {
-                if (topological_dimension != 2) @compileError("uniform_grid is only available for 2D meshes (topological_dimension = 2)");
-            }
-            if (nx == 0 or ny == 0) @panic("grid dimensions must be positive");
-            if (!(width > 0) or !(height > 0)) @panic("domain size must be positive");
-
-            const dx = width / @as(f64, @floatFromInt(nx));
-            const dy = height / @as(f64, @floatFromInt(ny));
-
-            const vertex_count: u32 = (nx + 1) * (ny + 1);
-            const horizontal_edge_count: u32 = nx * (ny + 1);
-            const vertical_edge_count: u32 = (nx + 1) * ny;
-            const diagonal_edge_count: u32 = nx * ny;
-            const edge_count: u32 = horizontal_edge_count + vertical_edge_count + diagonal_edge_count;
-            const face_count: u32 = 2 * nx * ny;
-
-            // -- Allocate entity storage --
-
-            var vertices = std.MultiArrayList(Vertex(embedding_dimension)){};
-            try vertices.ensureTotalCapacity(allocator, vertex_count);
-            errdefer vertices.deinit(allocator);
-
-            var edges_list = std.MultiArrayList(Simplex(embedding_dimension, topological_dimension, 1)){};
-            try edges_list.ensureTotalCapacity(allocator, edge_count);
-            errdefer edges_list.deinit(allocator);
-
-            var faces_list = std.MultiArrayList(Simplex(embedding_dimension, topological_dimension, 2)){};
-            try faces_list.ensureTotalCapacity(allocator, face_count);
-            errdefer faces_list.deinit(allocator);
-
-            // -- Populate vertices --
-            // Indexed as vertex_index(i, j) = i * (ny + 1) + j.
-            for (0..nx + 1) |i_u| {
-                const fi: f64 = @floatFromInt(i_u);
-                for (0..ny + 1) |j_u| {
-                    const fj: f64 = @floatFromInt(j_u);
-                    var coords: [embedding_dimension]f64 = @splat(0);
-                    coords[0] = fi * dx;
-                    coords[1] = fj * dy;
-                    vertices.appendAssumeCapacity(.{ .coords = coords, .dual_volume = 0 });
-                }
-            }
-
-            // -- Populate edges --
-            // Horizontal: horizontal_edge(i,j) = j*nx + i, tail = vertex(i,j), head = vertex(i+1,j)
-            for (0..ny + 1) |j_u| {
-                for (0..nx) |i_u| {
-                    const i: u32 = @intCast(i_u);
-                    const j: u32 = @intCast(j_u);
-                    edges_list.appendAssumeCapacity(.{
-                        .vertices = .{ vertex_index(i, j, ny), vertex_index(i + 1, j, ny) },
-                        .volume = 0,
-                        .barycenter = @splat(0),
-                    });
-                }
-            }
-            // Vertical: vertical_edge(i,j) = horizontal_edge_count + i*ny + j
-            for (0..nx + 1) |i_u| {
-                for (0..ny) |j_u| {
-                    const i: u32 = @intCast(i_u);
-                    const j: u32 = @intCast(j_u);
-                    edges_list.appendAssumeCapacity(.{
-                        .vertices = .{ vertex_index(i, j, ny), vertex_index(i, j + 1, ny) },
-                        .volume = 0,
-                        .barycenter = @splat(0),
-                    });
-                }
-            }
-            // Diagonal (SW→NE): diagonal_edge(i,j) = horizontal_edge_count + vertical_edge_count + i*ny + j
-            for (0..nx) |i_u| {
-                for (0..ny) |j_u| {
-                    const i: u32 = @intCast(i_u);
-                    const j: u32 = @intCast(j_u);
-                    edges_list.appendAssumeCapacity(.{
-                        .vertices = .{ vertex_index(i, j, ny), vertex_index(i + 1, j + 1, ny) },
-                        .volume = 0,
-                        .barycenter = @splat(0),
-                    });
-                }
-            }
-
-            // -- Populate faces --
-            // Two triangles per cell, both CCW-oriented.
-            for (0..nx) |i_u| {
-                const i: u32 = @intCast(i_u);
-                for (0..ny) |j_u| {
-                    const j: u32 = @intCast(j_u);
-                    const sw = vertex_index(i, j, ny);
-                    const se = vertex_index(i + 1, j, ny);
-                    const nw = vertex_index(i, j + 1, ny);
-                    const ne = vertex_index(i + 1, j + 1, ny);
-
-                    const zero_cc: [embedding_dimension]f64 = @splat(0);
-
-                    // Lower-right triangle: SW → SE → NE
-                    faces_list.appendAssumeCapacity(.{ .vertices = .{ sw, se, ne }, .volume = 0, .barycenter = zero_cc });
-                    // Upper-left triangle:  SW → NE → NW
-                    faces_list.appendAssumeCapacity(.{ .vertices = .{ sw, ne, nw }, .volume = 0, .barycenter = zero_cc });
-                }
-            }
-
-            // -- Build ∂₁ (n_edges × n_vertices) --
-            // Each edge row has exactly 2 nonzeros: tail = −1, head = +1.
-            var boundary_1: BoundaryMatrix = undefined;
-            {
-                var boundary_1_dense = try DenseBoundaryMatrix.init(allocator, edge_count, vertex_count, 2 * edge_count);
-                errdefer boundary_1_dense.deinit(allocator);
-                const edge_verts = edges_list.slice().items(.vertices);
-                for (0..edge_count) |e| {
-                    boundary_1_dense.row_ptr[e] = @intCast(2 * e);
-                    // tail < head for the uniform grid, so columns are sorted
-                    boundary_1_dense.col_idx[2 * e] = edge_verts[e][0];
-                    boundary_1_dense.values[2 * e] = -1;
-                    boundary_1_dense.col_idx[2 * e + 1] = edge_verts[e][1];
-                    boundary_1_dense.values[2 * e + 1] = 1;
-                }
-                boundary_1_dense.row_ptr[edge_count] = 2 * edge_count;
-
-                boundary_1 = try BoundaryMatrix.fromBoundaryCsr(allocator, 1, boundary_1_dense);
-                boundary_1_dense.deinit(allocator);
-            }
-            errdefer boundary_1.deinit(allocator);
-
-            // -- Build ∂₂ (n_faces × n_edges) --
-            // Each face row has exactly 3 nonzeros for the oriented boundary edges.
-            //
-            // Lower-right (SW,SE,NE): +h(i,j), +vert(i+1,j), −diag(i,j)
-            // Upper-left  (SW,NE,NW): −h(i,j+1), −vert(i,j), +diag(i,j)
-            //
-            // Column ordering: horizontal < vertical < diagonal (always sorted).
-            var boundary_2: BoundaryMatrix = undefined;
-            {
-                var boundary_2_dense = try DenseBoundaryMatrix.init(allocator, face_count, edge_count, 3 * face_count);
-                errdefer boundary_2_dense.deinit(allocator);
-                var f_idx: u32 = 0;
-                for (0..nx) |i_u| {
-                    const i: u32 = @intCast(i_u);
-                    for (0..ny) |j_u| {
-                        const j: u32 = @intCast(j_u);
-                        const h_ij = horizontal_edge_index(i, j, nx);
-                        const h_i_jp1 = horizontal_edge_index(i, j + 1, nx);
-                        const v_ip1_j = vertical_edge_index(i + 1, j, ny, horizontal_edge_count);
-                        const v_i_j = vertical_edge_index(i, j, ny, horizontal_edge_count);
-                        const d_ij = diagonal_edge_index(i, j, ny, horizontal_edge_count, vertical_edge_count);
-
-                        // Lower-right triangle
-                        boundary_2_dense.row_ptr[f_idx] = 3 * f_idx;
-                        boundary_2_dense.col_idx[3 * f_idx + 0] = h_ij;
-                        boundary_2_dense.values[3 * f_idx + 0] = 1;
-                        boundary_2_dense.col_idx[3 * f_idx + 1] = v_ip1_j;
-                        boundary_2_dense.values[3 * f_idx + 1] = 1;
-                        boundary_2_dense.col_idx[3 * f_idx + 2] = d_ij;
-                        boundary_2_dense.values[3 * f_idx + 2] = -1;
-                        f_idx += 1;
-
-                        // Upper-left triangle
-                        boundary_2_dense.row_ptr[f_idx] = 3 * f_idx;
-                        boundary_2_dense.col_idx[3 * f_idx + 0] = h_i_jp1;
-                        boundary_2_dense.values[3 * f_idx + 0] = -1;
-                        boundary_2_dense.col_idx[3 * f_idx + 1] = v_i_j;
-                        boundary_2_dense.values[3 * f_idx + 1] = -1;
-                        boundary_2_dense.col_idx[3 * f_idx + 2] = d_ij;
-                        boundary_2_dense.values[3 * f_idx + 2] = 1;
-                        f_idx += 1;
-                    }
-                }
-                boundary_2_dense.row_ptr[face_count] = 3 * face_count;
-
-                boundary_2 = try BoundaryMatrix.fromBoundaryCsr(allocator, 2, boundary_2_dense);
-                boundary_2_dense.deinit(allocator);
-            }
-            errdefer boundary_2.deinit(allocator);
-
-            // -- Compute primal geometry --
-
-            const coords = vertices.slice().items(.coords);
-
-            // Edge lengths and barycenters
-            {
-                const edge_slice = edges_list.slice();
-                const edge_verts = edge_slice.items(.vertices);
-                const edge_volumes = edge_slice.items(.volume);
-                const edge_barycenters = edge_slice.items(.barycenter);
-                for (0..edge_count) |e| {
-                    edge_volumes[e] = euclidean_distance(coords[edge_verts[e][0]], coords[edge_verts[e][1]]);
-                    edge_barycenters[e] = point_midpoint(coords[edge_verts[e][0]], coords[edge_verts[e][1]]);
-                }
-            }
-
-            // Face areas and barycenters
-            {
-                const face_slice = faces_list.slice();
-                const face_verts = face_slice.items(.vertices);
-                const face_volumes = face_slice.items(.volume);
-                const face_barycenters = face_slice.items(.barycenter);
-                for (0..face_count) |f| {
-                    const p0 = coords[face_verts[f][0]];
-                    const p1 = coords[face_verts[f][1]];
-                    const p2 = coords[face_verts[f][2]];
-                    face_volumes[f] = triangle_area(p0, p1, p2);
-                    face_barycenters[f] = triangle_barycenter(p0, p1, p2);
-                }
-            }
-
-            // -- Compute circumcentric dual geometry --
-
-            // Dual edge volumes require edge→face adjacency.
-            // Each edge borders at most 2 faces; boundary edges border exactly 1.
-            // Single scratch allocation: [count | face_0 | face_1], each edge_count u32s.
-            const dual_edge_volumes = try allocator.alloc(f64, edge_count);
-            errdefer allocator.free(dual_edge_volumes);
-            var boundary_edge_buf: []u32 = &.{};
-            {
-                const scratch = try allocator.alloc(u32, 3 * edge_count);
-                defer allocator.free(scratch);
-                const edge_face_count = scratch[0..edge_count];
-                const edge_face_0 = scratch[edge_count .. 2 * edge_count];
-                const edge_face_1 = scratch[2 * edge_count .. 3 * edge_count];
-                @memset(edge_face_count, 0);
-
-                for (0..face_count) |f| {
-                    const face_edges = boundary_2.row(@intCast(f));
-                    for (face_edges.cols) |e| {
-                        const count = edge_face_count[e];
-                        if (count == 0) {
-                            edge_face_0[e] = @intCast(f);
-                        } else {
-                            edge_face_1[e] = @intCast(f);
-                        }
-                        edge_face_count[e] = count + 1;
-                    }
-                }
-
-                const barycenters = faces_list.slice().items(.barycenter);
-                const edge_verts = edges_list.slice().items(.vertices);
-
-                // Count boundary edges (adjacent to exactly one face) and
-                // compute dual edge volumes in one pass.
-                var boundary_count: u32 = 0;
-                for (0..edge_count) |e| {
-                    if (edge_face_count[e] == 2) {
-                        dual_edge_volumes[e] = euclidean_distance(
-                            barycenters[edge_face_0[e]],
-                            barycenters[edge_face_1[e]],
-                        );
-                    } else if (edge_face_count[e] == 1) {
-                        const mid = point_midpoint(coords[edge_verts[e][0]], coords[edge_verts[e][1]]);
-                        dual_edge_volumes[e] = euclidean_distance(barycenters[edge_face_0[e]], mid);
-                        boundary_count += 1;
-                    } else {
-                        return flux.Error.NonManifoldEdge;
-                    }
-                }
-
-                // Collect boundary edge indices.
-                boundary_edge_buf = try allocator.alloc(u32, boundary_count);
-                var bi: u32 = 0;
-                for (0..edge_count) |e| {
-                    if (edge_face_count[e] == 1) {
-                        boundary_edge_buf[bi] = @intCast(e);
-                        bi += 1;
-                    }
-                }
-                std.debug.assert(bi == boundary_count);
-            }
-
-            // Dual vertex volumes via the cotangent formula.
-            //
-            // For triangle (v₀, v₁, v₂) with edge lengths l₀₁, l₁₂, l₂₀:
-            //   cot(αᵢ) = (lⱼₖ² + lₖᵢ² − lᵢⱼ²) / (4 · area)
-            //
-            //   dual_volume[vᵢ] += (cot(αⱼ) · lᵢₖ² + cot(αₖ) · lᵢⱼ²) / 8
-            //
-            // This gives the circumcentric (Voronoi) dual area contribution.
-            // Reference: Meyer et al., "Discrete Differential-Geometry Operators
-            // for Triangulated 2-Manifolds" (2002), §4.
-            {
-                const dual_volumes = vertices.slice().items(.dual_volume);
-                @memset(dual_volumes, 0);
-
-                const face_verts = faces_list.slice().items(.vertices);
-                for (0..face_count) |f| {
-                    const vs = face_verts[f];
-                    const p0 = coords[vs[0]];
-                    const p1 = coords[vs[1]];
-                    const p2 = coords[vs[2]];
-
-                    const l01_sq = distance_squared(p0, p1);
-                    const l12_sq = distance_squared(p1, p2);
-                    const l20_sq = distance_squared(p2, p0);
-
-                    const area_4 = 4.0 * triangle_area(p0, p1, p2);
-                    // Degenerate triangles cause division by zero in the
-                    // cotangent formula below.
-                    if (!(area_4 > 0)) return flux.Error.DegenerateTriangle;
-
-                    const cot0 = (l01_sq + l20_sq - l12_sq) / area_4;
-                    const cot1 = (l01_sq + l12_sq - l20_sq) / area_4;
-                    const cot2 = (l12_sq + l20_sq - l01_sq) / area_4;
-
-                    dual_volumes[vs[0]] += (cot1 * l20_sq + cot2 * l01_sq) / 8.0;
-                    dual_volumes[vs[1]] += (cot2 * l01_sq + cot0 * l12_sq) / 8.0;
-                    dual_volumes[vs[2]] += (cot0 * l12_sq + cot1 * l20_sq) / 8.0;
-                }
-            }
-
-            // -- Whitney mass matrix M₁ and diagonal preconditioner --
-            //
-            // M₁ is the Galerkin inner product of Whitney 1-form basis functions.
-            // It replaces the diagonal ★₁ (which only converges on orthogonal
-            // dual meshes) with an SPD matrix that is exact on any triangulation.
-            // The diagonal ★₁ values (dual_length / length) serve as a spectrally
-            // equivalent preconditioner for CG solves of M₁.
-
-            var partial = Self{
-                .vertices = vertices,
-                .simplex_lists = .{ edges_list, faces_list },
-                .boundaries = .{ boundary_1, boundary_2 },
-                .dual_edge_volumes = dual_edge_volumes,
-                .boundary_edges = boundary_edge_buf,
-                .whitney_operators = undefined,
-            };
-            partial.whitney_operators = try assembleWhitneyOperators(allocator, &partial);
-            return partial;
+            return geometries.plane(Self, allocator, nx, ny, width, height);
         }
 
         /// Construct an embedded triangulated sphere of radius `radius`.
@@ -753,21 +430,7 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             radius: f64,
             refinement: u32,
         ) !Self {
-            comptime {
-                if (embedding_dimension != 3 or topological_dimension != 2) {
-                    @compileError("sphere is only available for Mesh(3, 2)");
-                }
-            }
-            if (!(radius > 0.0)) @panic("sphere radius must be positive");
-
-            var polyhedron = try buildRefinedSphereOctahedron(allocator, radius, refinement);
-            defer polyhedron.deinit(allocator);
-
-            const oriented_faces = try allocator.dupe([3]u32, polyhedron.faces);
-            defer allocator.free(oriented_faces);
-            orientSphereFacesOutward(polyhedron.vertices, oriented_faces);
-
-            return Self.from_triangles(allocator, polyhedron.vertices, oriented_faces);
+            return geometries.sphere(Self, allocator, radius, refinement);
         }
 
         pub fn disk(
@@ -1688,9 +1351,9 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
 // Tests
 // ═══════════════════════════════════════════════════════════════════════════
 
-test "uniform grid entity counts" {
+test "plane constructor entity counts" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 3, 4, 1.0, 1.0);
+    var mesh = try Mesh(2, 2).plane(allocator, 3, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     try testing.expectEqual(@as(u32, 20), mesh.num_vertices()); // (3+1)*(4+1)
@@ -1829,7 +1492,7 @@ test "torus constructor produces an oriented embedded torus" {
 
 test "boundary operator ∂₁ has exactly 2 nonzeros per row" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh(2, 2).plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     for (0..mesh.num_edges()) |e| {
@@ -1845,7 +1508,7 @@ test "boundary operator ∂₁ has exactly 2 nonzeros per row" {
 
 test "boundary operator ∂₂ has exactly 3 nonzeros per row" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 4, 3, 2.0, 1.5);
+    var mesh = try Mesh(2, 2).plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
     for (0..mesh.num_faces()) |f| {
@@ -1870,7 +1533,7 @@ test "boundary of boundary is zero for 2D triangulations" {
     };
 
     for (sizes) |size| {
-        var mesh = try Mesh(2, 2).uniform_grid(allocator, size[0], size[1], 1.0, 1.0);
+        var mesh = try Mesh(2, 2).plane(allocator, size[0], size[1], 1.0, 1.0);
         defer mesh.deinit(allocator);
 
         var vertex_sum = try allocator.alloc(i32, mesh.num_vertices());
@@ -1900,7 +1563,7 @@ test "boundary queries on 2D meshes agree with boundary incidence" {
     const allocator = testing.allocator;
     const Mesh2D = Mesh(2, 2);
 
-    var mesh = try Mesh2D.uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const boundary_vertex_mask = try mesh.boundary_mask(allocator, 0);
@@ -1944,26 +1607,31 @@ test "boundary queries on 2D meshes agree with boundary incidence" {
 
 test "edge lengths for unit square 1×1 grid" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 1, 1, 1.0, 1.0);
+    var mesh = try Mesh(2, 2).plane(allocator, 1, 1, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const lengths = mesh.simplices(1).items(.volume);
 
     // 1×1 grid: 2 horizontal (len 1), 2 vertical (len 1), 1 diagonal (len √2)
     try testing.expectEqual(@as(u32, 5), mesh.num_edges());
-    // Horizontal edges
-    try testing.expectApproxEqAbs(@as(f64, 1.0), lengths[0], 1e-15);
-    try testing.expectApproxEqAbs(@as(f64, 1.0), lengths[1], 1e-15);
-    // Vertical edges
-    try testing.expectApproxEqAbs(@as(f64, 1.0), lengths[2], 1e-15);
-    try testing.expectApproxEqAbs(@as(f64, 1.0), lengths[3], 1e-15);
-    // Diagonal edge
-    try testing.expectApproxEqAbs(@sqrt(2.0), lengths[4], 1e-15);
+    var unit_count: u32 = 0;
+    var diagonal_count: u32 = 0;
+    for (lengths) |length| {
+        if (@abs(length - 1.0) < 1e-15) {
+            unit_count += 1;
+        } else if (@abs(length - @sqrt(2.0)) < 1e-15) {
+            diagonal_count += 1;
+        } else {
+            return error.TestUnexpectedResult;
+        }
+    }
+    try testing.expectEqual(@as(u32, 4), unit_count);
+    try testing.expectEqual(@as(u32, 1), diagonal_count);
 }
 
 test "face areas for uniform grid" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 2, 2, 1.0, 1.0);
+    var mesh = try Mesh(2, 2).plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const areas = mesh.simplices(2).items(.volume);
@@ -1976,7 +1644,7 @@ test "face areas for uniform grid" {
 
 test "barycenters of triangles are at centroids" {
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 1, 1, 2.0, 2.0);
+    var mesh = try Mesh(2, 2).plane(allocator, 1, 1, 2.0, 2.0);
     defer mesh.deinit(allocator);
 
     const barycenters = mesh.simplices(2).items(.barycenter);
@@ -1995,7 +1663,7 @@ test "dual vertex areas sum to total mesh area" {
     const width: f64 = 3.0;
     const height: f64 = 2.0;
 
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 5, 4, width, height);
+    var mesh = try Mesh(2, 2).plane(allocator, 5, 4, width, height);
     defer mesh.deinit(allocator);
 
     const dual_areas = mesh.vertices.slice().items(.dual_volume);
@@ -2016,7 +1684,7 @@ test "interior vertex dual area equals cell area" {
     const dx = width / @as(f64, @floatFromInt(nx));
     const dy = height / @as(f64, @floatFromInt(ny));
 
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, nx, ny, width, height);
+    var mesh = try Mesh(2, 2).plane(allocator, nx, ny, width, height);
     defer mesh.deinit(allocator);
 
     const dual_areas = mesh.vertices.slice().items(.dual_volume);
@@ -2034,7 +1702,7 @@ test "all edges have nonzero dual length" {
     // With barycentric dual, every edge (including diagonals) has nonzero
     // dual length because adjacent triangles have distinct barycenters.
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 3, 3, 1.0, 1.0);
+    var mesh = try Mesh(2, 2).plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
     const dual_lengths = mesh.dual_edge_volumes;
@@ -2076,7 +1744,7 @@ test "random grid dimensions produce valid meshes (100 trials)" {
         const width = rng.random().float(f64) * 99.9 + 0.1; // (0.1, 100.0)
         const height = rng.random().float(f64) * 99.9 + 0.1;
 
-        var mesh = try Mesh(2, 2).uniform_grid(allocator, nx, ny, width, height);
+        var mesh = try Mesh(2, 2).plane(allocator, nx, ny, width, height);
         defer mesh.deinit(allocator);
 
         // Entity counts match the grid formulas.
@@ -2135,7 +1803,7 @@ test "cotangent Laplacian is robust on random grid dimensions (50 trials)" {
         const width = rng.random().float(f64) * 99.9 + 0.1;
         const height = rng.random().float(f64) * 99.9 + 0.1;
 
-        var mesh = try Mesh(2, 2).uniform_grid(allocator, nx, ny, width, height);
+        var mesh = try Mesh(2, 2).plane(allocator, nx, ny, width, height);
         defer mesh.deinit(allocator);
 
         const operator_context = try context_mod.OperatorContext(Mesh(2, 2)).init(allocator, &mesh);
@@ -2629,7 +2297,7 @@ test "uniform_grid 1×1 is the smallest valid grid" {
     // nx=0, ny=0, width=0, height≤0 all panic (precondition violations).
     // This test verifies the smallest valid grid constructs successfully.
     const allocator = testing.allocator;
-    var mesh = try Mesh(2, 2).uniform_grid(allocator, 1, 1, 0.001, 0.001);
+    var mesh = try Mesh(2, 2).plane(allocator, 1, 1, 0.001, 0.001);
     defer mesh.deinit(allocator);
     try testing.expectEqual(@as(u32, 4), mesh.num_vertices());
     try testing.expectEqual(@as(u32, 2), mesh.num_faces());

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -391,6 +391,52 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             return operators;
         }
 
+        const PlaneGeometryApi = struct {
+            pub const VerticesStorage = @FieldType(Self, "vertices");
+            pub const EdgeStorage = @TypeOf(@as(Self, undefined).simplex_lists[0]);
+            pub const FaceStorage = @TypeOf(@as(Self, undefined).simplex_lists[1]);
+
+            pub fn assembleWhitneyOperators(allocator: std.mem.Allocator, mesh: *const Self) !@FieldType(Self, "whitney_operators") {
+                return Self.assembleWhitneyOperators(allocator, mesh);
+            }
+
+            pub fn vertexIndex(i: u32, j: u32, ny_val: u32) u32 {
+                return Self.vertex_index(i, j, ny_val);
+            }
+
+            pub fn horizontalEdgeIndex(i: u32, j: u32, nx_val: u32) u32 {
+                return Self.horizontal_edge_index(i, j, nx_val);
+            }
+
+            pub fn verticalEdgeIndex(i: u32, j: u32, ny_val: u32, n_horizontal: u32) u32 {
+                return Self.vertical_edge_index(i, j, ny_val, n_horizontal);
+            }
+
+            pub fn diagonalEdgeIndex(i: u32, j: u32, ny_val: u32, n_horizontal: u32, n_vertical: u32) u32 {
+                return Self.diagonal_edge_index(i, j, ny_val, n_horizontal, n_vertical);
+            }
+
+            pub fn distanceSquared(a: [embedding_dimension]f64, b: [embedding_dimension]f64) f64 {
+                return Self.distance_squared(a, b);
+            }
+
+            pub fn euclideanDistance(a: [embedding_dimension]f64, b: [embedding_dimension]f64) f64 {
+                return Self.euclidean_distance(a, b);
+            }
+
+            pub fn pointMidpoint(a: [embedding_dimension]f64, b: [embedding_dimension]f64) [embedding_dimension]f64 {
+                return Self.point_midpoint(a, b);
+            }
+
+            pub fn triangleArea(a: [embedding_dimension]f64, b: [embedding_dimension]f64, c: [embedding_dimension]f64) f64 {
+                return Self.triangle_area(a, b, c);
+            }
+
+            pub fn triangleBarycenter(a: [embedding_dimension]f64, b: [embedding_dimension]f64, c: [embedding_dimension]f64) [embedding_dimension]f64 {
+                return Self.triangle_barycenter(a, b, c);
+            }
+        };
+
         // ───────────────────────────────────────────────────────────────────
         // Plane constructor
         // ───────────────────────────────────────────────────────────────────
@@ -416,7 +462,7 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             width: f64,
             height: f64,
         ) !Self {
-            return geometries.plane(Self, allocator, nx, ny, width, height);
+            return geometries.plane(Self, PlaneGeometryApi, allocator, nx, ny, width, height);
         }
 
         /// Construct an embedded triangulated sphere of radius `radius`.

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -1123,133 +1123,6 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             return determinant / 6.0;
         }
 
-        const SpherePolyhedron = struct {
-            vertices: [][3]f64,
-            faces: [][3]u32,
-
-            fn deinit(self: *SpherePolyhedron, allocator: std.mem.Allocator) void {
-                allocator.free(self.faces);
-                allocator.free(self.vertices);
-            }
-        };
-
-        fn buildRefinedSphereOctahedron(allocator: std.mem.Allocator, radius: f64, refinement: u32) !SpherePolyhedron {
-            var polyhedron = SpherePolyhedron{
-                .vertices = try allocator.dupe([3]f64, &initial_sphere_octahedron_vertices),
-                .faces = try allocator.dupe([3]u32, &initial_sphere_octahedron_faces),
-            };
-            errdefer polyhedron.deinit(allocator);
-
-            scaleSphereVertices(polyhedron.vertices, radius);
-
-            for (0..refinement) |_| {
-                const next = try refineSpherePolyhedron(allocator, polyhedron, radius);
-                polyhedron.deinit(allocator);
-                polyhedron = next;
-            }
-
-            return polyhedron;
-        }
-
-        fn refineSpherePolyhedron(allocator: std.mem.Allocator, polyhedron: SpherePolyhedron, radius: f64) !SpherePolyhedron {
-            var vertices = try std.ArrayList([3]f64).initCapacity(allocator, polyhedron.vertices.len + polyhedron.faces.len);
-            defer vertices.deinit(allocator);
-            try vertices.appendSlice(allocator, polyhedron.vertices);
-
-            var faces = try std.ArrayList([3]u32).initCapacity(allocator, polyhedron.faces.len * 4);
-            defer faces.deinit(allocator);
-
-            var midpoint_map = std.AutoHashMap([2]u32, u32).init(allocator);
-            defer midpoint_map.deinit();
-
-            for (polyhedron.faces) |face| {
-                const ab = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[0], face[1], radius);
-                const bc = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[1], face[2], radius);
-                const ca = try sphereMidpointIndex(allocator, &vertices, &midpoint_map, face[2], face[0], radius);
-
-                try faces.append(allocator, .{ face[0], ab, ca });
-                try faces.append(allocator, .{ face[1], bc, ab });
-                try faces.append(allocator, .{ face[2], ca, bc });
-                try faces.append(allocator, .{ ab, bc, ca });
-            }
-
-            return .{
-                .vertices = try vertices.toOwnedSlice(allocator),
-                .faces = try faces.toOwnedSlice(allocator),
-            };
-        }
-
-        fn sphereMidpointIndex(
-            allocator: std.mem.Allocator,
-            vertices: *std.ArrayList([3]f64),
-            midpoint_map: *std.AutoHashMap([2]u32, u32),
-            a: u32,
-            b: u32,
-            radius: f64,
-        ) !u32 {
-            const key = canonical_edge_key(a, b);
-            const gop = try midpoint_map.getOrPut(key);
-            if (gop.found_existing) return gop.value_ptr.*;
-
-            const midpoint = normalizeSpherePoint(scaleSpherePoint(addSpherePoints(vertices.items[a], vertices.items[b]), 0.5), radius);
-            const new_index: u32 = @intCast(vertices.items.len);
-            try vertices.append(allocator, midpoint);
-            gop.value_ptr.* = new_index;
-            return new_index;
-        }
-
-        fn orientSphereFacesOutward(embedded_vertices: []const [3]f64, faces: [][3]u32) void {
-            for (faces) |*face| {
-                const a = embedded_vertices[face.*[0]];
-                const b = embedded_vertices[face.*[1]];
-                const c = embedded_vertices[face.*[2]];
-                const normal = cross3(subSpherePoints(b, a), subSpherePoints(c, a));
-                const centroid = normalizeSpherePoint(scaleSpherePoint(addSpherePoints(addSpherePoints(a, b), c), 1.0 / 3.0), 1.0);
-                if (dot3(normal, centroid) < 0.0) {
-                    std.mem.swap(u32, &face.*[1], &face.*[2]);
-                }
-            }
-        }
-
-        fn scaleSphereVertices(vertices: [][3]f64, radius: f64) void {
-            for (vertices) |*vertex| {
-                vertex.* = scaleSpherePoint(vertex.*, radius);
-            }
-        }
-
-        fn addSpherePoints(a: [3]f64, b: [3]f64) [3]f64 {
-            return .{ a[0] + b[0], a[1] + b[1], a[2] + b[2] };
-        }
-
-        fn subSpherePoints(a: [3]f64, b: [3]f64) [3]f64 {
-            return .{ a[0] - b[0], a[1] - b[1], a[2] - b[2] };
-        }
-
-        fn scaleSpherePoint(a: [3]f64, scale: f64) [3]f64 {
-            return .{ a[0] * scale, a[1] * scale, a[2] * scale };
-        }
-
-        fn dot3(a: [3]f64, b: [3]f64) f64 {
-            return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-        }
-
-        fn norm3(a: [3]f64) f64 {
-            return @sqrt(dot3(a, a));
-        }
-
-        fn normalizeSpherePoint(a: [3]f64, radius: f64) [3]f64 {
-            const inv_norm = radius / norm3(a);
-            return scaleSpherePoint(a, inv_norm);
-        }
-
-        fn cross3(a: [3]f64, b: [3]f64) [3]f64 {
-            return .{
-                a[1] * b[2] - a[2] * b[1],
-                a[2] * b[0] - a[0] * b[2],
-                a[0] * b[1] - a[1] * b[0],
-            };
-        }
-
         fn canonical_edge_key(a: u32, b: u32) [2]u32 {
             return if (a < b) .{ a, b } else .{ b, a };
         }
@@ -1323,26 +1196,6 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             .{ 0, 3 },
             .{ 0, 2 },
             .{ 0, 1 },
-        };
-
-        const initial_sphere_octahedron_vertices = [_][3]f64{
-            .{ 1.0, 0.0, 0.0 },
-            .{ -1.0, 0.0, 0.0 },
-            .{ 0.0, 1.0, 0.0 },
-            .{ 0.0, -1.0, 0.0 },
-            .{ 0.0, 0.0, 1.0 },
-            .{ 0.0, 0.0, -1.0 },
-        };
-
-        const initial_sphere_octahedron_faces = [_][3]u32{
-            .{ 0, 4, 2 },
-            .{ 2, 4, 1 },
-            .{ 1, 4, 3 },
-            .{ 3, 4, 0 },
-            .{ 2, 5, 0 },
-            .{ 1, 5, 2 },
-            .{ 3, 5, 1 },
-            .{ 0, 5, 3 },
         };
     };
 }
@@ -2293,7 +2146,7 @@ test "∂₂∂₃ = 0 on single tetrahedron" {
     }
 }
 
-test "uniform_grid 1×1 is the smallest valid grid" {
+test "plane 1×1 is the smallest valid grid" {
     // nx=0, ny=0, width=0, height≤0 all panic (precondition violations).
     // This test verifies the smallest valid grid constructs successfully.
     const allocator = testing.allocator;


### PR DESCRIPTION
Closes #150

## What

Make canonical geometry construction a single public mesh API: `Mesh(...).plane(...)`, `Mesh(...).disk(...)`, `Mesh(...).sphere(...)`, and `Mesh(...).torus(...)`. The implementation lives in `src/topology/geometries.zig` as a private helper module imported only by `mesh.zig`, so users cannot hit a second constructor surface directly.

This PR also renames the old rectangular-grid constructor from `uniform_grid(...)` to `plane(...)` across the codebase so the public geometry vocabulary is consistent.

## Acceptance criterion

A constructor layer covers at least:

- [x] plane
- [x] disk
- [x] sphere
- [x] torus

Each constructor is covered by tests checking:

- [x] entity counts match expected formulas where applicable
- [x] Euler characteristic matches the topological invariant
- [x] faces are positively oriented where orientation is meaningful
- [x] returned embedded geometry is numerically well-formed

Consumer proof point:
- [x] the diffusion sphere path continues to consume the shared sphere constructor

## Tasks

- [x] Write topology/consumer tests for canonical geometries
- [x] Design public API (stubs)
- [x] Implement constructors and migrate consumers
- [x] CI green

## Decisions

- Keep `Mesh(...)` as the only public constructor surface; `geometries.zig` is a private implementation detail rather than a second hittable API.
- Standardize the rectangular constructor name on `plane(...)` instead of `uniform_grid(...)` so the geometry surface is expressed in one consistent set of nouns.
- Implement `plane`, `disk`, `sphere`, and `torus` in the geometry helper and have `mesh.zig` forward to that helper, so constructor ownership flows in one direction.

## Limitations

- The current `plane` and `disk` constructors target `Mesh(2, 2)`, while `sphere` and `torus` target `Mesh(3, 2)`, which matches the mesh types the library can honestly support today.
