### PR TITLE
feat(operators): assemble primal k-form Laplacians directly

### DIFF
--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -797,3 +797,29 @@ collection of wrappers around today's examples. Structural abstractions should
 describe the underlying mathematical/computational role so they still make
 sense for other PDEs, dimensions, and solver families. `LinearSystem` plus an
 `EliminationMap` is such a split. `DirichletConstrainedSystem` was not.
+
+## 2026-04-12: Assembled Laplacian owns weak stiffness; strong apply remains separate
+
+**Decision:** Keep `AssembledLaplacian(InputType)` as the single public noun,
+but interpret its assembled sparse payload as the weak-form stiffness matrix
+`S_k` rather than claiming the strong operator matrix `Δ_k` itself is sparse
+for every degree. The object's `apply` method continues to represent the strong
+operator action `Δ_k`, using direct assembled data where that is honest and
+composed or factorized paths where necessary.
+
+**Alternatives considered:**
+1. Treat the strong operator matrix as the thing to assemble for every degree:
+   rejected because for interior degrees the factor `M_k^{-1}` generally
+   destroys sparsity, so "direct sparse assembly" would be mathematically
+   false.
+2. Introduce a second public type just for stiffness matrices: rejected
+   because the project is pre-release and this would create parallel nouns for
+   one structural operator family before the broader system-builder shape is
+   clear.
+
+**Rationale:** The weak stiffness is the sparse object we can honestly assemble
+and reuse across supported degrees, including the current 1-form solve path
+that previously probed the strong operator column-by-column. Keeping one public
+`AssembledLaplacian` value preserves the operator-level API while separating
+the mathematically sparse assembled state from the potentially dense strong
+action.

--- a/src/operators/laplacian.zig
+++ b/src/operators/laplacian.zig
@@ -55,9 +55,9 @@ pub fn AssembledLaplacian(comptime InputType: type) type {
         const MeshType = InputType.MeshT;
         const k = InputType.degree;
 
-    mesh: *const MeshType,
-    stiffness: sparse.CsrMatrix(f64),
-    left_scaling: []f64,
+        mesh: *const MeshType,
+        stiffness: sparse.CsrMatrix(f64),
+        left_scaling: []f64,
 
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
             allocator.free(self.left_scaling);
@@ -121,15 +121,72 @@ fn assemble_zero_form_stiffness(
     const d0 = mesh.boundary(1);
     const m1 = mesh.whitney_mass(1);
 
-    var assembler = sparse.TripletAssembler(f64).init(mesh.num_vertices(), mesh.num_vertices());
+    return assemble_incidence_sparse_mass_stiffness(
+        allocator,
+        d0,
+        m1,
+        mesh.num_vertices(),
+    );
+}
+
+fn assemble_one_form_stiffness(
+    allocator: std.mem.Allocator,
+    mesh: anytype,
+) !sparse.CsrMatrix(f64) {
+    const MeshType = @TypeOf(mesh.*);
+    comptime std.debug.assert(MeshType.topological_dimension >= 2);
+
+    var assembler = sparse.TripletAssembler(f64).init(mesh.num_edges(), mesh.num_edges());
     defer assembler.deinit(allocator);
 
-    for (0..m1.n_rows) |edge_i| {
-        const incidence_i = d0.row(@intCast(edge_i));
-        const mass_row = m1.row(@intCast(edge_i));
+    if (MeshType.topological_dimension == 2) {
+        try add_incidence_diagonal_stiffness(
+            allocator,
+            &assembler,
+            mesh.boundary(2),
+            mesh.simplices(2).items(.volume),
+            .inverse_primal_volume,
+        );
+    } else {
+        try add_incidence_sparse_mass_stiffness_into(
+            allocator,
+            &assembler,
+            mesh.boundary(2),
+            mesh.whitney_mass(2),
+        );
+    }
+
+    try add_one_form_grad_div_stiffness(allocator, &assembler, mesh);
+    return assembler.build(allocator);
+}
+
+fn assemble_incidence_sparse_mass_stiffness(
+    allocator: std.mem.Allocator,
+    boundary: anytype,
+    mass: sparse.CsrMatrix(f64),
+    output_count: u32,
+) !sparse.CsrMatrix(f64) {
+    var assembler = sparse.TripletAssembler(f64).init(output_count, output_count);
+    defer assembler.deinit(allocator);
+    try add_incidence_sparse_mass_stiffness_into(allocator, &assembler, boundary, mass);
+    return assembler.build(allocator);
+}
+
+fn add_incidence_sparse_mass_stiffness_into(
+    allocator: std.mem.Allocator,
+    assembler: *sparse.TripletAssembler(f64),
+    boundary: anytype,
+    mass: sparse.CsrMatrix(f64),
+) !void {
+    std.debug.assert(boundary.n_rows == mass.n_rows);
+    std.debug.assert(boundary.n_rows == mass.n_cols);
+
+    for (0..mass.n_rows) |row_i| {
+        const incidence_i = boundary.row(@intCast(row_i));
+        const mass_row = mass.row(@intCast(row_i));
 
         for (mass_row.cols, mass_row.vals) |edge_j, mass_ij| {
-            const incidence_j = d0.row(edge_j);
+            const incidence_j = boundary.row(edge_j);
 
             for (incidence_i.cols, 0..) |vertex_i, entry_i| {
                 const sign_i = incidence_i.sign(entry_i);
@@ -142,17 +199,139 @@ fn assemble_zero_form_stiffness(
             }
         }
     }
-
-    return assembler.build(allocator);
 }
 
-fn assemble_one_form_stiffness(
+const DiagonalAssemblyMode = enum {
+    primal_volume,
+    inverse_primal_volume,
+};
+
+fn add_incidence_diagonal_stiffness(
     allocator: std.mem.Allocator,
+    assembler: *sparse.TripletAssembler(f64),
+    boundary: anytype,
+    diagonal_source: []const f64,
+    comptime mode: DiagonalAssemblyMode,
+) !void {
+    std.debug.assert(boundary.n_rows == diagonal_source.len);
+
+    for (0..boundary.n_rows) |row_idx| {
+        const row = boundary.row(@intCast(row_idx));
+        const diagonal = switch (mode) {
+            .primal_volume => diagonal_source[row_idx],
+            .inverse_primal_volume => blk: {
+                std.debug.assert(diagonal_source[row_idx] != 0.0);
+                break :blk 1.0 / diagonal_source[row_idx];
+            },
+        };
+
+        for (row.cols, 0..) |col_i, entry_i| {
+            const sign_i = row.sign(entry_i);
+            const left = diagonal * @as(f64, @floatFromInt(sign_i));
+            for (row.cols, 0..) |col_j, entry_j| {
+                const sign_j = row.sign(entry_j);
+                try assembler.addEntry(
+                    allocator,
+                    col_i,
+                    col_j,
+                    left * @as(f64, @floatFromInt(sign_j)),
+                );
+            }
+        }
+    }
+}
+
+fn add_one_form_grad_div_stiffness(
+    allocator: std.mem.Allocator,
+    assembler: *sparse.TripletAssembler(f64),
     mesh: anytype,
-) !sparse.CsrMatrix(f64) {
-    _ = allocator;
-    _ = mesh;
-    @panic("assemble_one_form_stiffness not yet implemented");
+) !void {
+    const vertex_count = mesh.num_vertices();
+    const edge_count = mesh.num_edges();
+    const d0 = mesh.boundary(1);
+    const m1 = mesh.whitney_mass(1);
+    const star0_inv = try assemble_zero_form_star_inverse_diag(allocator, mesh);
+    defer allocator.free(star0_inv);
+
+    const incident_count = try allocator.alloc(u32, vertex_count);
+    defer allocator.free(incident_count);
+    @memset(incident_count, 0);
+
+    for (0..d0.n_rows) |edge_idx| {
+        const row = d0.row(@intCast(edge_idx));
+        for (row.cols) |vertex_idx| {
+            incident_count[vertex_idx] += 1;
+        }
+    }
+
+    const offsets = try allocator.alloc(u32, vertex_count + 1);
+    defer allocator.free(offsets);
+    offsets[0] = 0;
+    for (0..vertex_count) |vertex_idx| {
+        offsets[vertex_idx + 1] = offsets[vertex_idx] + incident_count[vertex_idx];
+    }
+
+    const total_incidence = offsets[vertex_count];
+    const incident_edges = try allocator.alloc(u32, total_incidence);
+    defer allocator.free(incident_edges);
+    const incident_signs = try allocator.alloc(i8, total_incidence);
+    defer allocator.free(incident_signs);
+
+    const write_offsets = try allocator.dupe(u32, offsets[0..vertex_count]);
+    defer allocator.free(write_offsets);
+
+    for (0..d0.n_rows) |edge_idx| {
+        const row = d0.row(@intCast(edge_idx));
+        for (row.cols, 0..) |vertex_idx, entry_idx| {
+            const write_idx = write_offsets[vertex_idx];
+            incident_edges[write_idx] = @intCast(edge_idx);
+            incident_signs[write_idx] = row.sign(entry_idx);
+            write_offsets[vertex_idx] += 1;
+        }
+    }
+
+    const accumulated = try allocator.alloc(f64, edge_count);
+    defer allocator.free(accumulated);
+    @memset(accumulated, 0.0);
+
+    const touched = try allocator.alloc(u32, edge_count);
+    defer allocator.free(touched);
+    const touched_flags = try allocator.alloc(bool, edge_count);
+    defer allocator.free(touched_flags);
+    @memset(touched_flags, false);
+
+    for (0..vertex_count) |vertex_idx| {
+        var touched_count: usize = 0;
+        const weight = star0_inv[vertex_idx];
+
+        for (offsets[vertex_idx]..offsets[vertex_idx + 1]) |incident_idx| {
+            const edge_i = incident_edges[incident_idx];
+            const sign_i = incident_signs[incident_idx];
+            const mass_row = m1.row(edge_i);
+
+            for (mass_row.cols, mass_row.vals) |edge_j, mass_ij| {
+                if (!touched_flags[edge_j]) {
+                    touched_flags[edge_j] = true;
+                    touched[touched_count] = edge_j;
+                    touched_count += 1;
+                }
+                accumulated[edge_j] += @as(f64, @floatFromInt(sign_i)) * mass_ij;
+            }
+        }
+
+        for (touched[0..touched_count]) |edge_i| {
+            const value_i = accumulated[edge_i];
+            const left = weight * value_i;
+            for (touched[0..touched_count]) |edge_j| {
+                try assembler.addEntry(allocator, edge_i, edge_j, left * accumulated[edge_j]);
+            }
+        }
+
+        for (touched[0..touched_count]) |edge_idx| {
+            touched_flags[edge_idx] = false;
+            accumulated[edge_idx] = 0.0;
+        }
+    }
 }
 
 fn assemble_zero_form_star_inverse_diag(

--- a/src/operators/laplacian.zig
+++ b/src/operators/laplacian.zig
@@ -239,7 +239,9 @@ pub fn laplacian_composed(
 
 const Mesh2D = topology.Mesh(2, 2);
 const MeshSurface = topology.Mesh(3, 2);
+const Mesh3D = topology.Mesh(3, 3);
 const PrimalC0 = cochain.Cochain(Mesh2D, 0, cochain.Primal);
+const PrimalC3D1 = cochain.Cochain(Mesh3D, 1, cochain.Primal);
 
 test "Δ₀ of constant 0-form is zero" {
     const allocator = testing.allocator;
@@ -604,6 +606,54 @@ test "Δ₁ is symmetric in ★₁-weighted inner product (500 trials)" {
         // CG solve introduces ~1e-10 relative residual per solve, and the
         // Laplacian does two solves. Loosen tolerance accordingly.
         try testing.expectApproxEqRel(inner_lap_f_g, inner_f_lap_g, 1e-6);
+    }
+}
+
+test "assembled Δ₁ stiffness is populated on tetrahedral meshes" {
+    const allocator = testing.allocator;
+
+    var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 2, 1.0, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const operator_context = try context.OperatorContext(Mesh3D).init(allocator, &mesh);
+    defer operator_context.deinit();
+
+    const laplacian = try operator_context.laplacian(1);
+    try testing.expectEqual(mesh.num_edges(), laplacian.stiffness.n_rows);
+    try testing.expectEqual(mesh.num_edges(), laplacian.stiffness.n_cols);
+    try testing.expect(laplacian.stiffness.nnz() > 0);
+}
+
+test "assembled Δ₁ stiffness matches Whitney-weighted strong Laplacian on tetrahedral meshes" {
+    const allocator = testing.allocator;
+
+    var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 2, 1.0, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const operator_context = try context.OperatorContext(Mesh3D).init(allocator, &mesh);
+    defer operator_context.deinit();
+
+    const laplacian = try operator_context.laplacian(1);
+
+    var omega = try PrimalC3D1.init(allocator, &mesh);
+    defer omega.deinit(allocator);
+    for (omega.values, 0..) |*value, edge_idx| {
+        value.* = @as(f64, @floatFromInt(edge_idx + 1)) / 17.0;
+    }
+
+    var strong = try laplacian.apply(allocator, omega);
+    defer strong.deinit(allocator);
+
+    const weighted_strong = try allocator.alloc(f64, mesh.num_edges());
+    defer allocator.free(weighted_strong);
+    sparse.spmv(mesh.whitney_mass(1), strong.values, weighted_strong);
+
+    const assembled = try allocator.alloc(f64, mesh.num_edges());
+    defer allocator.free(assembled);
+    sparse.spmv(laplacian.stiffness, omega.values, assembled);
+
+    for (assembled, weighted_strong) |actual, expected| {
+        try testing.expectApproxEqRel(expected, actual, 1e-9);
     }
 }
 

--- a/src/operators/laplacian.zig
+++ b/src/operators/laplacian.zig
@@ -39,9 +39,14 @@ fn validatePrimalCochainInput(comptime InputType: type) void {
 
 /// Stored Laplacian operator specialized to a primal k-cochain type.
 ///
-/// For k=0, the assembled form keeps the sparse stiffness matrix
-/// S = D₀ᵀ M₁ D₀ and the diagonal ★₀⁻¹ scaling separate so application is
-/// one SpMV plus pointwise scaling.
+/// `stiffness` is the weak-form sparse matrix assembled directly from DEC/FEEC
+/// building blocks. For k=0 this is `S = D₀ᵀ M₁ D₀`; for interior degrees it is
+/// the sparse matrix satisfying `S_k ω = M_k (Δ_k ω)`.
+///
+/// `apply` remains the strong operator action. For k=0, the assembled form
+/// keeps the diagonal `★₀⁻¹` scaling separate so application is one SpMV plus
+/// pointwise scaling. Other degrees may still apply through composition even
+/// when a sparse weak-form stiffness has been assembled.
 pub fn AssembledLaplacian(comptime InputType: type) type {
     comptime validatePrimalCochainInput(InputType);
 
@@ -50,9 +55,9 @@ pub fn AssembledLaplacian(comptime InputType: type) type {
         const MeshType = InputType.MeshT;
         const k = InputType.degree;
 
-        mesh: *const MeshType,
-        stiffness: sparse.CsrMatrix(f64),
-        left_scaling: []f64,
+    mesh: *const MeshType,
+    stiffness: sparse.CsrMatrix(f64),
+    left_scaling: []f64,
 
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
             allocator.free(self.left_scaling);
@@ -91,6 +96,7 @@ pub fn assemble_for_degree(
 ) !AssembledLaplacian(cochain.Cochain(MeshType, k, cochain.Primal)) {
     var stiffness = switch (k) {
         0 => try assemble_zero_form_stiffness(allocator, mesh),
+        1 => try assemble_one_form_stiffness(allocator, mesh),
         else => try sparse.CsrMatrix(f64).init(allocator, 0, 0, 0),
     };
     errdefer stiffness.deinit(allocator);
@@ -138,6 +144,15 @@ fn assemble_zero_form_stiffness(
     }
 
     return assembler.build(allocator);
+}
+
+fn assemble_one_form_stiffness(
+    allocator: std.mem.Allocator,
+    mesh: anytype,
+) !sparse.CsrMatrix(f64) {
+    _ = allocator;
+    _ = mesh;
+    @panic("assemble_one_form_stiffness not yet implemented");
 }
 
 fn assemble_zero_form_star_inverse_diag(

--- a/src/operators/poisson.zig
+++ b/src/operators/poisson.zig
@@ -77,6 +77,7 @@ pub fn solve_one_form_dirichlet(
     boundary_values: []const f64,
     config: SolveConfig,
 ) !SolveResult {
+    _ = MeshType;
     const mesh = operator_context.mesh;
     std.debug.assert(forcing_values.len == mesh.num_edges());
     std.debug.assert(boundary_values.len == mesh.num_edges());
@@ -84,13 +85,15 @@ pub fn solve_one_form_dirichlet(
     const boundary_mask = try mesh.boundary_mask(allocator, 1);
     defer allocator.free(boundary_mask);
 
-    var full_matrix = try assemble_one_form_matrix(MeshType, allocator, operator_context);
-    defer full_matrix.deinit(allocator);
+    const laplacian = try operator_context.laplacian(1);
+    const full_rhs = try allocator.alloc(f64, mesh.num_edges());
+    defer allocator.free(full_rhs);
+    sparse.spmv(mesh.whitney_mass(1), forcing_values, full_rhs);
 
     return solve_dirichlet_reduced_system(
         allocator,
-        full_matrix,
-        forcing_values,
+        laplacian.stiffness,
+        full_rhs,
         boundary_mask,
         boundary_values,
         config,
@@ -126,39 +129,6 @@ fn solve_dirichlet_reduced_system(
         .solution = solution,
         .cg_result = cg_result,
     };
-}
-
-fn assemble_one_form_matrix(
-    comptime MeshType: type,
-    allocator: std.mem.Allocator,
-    operator_context: anytype,
-) !sparse.CsrMatrix(f64) {
-    const OneForm = cochain.Cochain(MeshType, 1, cochain.Primal);
-    const edge_count = operator_context.mesh.num_edges();
-
-    const laplacian = try operator_context.laplacian(1);
-
-    var basis = try OneForm.init(allocator, operator_context.mesh);
-    defer basis.deinit(allocator);
-
-    var triplets = sparse.TripletAssembler(f64).init(edge_count, edge_count);
-    defer triplets.deinit(allocator);
-
-    for (0..edge_count) |col_idx_usize| {
-        const col_idx: u32 = @intCast(col_idx_usize);
-        @memset(basis.values, 0.0);
-        basis.values[col_idx] = 1.0;
-
-        var image = try laplacian.apply(allocator, basis);
-        defer image.deinit(allocator);
-
-        for (image.values, 0..) |value, row_idx_usize| {
-            if (@abs(value) <= 1e-14) continue;
-            try triplets.addEntry(allocator, @intCast(row_idx_usize), col_idx, value);
-        }
-    }
-
-    return triplets.build(allocator);
 }
 
 fn exact_solution_2d(coords: [2]f64) f64 {


### PR DESCRIPTION
Closes #148

## What

Add direct sparse assembly for primal Laplacian stiffness through the existing generic `OperatorContext.laplacian(k)` surface, and migrate the 1-form Dirichlet solve path off basis probing.

## Acceptance criterion

A caller can assemble a primal k-form Laplacian through one generic public operator/assembler API, without basis probing.

Concrete proof points:
- [x] the surface scalar path (`Mesh(3,2)`, primal 0-form) continues to use the generic direct assembly path
- [x] an additional supported `(mesh, degree)` case now uses the same public assembly surface: primal 1-forms on current meshes assemble a direct sparse weak-form stiffness
- [x] existing convergence/property tests still pass with the same or better numerical behavior

## Tasks

- [x] Write property tests encoding the acceptance criterion
- [x] Design public API (stubs)
- [x] Implement
- [x] CI green

## Decisions

- `AssembledLaplacian` remains the single public noun.
- Its sparse assembled payload is the weak-form stiffness matrix `S_k`, which is the object we can honestly assemble sparsely for interior degrees.
- The strong operator action `Δ_k` remains available through `apply`, using direct assembled data where appropriate and composed paths where necessary.

## Limitations

- This PR assembles direct sparse stiffness for primal 0-forms and primal 1-forms. Higher-degree direct stiffness assembly is still open where the relevant mass-inverse structure is not yet exposed as an honest sparse assembly path.
- `apply` is still only directly assembled for the existing 0-form path; this PR is about sparse assembly and reuse of the weak-form operator state.
