### PR TITLE
feat(operators): expose explicit DEC and FEEC operator families

### DIFF
--- a/bench/main.zig
+++ b/bench/main.zig
@@ -32,8 +32,8 @@ const SurfaceMesh = flux.topology.Mesh(3, 2);
 const PrimalC0 = flux.forms.Cochain(Mesh2D, 0, flux.forms.Primal);
 const PrimalC1 = flux.forms.Cochain(Mesh2D, 1, flux.forms.Primal);
 const PrimalC2 = flux.forms.Cochain(Mesh2D, 2, flux.forms.Primal);
-const OperatorContext2D = flux.operators.context.OperatorContext(Mesh2D);
-const SurfaceOperatorContext = flux.operators.context.OperatorContext(SurfaceMesh);
+const DecOperatorContext2D = flux.operators.dec.context.OperatorContext(Mesh2D);
+const FeecOperatorContext2D = flux.operators.feec.context.OperatorContext(Mesh2D);
 const MaxwellState2D = maxwell.State(2);
 const ArithmeticMesh = struct {
     pub const embedding_dimension = 2;
@@ -225,7 +225,8 @@ const BenchmarkContext = struct {
     arithmetic_cases: [arithmetic_case_lengths.len]ArithmeticCase,
     cavity_mesh: *Mesh2D,
     cavity_state: MaxwellState2D,
-    operator_context: *OperatorContext2D,
+    dec_operator_context: *DecOperatorContext2D,
+    feec_operator_context: *FeecOperatorContext2D,
     surface_mesh: *SurfaceMesh,
 
     fn init(allocator: std.mem.Allocator, mesh: *Mesh2D) !BenchmarkContext {
@@ -255,19 +256,21 @@ const BenchmarkContext = struct {
         var cavity_state = try MaxwellState2D.init(allocator, cavity_mesh);
         errdefer cavity_state.deinit(allocator);
         try maxwell.seedReferenceMode(2, allocator, &cavity_state, cavityDt(), cavity_domain, cavity_domain);
-        const operator_context = try OperatorContext2D.init(allocator, mesh);
-        errdefer operator_context.deinit();
+        const dec_operator_context = try DecOperatorContext2D.init(allocator, mesh);
+        errdefer dec_operator_context.deinit();
+        const feec_operator_context = try FeecOperatorContext2D.init(allocator, mesh);
+        errdefer feec_operator_context.deinit();
         const surface_mesh = try allocator.create(SurfaceMesh);
         errdefer allocator.destroy(surface_mesh);
         surface_mesh.* = try buildEmbeddedSurfacePatch(allocator, surface_patch_nx, surface_patch_ny);
         errdefer surface_mesh.deinit(allocator);
-        _ = try operator_context.exteriorDerivative(flux.forms.Primal, 0);
-        _ = try operator_context.exteriorDerivative(flux.forms.Primal, 1);
-        _ = try operator_context.hodgeStar(0);
-        _ = try operator_context.hodgeStar(1);
-        _ = try operator_context.hodgeStar(2);
-        _ = try operator_context.hodgeStarInverse(1);
-        _ = try operator_context.laplacian(0);
+        _ = try dec_operator_context.exteriorDerivative(flux.forms.Primal, 0);
+        _ = try dec_operator_context.exteriorDerivative(flux.forms.Primal, 1);
+        _ = try feec_operator_context.hodgeStar(0);
+        _ = try feec_operator_context.hodgeStar(1);
+        _ = try feec_operator_context.hodgeStar(2);
+        _ = try feec_operator_context.hodgeStarInverse(1);
+        _ = try feec_operator_context.laplacian(0);
 
         // Fill with deterministic pseudo-random values.
         var rng = std.Random.DefaultPrng.init(0xBEEF_CAFE);
@@ -288,7 +291,8 @@ const BenchmarkContext = struct {
             .arithmetic_cases = arithmetic_cases,
             .cavity_mesh = cavity_mesh,
             .cavity_state = cavity_state,
-            .operator_context = operator_context,
+            .dec_operator_context = dec_operator_context,
+            .feec_operator_context = feec_operator_context,
             .surface_mesh = surface_mesh,
         };
     }
@@ -296,7 +300,8 @@ const BenchmarkContext = struct {
     fn deinit(self: *BenchmarkContext) void {
         self.surface_mesh.deinit(self.allocator);
         self.allocator.destroy(self.surface_mesh);
-        self.operator_context.deinit();
+        self.feec_operator_context.deinit();
+        self.dec_operator_context.deinit();
         self.cavity_state.deinit(self.allocator);
         self.cavity_mesh.deinit(self.allocator);
         self.allocator.destroy(self.cavity_mesh);
@@ -678,31 +683,31 @@ fn stdoutWriter() @TypeOf((std.fs.File{ .handle = std.posix.STDOUT_FILENO }).dep
 
 /// d₀: exterior derivative on 0-forms (sparse matrix–vector multiply).
 fn benchExteriorDerivativeD0(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.exteriorDerivative(flux.forms.Primal, 0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
+    var result = (ctx.dec_operator_context.exteriorDerivative(flux.forms.Primal, 0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
 /// d₁: exterior derivative on 1-forms.
 fn benchExteriorDerivativeD1(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.exteriorDerivative(flux.forms.Primal, 1) catch unreachable).apply(ctx.allocator, ctx.c1) catch unreachable;
+    var result = (ctx.dec_operator_context.exteriorDerivative(flux.forms.Primal, 1) catch unreachable).apply(ctx.allocator, ctx.c1) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
 /// ★₀: diagonal Hodge star on 0-forms.
 fn benchHodgeStar0(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.hodgeStar(0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
+    var result = (ctx.feec_operator_context.hodgeStar(0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
 /// ★₁: Whitney mass matrix SpMV on 1-forms.
 fn benchHodgeStar1(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.hodgeStar(1) catch unreachable).apply(ctx.allocator, ctx.c1) catch unreachable;
+    var result = (ctx.feec_operator_context.hodgeStar(1) catch unreachable).apply(ctx.allocator, ctx.c1) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
 /// ★₂: diagonal Hodge star on 2-forms.
 fn benchHodgeStar2(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.hodgeStar(2) catch unreachable).apply(ctx.allocator, ctx.c2) catch unreachable;
+    var result = (ctx.feec_operator_context.hodgeStar(2) catch unreachable).apply(ctx.allocator, ctx.c2) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
@@ -714,13 +719,13 @@ fn benchHodgeStarInverse1(ctx: *BenchmarkContext) void {
     var rng = std.Random.DefaultPrng.init(0xDEAD);
     fillRandom(&rng, dual.values);
 
-    var result = (ctx.operator_context.hodgeStarInverse(1) catch unreachable).apply(ctx.allocator, dual) catch unreachable;
+    var result = (ctx.feec_operator_context.hodgeStarInverse(1) catch unreachable).apply(ctx.allocator, dual) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
 /// Δ₀: repeated application via a reused assembled operator.
 fn benchLaplacian0(ctx: *BenchmarkContext) void {
-    var result = (ctx.operator_context.laplacian(0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
+    var result = (ctx.feec_operator_context.laplacian(0) catch unreachable).apply(ctx.allocator, ctx.c0) catch unreachable;
     result.deinit(ctx.allocator);
 }
 
@@ -756,7 +761,7 @@ fn benchMaxwellCavityStep256(ctx: *BenchmarkContext) void {
 }
 
 fn benchSurfaceLaplacianAssemblyDirect(ctx: *BenchmarkContext) void {
-    const operator_context = SurfaceOperatorContext.init(ctx.allocator, ctx.surface_mesh) catch unreachable;
+    const operator_context = flux.operators.feec.context.OperatorContext(SurfaceMesh).init(ctx.allocator, ctx.surface_mesh) catch unreachable;
     defer operator_context.deinit();
     _ = operator_context.laplacian(0) catch unreachable;
 }
@@ -807,13 +812,13 @@ fn arithmeticCompareDefs() [arithmetic_case_lengths.len * 4]ArithmeticCompareDef
 const arithmetic_compare_defs = arithmeticCompareDefs();
 
 const default_benchmarks = [_]BenchmarkDef{
-    .{ .name = "exterior_derivative_d0", .run = benchExteriorDerivativeD0, .scope = .public_library },
-    .{ .name = "exterior_derivative_d1", .run = benchExteriorDerivativeD1, .scope = .public_library },
-    .{ .name = "hodge_star_0", .run = benchHodgeStar0, .scope = .public_library },
-    .{ .name = "hodge_star_1_whitney", .run = benchHodgeStar1, .scope = .public_library },
-    .{ .name = "hodge_star_2", .run = benchHodgeStar2, .scope = .public_library },
-    .{ .name = "hodge_star_inverse_1_cg", .run = benchHodgeStarInverse1, .scope = .public_library },
-    .{ .name = "laplacian_0", .run = benchLaplacian0, .scope = .public_library },
+    .{ .name = "dec_exterior_derivative_d0", .run = benchExteriorDerivativeD0, .scope = .public_library },
+    .{ .name = "dec_exterior_derivative_d1", .run = benchExteriorDerivativeD1, .scope = .public_library },
+    .{ .name = "feec_hodge_star_0", .run = benchHodgeStar0, .scope = .public_library },
+    .{ .name = "feec_hodge_star_1_whitney", .run = benchHodgeStar1, .scope = .public_library },
+    .{ .name = "feec_hodge_star_2", .run = benchHodgeStar2, .scope = .public_library },
+    .{ .name = "feec_hodge_star_inverse_1_cg", .run = benchHodgeStarInverse1, .scope = .public_library },
+    .{ .name = "feec_laplacian_0", .run = benchLaplacian0, .scope = .public_library },
     .{ .name = "laplacian_0_composed", .run = benchLaplacian0Composed, .scope = .public_library },
     .{
         .name = "cochain_add",
@@ -849,7 +854,7 @@ const default_benchmarks = [_]BenchmarkDef{
     },
     .{ .name = "maxwell_cavity_step_256", .run = benchMaxwellCavityStep256, .scope = .shipped_example },
     .{
-        .name = "surface_laplacian_0_assembly_direct",
+        .name = "feec_surface_laplacian_0_assembly_direct",
         .run = benchSurfaceLaplacianAssemblyDirect,
         .class = .info,
         .scope = .public_library,

--- a/examples/diffusion/plane.zig
+++ b/examples/diffusion/plane.zig
@@ -4,7 +4,7 @@ const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
 const linear_system = flux.math.linear_system;
-const operator_context_mod = flux.operators.context;
+const feec_context_mod = flux.operators.feec.context;
 const evolution_mod = flux.integrators.evolution;
 
 pub const Mesh2D = flux.topology.Mesh(2, 2);
@@ -51,7 +51,7 @@ const HeatSystem = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         mesh: *const Mesh2D,
-        operator_context: *operator_context_mod.OperatorContext(Mesh2D),
+        operator_context: *feec_context_mod.OperatorContext(Mesh2D),
         dt: f64,
     ) !HeatSystem {
         const laplacian = try operator_context.laplacian(0);
@@ -140,7 +140,7 @@ fn simulateCase(
     var mesh = try Mesh2D.plane(allocator, config.grid, config.grid, config.domain, config.domain);
     defer mesh.deinit(allocator);
 
-    const operator_context = try operator_context_mod.OperatorContext(Mesh2D).init(allocator, &mesh);
+    const operator_context = try feec_context_mod.OperatorContext(Mesh2D).init(allocator, &mesh);
     defer operator_context.deinit();
 
     const total_time = final_time_override orelse (@as(f64, @floatFromInt(config.steps)) * config.dt());

--- a/examples/diffusion/sphere.zig
+++ b/examples/diffusion/sphere.zig
@@ -4,12 +4,12 @@ const common = @import("examples_common");
 
 const sparse = flux.math.sparse;
 const linear_system = flux.math.linear_system;
-const operator_context_mod = flux.operators.context;
+const feec_context_mod = flux.operators.feec.context;
 const evolution_mod = flux.integrators.evolution;
 
 pub const SurfaceMesh = flux.topology.Mesh(3, 2);
 pub const VertexField = flux.forms.Cochain(SurfaceMesh, 0, flux.forms.Primal);
-const SurfaceOperatorContext = operator_context_mod.OperatorContext(SurfaceMesh);
+const SurfaceOperatorContext = feec_context_mod.OperatorContext(SurfaceMesh);
 
 pub const ConfigImpl = struct {
     refinement: u32 = 0,

--- a/examples/euler/three_dimensional.zig
+++ b/examples/euler/three_dimensional.zig
@@ -3,7 +3,8 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const poisson = flux.operators.poisson;
-const operator_context_mod = flux.operators.context;
+const dec_context_mod = flux.operators.dec.context;
+const feec_context_mod = flux.operators.feec.context;
 const observers = flux.operators.observers;
 const wedge_product = flux.operators.wedge_product;
 const evolution_mod = flux.integrators.evolution;
@@ -34,7 +35,8 @@ pub const RunResultImpl = struct {
 
 pub const StateImpl = struct {
     mesh: *const Mesh,
-    operators: *operator_context_mod.OperatorContext(Mesh),
+    dec_operators: *dec_context_mod.OperatorContext(Mesh),
+    feec_operators: *feec_context_mod.OperatorContext(Mesh),
     velocity: Velocity,
     vorticity: Vorticity,
     boundary_velocity: []f64,
@@ -47,12 +49,14 @@ pub const StateImpl = struct {
         var vorticity = try Vorticity.init(allocator, mesh);
         errdefer vorticity.deinit(allocator);
 
-        const operators = try operator_context_mod.OperatorContext(Mesh).init(allocator, mesh);
-        errdefer operators.deinit();
-        _ = try operators.codifferential(2);
-        _ = try operators.codifferential(3);
-        _ = try operators.exteriorDerivative(flux.forms.Primal, 1);
-        _ = try operators.laplacian(1);
+        const dec_operators = try dec_context_mod.OperatorContext(Mesh).init(allocator, mesh);
+        errdefer dec_operators.deinit();
+        const feec_operators = try feec_context_mod.OperatorContext(Mesh).init(allocator, mesh);
+        errdefer feec_operators.deinit();
+        _ = try feec_operators.codifferential(2);
+        _ = try feec_operators.codifferential(3);
+        _ = try dec_operators.exteriorDerivative(flux.forms.Primal, 1);
+        _ = try feec_operators.laplacian(1);
 
         const boundary_velocity = try allocator.alloc(f64, mesh.num_edges());
         errdefer allocator.free(boundary_velocity);
@@ -64,7 +68,8 @@ pub const StateImpl = struct {
 
         return .{
             .mesh = mesh,
-            .operators = operators,
+            .dec_operators = dec_operators,
+            .feec_operators = feec_operators,
             .velocity = velocity,
             .vorticity = vorticity,
             .boundary_velocity = boundary_velocity,
@@ -77,7 +82,8 @@ pub const StateImpl = struct {
         allocator.free(self.boundary_velocity);
         self.vorticity.deinit(allocator);
         self.velocity.deinit(allocator);
-        self.operators.deinit();
+        self.feec_operators.deinit();
+        self.dec_operators.deinit();
     }
 };
 
@@ -147,14 +153,14 @@ pub fn stepImpl(allocator: std.mem.Allocator, state: *StateImpl, dt: f64) !void 
     _ = dt;
     try recoverVelocityFromVorticity(allocator, state);
 
-    var vorticity = try (try state.operators.exteriorDerivative(flux.forms.Primal, 1)).apply(allocator, state.velocity);
+    var vorticity = try (try state.dec_operators.exteriorDerivative(flux.forms.Primal, 1)).apply(allocator, state.velocity);
     defer vorticity.deinit(allocator);
     @memcpy(state.vorticity.values, vorticity.values);
 
     var advection_density = try wedge_product.wedge(allocator, state.velocity, state.vorticity);
     defer advection_density.deinit(allocator);
 
-    var transport = try (try state.operators.codifferential(3)).apply(allocator, advection_density);
+    var transport = try (try state.feec_operators.codifferential(3)).apply(allocator, advection_density);
     defer transport.deinit(allocator);
 }
 
@@ -185,12 +191,12 @@ pub fn seedReferenceMode(allocator: std.mem.Allocator, state: *StateImpl) !void 
         value.* = field[0] * tangent[0] + field[1] * tangent[1] + field[2] * tangent[2];
     }
 
-    var vorticity = try (try state.operators.exteriorDerivative(flux.forms.Primal, 1)).apply(allocator, state.velocity);
+    var vorticity = try (try state.dec_operators.exteriorDerivative(flux.forms.Primal, 1)).apply(allocator, state.velocity);
     defer vorticity.deinit(allocator);
     @memcpy(state.vorticity.values, vorticity.values);
     @memcpy(state.boundary_velocity, state.velocity.values);
 
-    var forcing = try (try state.operators.laplacian(1)).apply(allocator, state.velocity);
+    var forcing = try (try state.feec_operators.laplacian(1)).apply(allocator, state.velocity);
     defer forcing.deinit(allocator);
     @memcpy(state.velocity_forcing, forcing.values);
 }
@@ -223,7 +229,7 @@ fn recoverVelocityFromVorticity(allocator: std.mem.Allocator, state: *StateImpl)
     var solve = try poisson.solve_one_form_dirichlet(
         Mesh,
         allocator,
-        state.operators,
+        state.feec_operators,
         state.velocity_forcing,
         state.boundary_velocity,
         .{

--- a/examples/euler/two_dimensional.zig
+++ b/examples/euler/two_dimensional.zig
@@ -4,7 +4,7 @@ const common = @import("examples_common");
 
 const poisson = flux.operators.poisson;
 const flux_io = flux.io;
-const operator_context_mod = flux.operators.context;
+const feec_context_mod = flux.operators.feec.context;
 const evolution_mod = flux.integrators.evolution;
 
 pub const Mesh = flux.topology.Mesh(2, 2);
@@ -46,7 +46,7 @@ pub const StateImpl = struct {
     };
 
     mesh: *const Mesh,
-    operators: *operator_context_mod.OperatorContext(Mesh),
+    feec_operators: *feec_context_mod.OperatorContext(Mesh),
     stream_function: VertexVorticity,
     vorticity: FaceVorticity,
     tracer: FaceTracer,
@@ -63,9 +63,9 @@ pub const StateImpl = struct {
         var tracer = try FaceTracer.init(allocator, mesh);
         errdefer tracer.deinit(allocator);
 
-        const operators = try operator_context_mod.OperatorContext(Mesh).init(allocator, mesh);
-        errdefer operators.deinit();
-        _ = try operators.laplacian(0);
+        const feec_operators = try feec_context_mod.OperatorContext(Mesh).init(allocator, mesh);
+        errdefer feec_operators.deinit();
+        _ = try feec_operators.laplacian(0);
 
         const face_velocity = try allocator.alloc(Vec2, mesh.num_faces());
         errdefer allocator.free(face_velocity);
@@ -76,7 +76,7 @@ pub const StateImpl = struct {
 
         return .{
             .mesh = mesh,
-            .operators = operators,
+            .feec_operators = feec_operators,
             .stream_function = stream_function,
             .vorticity = vorticity,
             .tracer = tracer,
@@ -91,7 +91,7 @@ pub const StateImpl = struct {
         self.tracer.deinit(allocator);
         self.vorticity.deinit(allocator);
         self.stream_function.deinit(allocator);
-        self.operators.deinit();
+        self.feec_operators.deinit();
     }
 };
 
@@ -312,7 +312,7 @@ fn recoverStreamFunction(allocator: std.mem.Allocator, state: *StateImpl) !void 
         forcing_value.* /= weight;
     }
 
-    var solve = try poisson.solve_zero_form_dirichlet(Mesh, allocator, state.operators, forcing, boundary, .{});
+    var solve = try poisson.solve_zero_form_dirichlet(Mesh, allocator, state.feec_operators, forcing, boundary, .{});
     defer solve.deinit(allocator);
     @memcpy(state.stream_function.values, solve.solution);
 }

--- a/examples/maxwell/reference.zig
+++ b/examples/maxwell/reference.zig
@@ -4,7 +4,8 @@ const common = @import("examples_common");
 const runtime = @import("runtime.zig");
 
 const cochain = flux.forms;
-const operator_context_mod = flux.operators.context;
+const dec_context_mod = flux.operators.dec.context;
+const feec_context_mod = flux.operators.feec.context;
 
 pub fn project_te10_e(mesh: *const runtime.Mesh2D, values: []f64, t: f64, domain_length: f64) void {
     const edge_verts = mesh.simplices(1).items(.vertices);
@@ -34,10 +35,10 @@ pub fn project_te10_b(mesh: *const runtime.Mesh2D, values: []f64, t: f64, domain
 }
 
 fn discrete_energy_from_arrays(allocator: std.mem.Allocator, mesh: *const runtime.Mesh2D, e_vals: []const f64, b_vals: []const f64) !f64 {
-    const operator_context = try operator_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, mesh);
-    defer operator_context.deinit();
-    _ = try operator_context.hodgeStar(1);
-    _ = try operator_context.hodgeStar(2);
+    const feec_operators = try feec_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, mesh);
+    defer feec_operators.deinit();
+    _ = try feec_operators.hodgeStar(1);
+    _ = try feec_operators.hodgeStar(2);
 
     var E = try runtime.MaxwellState2D.OneForm.init(allocator, mesh);
     defer E.deinit(allocator);
@@ -50,8 +51,8 @@ fn discrete_energy_from_arrays(allocator: std.mem.Allocator, mesh: *const runtim
     const state = struct {
         E: runtime.MaxwellState2D.OneForm,
         B: runtime.MaxwellState2D.TwoForm,
-        operators: *operator_context_mod.OperatorContext(runtime.Mesh2D),
-    }{ .E = E, .B = B, .operators = operator_context };
+        feec_operators: *feec_context_mod.OperatorContext(runtime.Mesh2D),
+    }{ .E = E, .B = B, .feec_operators = feec_operators };
     return runtime.electromagnetic_energy(allocator, state);
 }
 
@@ -81,24 +82,26 @@ pub fn run_cavity_energy_drift(allocator: std.mem.Allocator, grid_n: u32, final_
 pub fn compute_te10_eigenvalue(allocator: std.mem.Allocator, grid_n: u32, domain_length: f64) !f64 {
     var mesh = try runtime.Mesh2D.plane(allocator, grid_n, grid_n, domain_length, domain_length);
     defer mesh.deinit(allocator);
-    const operator_context = try operator_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, &mesh);
-    defer operator_context.deinit();
-    _ = try operator_context.exteriorDerivative(cochain.Primal, 1);
-    _ = try operator_context.hodgeStar(1);
-    _ = try operator_context.hodgeStar(2);
+    const dec_operators = try dec_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, &mesh);
+    defer dec_operators.deinit();
+    const feec_operators = try feec_context_mod.OperatorContext(runtime.Mesh2D).init(allocator, &mesh);
+    defer feec_operators.deinit();
+    _ = try dec_operators.exteriorDerivative(cochain.Primal, 1);
+    _ = try feec_operators.hodgeStar(1);
+    _ = try feec_operators.hodgeStar(2);
 
     var E = try runtime.MaxwellState2D.OneForm.init(allocator, &mesh);
     defer E.deinit(allocator);
     project_te10_e(&mesh, E.values, domain_length / 2.0, domain_length);
 
-    var dE = try (try operator_context.exteriorDerivative(cochain.Primal, 1)).apply(allocator, E);
+    var dE = try (try dec_operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, E);
     defer dE.deinit(allocator);
-    var star_dE = try (try operator_context.hodgeStar(2)).apply(allocator, dE);
+    var star_dE = try (try feec_operators.hodgeStar(2)).apply(allocator, dE);
     defer star_dE.deinit(allocator);
     var numerator: f64 = 0.0;
     for (dE.values, star_dE.values) |de, sde| numerator += de * sde;
 
-    var star_E = try (try operator_context.hodgeStar(1)).apply(allocator, E);
+    var star_E = try (try feec_operators.hodgeStar(1)).apply(allocator, E);
     defer star_E.deinit(allocator);
     var denominator: f64 = 0.0;
     for (E.values, star_E.values) |e, se| denominator += e * se;
@@ -173,7 +176,7 @@ pub fn seedTm110Mode(allocator: std.mem.Allocator, state: anytype, dt: f64, widt
     var potential = try @TypeOf(state.*).OneForm.init(allocator, state.mesh);
     defer potential.deinit(allocator);
     project_tm110_potential(state.mesh, potential.values, -dt / 2.0, width, height);
-    var exact_flux = try (try state.operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, potential);
+    var exact_flux = try (try state.dec_operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, potential);
     defer exact_flux.deinit(allocator);
     @memcpy(state.B.values, exact_flux.values);
 }
@@ -192,7 +195,7 @@ pub fn writeSnapshot(allocator: std.mem.Allocator, writer: anytype, state: anyty
 }
 
 pub fn divergenceNorm3D(allocator: std.mem.Allocator, state: anytype) !f64 {
-    var divergence = try (try state.operators.exteriorDerivative(cochain.Primal, 2)).apply(allocator, state.B);
+    var divergence = try (try state.dec_operators.exteriorDerivative(cochain.Primal, 2)).apply(allocator, state.B);
     defer divergence.deinit(allocator);
     return std.math.sqrt(divergence.norm_squared());
 }
@@ -200,25 +203,27 @@ pub fn divergenceNorm3D(allocator: std.mem.Allocator, state: anytype) !f64 {
 pub fn compute_tm110_eigenvalue(allocator: std.mem.Allocator, nx: u32, ny: u32, nz: u32, width: f64, height: f64, depth: f64) !f64 {
     var mesh = try runtime.Mesh3D.uniform_tetrahedral_grid(allocator, nx, ny, nz, width, height, depth);
     defer mesh.deinit(allocator);
-    const operator_context = try operator_context_mod.OperatorContext(runtime.Mesh3D).init(allocator, &mesh);
-    defer operator_context.deinit();
-    _ = try operator_context.exteriorDerivative(cochain.Primal, 1);
-    _ = try operator_context.hodgeStar(1);
-    _ = try operator_context.hodgeStar(2);
+    const dec_operators = try dec_context_mod.OperatorContext(runtime.Mesh3D).init(allocator, &mesh);
+    defer dec_operators.deinit();
+    const feec_operators = try feec_context_mod.OperatorContext(runtime.Mesh3D).init(allocator, &mesh);
+    defer feec_operators.deinit();
+    _ = try dec_operators.exteriorDerivative(cochain.Primal, 1);
+    _ = try feec_operators.hodgeStar(1);
+    _ = try feec_operators.hodgeStar(2);
 
     var E = try runtime.MaxwellState3D.OneForm.init(allocator, &mesh);
     defer E.deinit(allocator);
     const omega = tm110AngularFrequency(width, height);
     project_tm110_e(&mesh, E.values, std.math.pi / (2.0 * omega), width, height);
 
-    var dE = try (try operator_context.exteriorDerivative(cochain.Primal, 1)).apply(allocator, E);
+    var dE = try (try dec_operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, E);
     defer dE.deinit(allocator);
-    var star_dE = try (try operator_context.hodgeStar(2)).apply(allocator, dE);
+    var star_dE = try (try feec_operators.hodgeStar(2)).apply(allocator, dE);
     defer star_dE.deinit(allocator);
     var numerator: f64 = 0.0;
     for (dE.values, star_dE.values) |lhs, rhs| numerator += lhs * rhs;
 
-    var star_E = try (try operator_context.hodgeStar(1)).apply(allocator, E);
+    var star_E = try (try feec_operators.hodgeStar(1)).apply(allocator, E);
     defer star_E.deinit(allocator);
     var denominator: f64 = 0.0;
     for (E.values, star_E.values) |lhs, rhs| denominator += lhs * rhs;

--- a/examples/maxwell/runtime.zig
+++ b/examples/maxwell/runtime.zig
@@ -3,7 +3,8 @@ const flux = @import("flux");
 
 const cochain = flux.forms;
 const topology = flux.topology;
-const operator_context_mod = flux.operators.context;
+const dec_context_mod = flux.operators.dec.context;
+const feec_context_mod = flux.operators.feec.context;
 
 pub const Mesh2D = topology.Mesh(2, 2);
 pub const Mesh3D = topology.Mesh(3, 3);
@@ -20,7 +21,8 @@ fn MaxwellCore(comptime MeshType: type, comptime Hooks: type) type {
             B: TwoForm,
             J: OneForm,
             mesh: *const MeshType,
-            operators: *operator_context_mod.OperatorContext(MeshType),
+            dec_operators: *dec_context_mod.OperatorContext(MeshType),
+            feec_operators: *feec_context_mod.OperatorContext(MeshType),
             timestep: u64,
 
             pub fn init(allocator: std.mem.Allocator, mesh: *const MeshType) !Self {
@@ -33,22 +35,26 @@ fn MaxwellCore(comptime MeshType: type, comptime Hooks: type) type {
                 var current = try OneForm.init(allocator, mesh);
                 errdefer current.deinit(allocator);
 
-                const operators = try operator_context_mod.OperatorContext(MeshType).init(allocator, mesh);
-                errdefer operators.deinit();
-                try Hooks.primeOperators(operators);
+                const dec_operators = try dec_context_mod.OperatorContext(MeshType).init(allocator, mesh);
+                errdefer dec_operators.deinit();
+                const feec_operators = try feec_context_mod.OperatorContext(MeshType).init(allocator, mesh);
+                errdefer feec_operators.deinit();
+                try Hooks.primeOperators(dec_operators, feec_operators);
 
                 return .{
                     .E = electric,
                     .B = magnetic,
                     .J = current,
                     .mesh = mesh,
-                    .operators = operators,
+                    .dec_operators = dec_operators,
+                    .feec_operators = feec_operators,
                     .timestep = 0,
                 };
             }
 
             pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
-                self.operators.deinit();
+                self.feec_operators.deinit();
+                self.dec_operators.deinit();
                 self.J.deinit(allocator);
                 self.B.deinit(allocator);
                 self.E.deinit(allocator);
@@ -56,7 +62,7 @@ fn MaxwellCore(comptime MeshType: type, comptime Hooks: type) type {
         };
 
         pub fn faradayStep(allocator: std.mem.Allocator, state: anytype, dt: f64) !void {
-            var derivative = try (try state.operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, state.E);
+            var derivative = try (try state.dec_operators.exteriorDerivative(cochain.Primal, 1)).apply(allocator, state.E);
             defer derivative.deinit(allocator);
             derivative.scale(dt);
             state.B.sub(derivative);
@@ -85,18 +91,21 @@ fn hooks2d(comptime MeshType: type) type {
     return struct {
         pub const apply_boundary_in_leapfrog = false;
 
-        pub fn primeOperators(operators: *operator_context_mod.OperatorContext(MeshType)) !void {
-            _ = try operators.exteriorDerivative(cochain.Primal, 1);
-            _ = try operators.exteriorDerivative(cochain.Dual, 0);
-            _ = try operators.hodgeStar(1);
-            _ = try operators.hodgeStar(2);
+        pub fn primeOperators(
+            dec_operators: *dec_context_mod.OperatorContext(MeshType),
+            feec_operators: *feec_context_mod.OperatorContext(MeshType),
+        ) !void {
+            _ = try dec_operators.exteriorDerivative(cochain.Primal, 1);
+            _ = try dec_operators.exteriorDerivative(cochain.Dual, 0);
+            _ = try feec_operators.hodgeStar(1);
+            _ = try feec_operators.hodgeStar(2);
         }
 
         pub fn ampereStep(allocator: std.mem.Allocator, state: anytype, dt: f64) !void {
-            var star_B = try (try state.operators.hodgeStar(2)).apply(allocator, state.B);
+            var star_B = try (try state.feec_operators.hodgeStar(2)).apply(allocator, state.B);
             defer star_B.deinit(allocator);
 
-            var d_star_B = try (try state.operators.exteriorDerivative(cochain.Dual, 0)).apply(allocator, star_B);
+            var d_star_B = try (try state.dec_operators.exteriorDerivative(cochain.Dual, 0)).apply(allocator, star_B);
             defer d_star_B.deinit(allocator);
 
             const edge_volumes = state.mesh.simplices(1).items(.volume);
@@ -113,22 +122,25 @@ fn hooks3d(comptime MeshType: type) type {
     return struct {
         pub const apply_boundary_in_leapfrog = true;
 
-        pub fn primeOperators(operators: *operator_context_mod.OperatorContext(MeshType)) !void {
-            _ = try operators.exteriorDerivative(cochain.Primal, 1);
-            _ = try operators.exteriorDerivative(cochain.Primal, 2);
-            _ = try operators.exteriorDerivative(cochain.Dual, 1);
-            _ = try operators.hodgeStar(2);
-            _ = try operators.hodgeStarInverse(1);
+        pub fn primeOperators(
+            dec_operators: *dec_context_mod.OperatorContext(MeshType),
+            feec_operators: *feec_context_mod.OperatorContext(MeshType),
+        ) !void {
+            _ = try dec_operators.exteriorDerivative(cochain.Primal, 1);
+            _ = try dec_operators.exteriorDerivative(cochain.Primal, 2);
+            _ = try dec_operators.exteriorDerivative(cochain.Dual, 1);
+            _ = try feec_operators.hodgeStar(2);
+            _ = try feec_operators.hodgeStarInverse(1);
         }
 
         pub fn ampereStep(allocator: std.mem.Allocator, state: anytype, dt: f64) !void {
-            var star_b = try (try state.operators.hodgeStar(2)).apply(allocator, state.B);
+            var star_b = try (try state.feec_operators.hodgeStar(2)).apply(allocator, state.B);
             defer star_b.deinit(allocator);
 
-            var derivative = try (try state.operators.exteriorDerivative(cochain.Dual, 1)).apply(allocator, star_b);
+            var derivative = try (try state.dec_operators.exteriorDerivative(cochain.Dual, 1)).apply(allocator, star_b);
             defer derivative.deinit(allocator);
 
-            var curl_b = try (try state.operators.hodgeStarInverse(1)).apply(allocator, derivative);
+            var curl_b = try (try state.feec_operators.hodgeStarInverse(1)).apply(allocator, derivative);
             defer curl_b.deinit(allocator);
 
             for (state.E.values, curl_b.values, state.J.values) |*electric, curl_value, current| {
@@ -190,9 +202,9 @@ pub fn leapfrog_step_3d(allocator: std.mem.Allocator, state: anytype, dt: f64) !
 }
 
 pub fn electromagnetic_energy(allocator: std.mem.Allocator, state: anytype) !f64 {
-    var star_E = try (try state.operators.hodgeStar(1)).apply(allocator, state.E);
+    var star_E = try (try state.feec_operators.hodgeStar(1)).apply(allocator, state.E);
     defer star_E.deinit(allocator);
-    var star_B = try (try state.operators.hodgeStar(2)).apply(allocator, state.B);
+    var star_B = try (try state.feec_operators.hodgeStar(2)).apply(allocator, state.B);
     defer star_B.deinit(allocator);
 
     var e_energy: f64 = 0.0;

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -218,6 +218,33 @@ operators until the benchmark shows a real SpMV win.
    the packed path proves it helps the hot loop. The issue explicitly allows
    not shipping the optimization if decode overhead erases the cache benefit.
 
+## 2026-04-12: Expose explicit DEC and FEEC operator families before splitting internal caches
+
+**Decision:** Make the public operator API explicit with family namespaces
+under `flux.operators.dec` and `flux.operators.feec`, and migrate examples and
+benchmarks to name the family they use. Keep the current shared internal
+`operators/context.zig` cache as an implementation detail for now, wrapped by
+family-specific public contexts.
+
+**Alternatives considered:**
+1. Keep a single public `OperatorContext` until DEC and FEEC internals are
+   fully separated: rejected because it preserves the current mathematical
+   ambiguity in exactly the place users learn the library surface.
+2. Fully split the internal caches in the same issue: rejected because this
+   issue is about public API honesty first. Forcing a complete backend split
+   here would blur the milestone sequencing and make it harder to review the
+   public-noun decision on its own.
+
+**Rationale:** The milestone goal is explicit DEC/FEEC separation with
+principled composition, and examples are a first-class API consumer. Public
+names must therefore become explicit immediately, even if the implementation
+temporarily shares cache ownership behind the scenes. This keeps the user-facing
+math honest, makes mixed examples declare both families explicitly, and leaves
+follow-on issues to split FEEC form-space and weak-form assembly without
+reintroducing another transitional public API.
+
+**Source:** PR #198, issue #193
+
 ## 2026-04-11: Canonical geometry constructors stay honest about supported mesh types
 
 **Decision:** Add `Mesh(3, 2).sphere(allocator, radius, refinement)` as the

--- a/src/operators/dec_context.zig
+++ b/src/operators/dec_context.zig
@@ -1,0 +1,44 @@
+//! Explicit DEC operator context.
+//!
+//! This public family-specific context exposes only DEC/topological operators.
+
+const std = @import("std");
+const base_context = @import("context.zig");
+const cochain = @import("../forms/cochain.zig");
+
+pub fn OperatorContext(comptime MeshType: type) type {
+    return struct {
+        const Self = @This();
+
+        allocator: std.mem.Allocator,
+        mesh: *const MeshType,
+        base: *base_context.OperatorContext(MeshType),
+
+        pub fn init(allocator: std.mem.Allocator, mesh: *const MeshType) !*Self {
+            const self = try allocator.create(Self);
+            errdefer allocator.destroy(self);
+
+            self.* = .{
+                .allocator = allocator,
+                .mesh = mesh,
+                .base = try base_context.OperatorContext(MeshType).init(allocator, mesh),
+            };
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.base.deinit();
+            self.allocator.destroy(self);
+        }
+
+        pub fn exteriorDerivative(
+            self: *Self,
+            comptime Duality: type,
+            comptime k: comptime_int,
+        ) !*const @import("exterior_derivative.zig").AssembledExteriorDerivative(
+            cochain.Cochain(MeshType, k, Duality),
+        ) {
+            return self.base.exteriorDerivative(Duality, k);
+        }
+    };
+}

--- a/src/operators/feec_context.zig
+++ b/src/operators/feec_context.zig
@@ -1,0 +1,70 @@
+//! Explicit FEEC operator context.
+//!
+//! This public family-specific context exposes FEEC/Whitney-based operators.
+
+const std = @import("std");
+const base_context = @import("context.zig");
+const cochain = @import("../forms/cochain.zig");
+
+pub fn OperatorContext(comptime MeshType: type) type {
+    return struct {
+        const Self = @This();
+
+        allocator: std.mem.Allocator,
+        mesh: *const MeshType,
+        base: *base_context.OperatorContext(MeshType),
+
+        pub fn init(allocator: std.mem.Allocator, mesh: *const MeshType) !*Self {
+            const self = try allocator.create(Self);
+            errdefer allocator.destroy(self);
+
+            self.* = .{
+                .allocator = allocator,
+                .mesh = mesh,
+                .base = try base_context.OperatorContext(MeshType).init(allocator, mesh),
+            };
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.base.deinit();
+            self.allocator.destroy(self);
+        }
+
+        pub fn hodgeStar(
+            self: *Self,
+            comptime k: comptime_int,
+        ) !*const @import("hodge_star.zig").AssembledHodgeStar(
+            cochain.Cochain(MeshType, k, cochain.Primal),
+        ) {
+            return self.base.hodgeStar(k);
+        }
+
+        pub fn hodgeStarInverse(
+            self: *Self,
+            comptime k: comptime_int,
+        ) !*const @import("hodge_star.zig").AssembledHodgeStarInverse(
+            cochain.Cochain(MeshType, MeshType.topological_dimension - k, cochain.Dual),
+        ) {
+            return self.base.hodgeStarInverse(k);
+        }
+
+        pub fn codifferential(
+            self: *Self,
+            comptime k: comptime_int,
+        ) !*const @import("codifferential.zig").AssembledCodifferential(
+            cochain.Cochain(MeshType, k, cochain.Primal),
+        ) {
+            return self.base.codifferential(k);
+        }
+
+        pub fn laplacian(
+            self: *Self,
+            comptime k: comptime_int,
+        ) !*const @import("laplacian.zig").AssembledLaplacian(
+            cochain.Cochain(MeshType, k, cochain.Primal),
+        ) {
+            return self.base.laplacian(k);
+        }
+    };
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -85,6 +85,34 @@ pub const concepts = struct {
     pub const mesh = @import("concepts/mesh.zig");
 };
 
+test "public API exposes explicit DEC and FEEC operator families" {
+    const testing = @import("std").testing;
+
+    try testing.expect(@hasDecl(@This().operators, "dec"));
+    try testing.expect(@hasDecl(@This().operators, "feec"));
+    try testing.expect(!@hasDecl(@This().operators, "context"));
+}
+
+test "DEC context only exposes DEC-family operators" {
+    const testing = @import("std").testing;
+    const Mesh2D = topology.Mesh(2, 2);
+    const DecContext = @This().operators.dec.context.OperatorContext(Mesh2D);
+
+    try testing.expect(@hasDecl(DecContext, "exteriorDerivative"));
+    try testing.expect(!@hasDecl(DecContext, "hodgeStar"));
+    try testing.expect(!@hasDecl(DecContext, "laplacian"));
+}
+
+test "FEEC context only exposes FEEC-family operators" {
+    const testing = @import("std").testing;
+    const Mesh2D = topology.Mesh(2, 2);
+    const FeecContext = @This().operators.feec.context.OperatorContext(Mesh2D);
+
+    try testing.expect(@hasDecl(FeecContext, "hodgeStar"));
+    try testing.expect(@hasDecl(FeecContext, "laplacian"));
+    try testing.expect(!@hasDecl(FeecContext, "exteriorDerivative"));
+}
+
 test {
     @import("std").testing.refAllDeclsRecursive(@This());
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,14 +13,14 @@
 //! // Build a mesh
 //! const Mesh2D = flux.topology.Mesh(2, 2);
 //! var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
-//! const operators = try flux.operators.context.OperatorContext(Mesh2D).init(allocator, &mesh);
-//! defer operators.deinit();
+//! const dec = try flux.operators.dec.context.OperatorContext(Mesh2D).init(allocator, &mesh);
+//! defer dec.deinit();
 //!
 //! // Create a 0-cochain (scalar field on vertices)
 //! var omega = try flux.forms.Cochain(Mesh2D, 0, flux.forms.Primal).init(allocator, &mesh);
 //!
 //! // Apply operators with compile-time type safety
-//! var d_omega = try (try operators.exteriorDerivative(flux.forms.Primal, 0)).apply(allocator, omega);
+//! var d_omega = try (try dec.exteriorDerivative(flux.forms.Primal, 0)).apply(allocator, omega);
 //! ```
 //!
 //! ## Modules
@@ -62,10 +62,21 @@ pub const math = struct {
     pub const linear_system = @import("math/linear_system.zig");
 };
 pub const operators = struct {
+    pub const dec = struct {
+        pub const context = @import("operators/dec_context.zig");
+        pub const exterior_derivative = @import("operators/exterior_derivative.zig");
+    };
+    pub const feec = struct {
+        pub const context = @import("operators/feec_context.zig");
+        pub const codifferential = @import("operators/codifferential.zig");
+        pub const hodge_star = @import("operators/hodge_star.zig");
+        pub const laplacian = @import("operators/laplacian.zig");
+        pub const whitney_mass = @import("operators/whitney_mass.zig");
+    };
+    pub const bridges = struct {};
     pub const boundary_conditions = @import("operators/boundary_conditions.zig");
     pub const codifferential = @import("operators/codifferential.zig");
     pub const compose = @import("operators/compose.zig");
-    pub const context = @import("operators/context.zig");
     pub const exterior_derivative = @import("operators/exterior_derivative.zig");
     pub const hodge_star = @import("operators/hodge_star.zig");
     pub const laplacian = @import("operators/laplacian.zig");


### PR DESCRIPTION
Closes #193

## What

Expose explicit DEC and FEEC operator families in the public API and migrate at least one operator path onto that split.

## Acceptance criterion

A caller can tell, from the public API alone, whether an operator belongs to the DEC family, the FEEC family, or an explicit bridge between them, and at least one existing operator path has been migrated to the split without numerical regression.

## Tasks

- [ ] Write property tests encoding the acceptance criterion
- [ ] Design public API (stubs)
- [ ] Implement
- [ ] CI green
