### PR TITLE
feat(forms): separate FEEC form-space semantics from cochains

### DIFF
--- a/examples/euler/three_dimensional.zig
+++ b/examples/euler/three_dimensional.zig
@@ -3,6 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const poisson = flux.operators.poisson;
+const feec_forms = flux.forms.feec;
 const dec_context_mod = flux.operators.dec.context;
 const feec_context_mod = flux.operators.feec.context;
 const observers = flux.operators.observers;
@@ -157,10 +158,16 @@ pub fn stepImpl(allocator: std.mem.Allocator, state: *StateImpl, dt: f64) !void 
     defer vorticity.deinit(allocator);
     @memcpy(state.vorticity.values, vorticity.values);
 
-    var advection_density = try wedge_product.wedge(allocator, state.velocity, state.vorticity);
+    const velocity_space = feec_forms.WhitneySpace(Mesh, 1).init(state.mesh);
+    const vorticity_space = feec_forms.WhitneySpace(Mesh, 2).init(state.mesh);
+    var advection_density = try wedge_product.wedge(
+        allocator,
+        velocity_space.view(&state.velocity),
+        vorticity_space.view(&state.vorticity),
+    );
     defer advection_density.deinit(allocator);
 
-    var transport = try (try state.feec_operators.codifferential(3)).apply(allocator, advection_density);
+    var transport = try (try state.feec_operators.codifferential(3)).apply(allocator, advection_density.coefficientsConst().*);
     defer transport.deinit(allocator);
 }
 

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -245,6 +245,32 @@ reintroducing another transitional public API.
 
 **Source:** PR #198, issue #193
 
+## 2026-04-13: FEEC semantics use explicit Space/Form wrappers over shared cochain storage
+
+**Decision:** Keep `Cochain` as the shared coefficient-storage object and add a
+FEEC layer in `forms.feec` built around explicit `Space` and `Form` nouns.
+Current lowest-order FEEC use is represented honestly by `WhitneySpace(...)`,
+while `Form(space)` wraps shared or owned cochain storage without making the
+storage type itself carry FEEC semantic meaning.
+
+**Alternatives considered:**
+1. Add FEEC methods directly onto `Cochain`: rejected because it would keep
+   storage and FEEC basis semantics conflated, which is the ambiguity this
+   milestone is trying to remove.
+2. Introduce only a `WhitneyForm` noun with no separate space object:
+   rejected because the structural concept in the library vision is the
+   function space. A form value should be understood as an element of a space,
+   not as a new storage family.
+
+**Rationale:** This gives the library a stable structural noun pair that fits
+the long-term operator-on-function-space vision and still stays honest about
+today's FEEC support. `Space` is the reusable semantic layer, `Form` is a view
+or owner over coefficients in that space, and `WhitneySpace` remains an
+explicit family qualifier rather than pretending FEEC is already generic over
+all basis families.
+
+**Source:** PR #199, issue #129
+
 ## 2026-04-11: Canonical geometry constructors stay honest about supported mesh types
 
 **Decision:** Add `Mesh(3, 2).sphere(allocator, radius, refinement)` as the

--- a/src/forms/feec.zig
+++ b/src/forms/feec.zig
@@ -1,0 +1,85 @@
+//! FEEC form-space abstractions layered over shared cochain storage.
+
+const std = @import("std");
+const cochain = @import("cochain.zig");
+
+pub const Whitney = struct {};
+
+pub fn Space(comptime MeshType: type, comptime k: comptime_int, comptime Family: type) type {
+    const Storage = cochain.Cochain(MeshType, k, cochain.Primal);
+
+    return struct {
+        const Self = @This();
+
+        pub const MeshT = MeshType;
+        pub const degree = k;
+        pub const family = Family;
+        pub const StorageT = Storage;
+
+        mesh: *const MeshType,
+
+        pub fn init(mesh: *const MeshType) Self {
+            return .{ .mesh = mesh };
+        }
+
+        pub fn view(self: Self, coefficients: *Storage) Form(Self) {
+            std.debug.assert(coefficients.mesh == self.mesh);
+            return .{
+                .space = self,
+                .storage = .{ .borrowed = coefficients },
+            };
+        }
+    };
+}
+
+pub fn WhitneySpace(comptime MeshType: type, comptime k: comptime_int) type {
+    return Space(MeshType, k, Whitney);
+}
+
+pub fn Form(comptime SpaceType: type) type {
+    const Storage = SpaceType.StorageT;
+
+    return struct {
+        const Self = @This();
+
+        pub const SpaceT = SpaceType;
+        pub const MeshT = SpaceType.MeshT;
+        pub const degree = SpaceType.degree;
+
+        pub const StorageHandle = union(enum) {
+            borrowed: *Storage,
+            owned: Storage,
+        };
+
+        space: SpaceType,
+        storage: StorageHandle,
+
+        pub fn initOwned(allocator: std.mem.Allocator, space: SpaceType) !Self {
+            return .{
+                .space = space,
+                .storage = .{ .owned = try Storage.init(allocator, space.mesh) },
+            };
+        }
+
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+            switch (self.storage) {
+                .borrowed => {},
+                .owned => |*owned| owned.deinit(allocator),
+            }
+        }
+
+        pub fn coefficients(self: *Self) *Storage {
+            return switch (self.storage) {
+                .borrowed => |borrowed| borrowed,
+                .owned => |*owned| owned,
+            };
+        }
+
+        pub fn coefficientsConst(self: *const Self) *const Storage {
+            return switch (self.storage) {
+                .borrowed => |borrowed| borrowed,
+                .owned => |*owned| owned,
+            };
+        }
+    };
+}

--- a/src/forms/feec.zig
+++ b/src/forms/feec.zig
@@ -22,7 +22,7 @@ pub fn Space(comptime MeshType: type, comptime k: comptime_int, comptime Family:
             return .{ .mesh = mesh };
         }
 
-        pub fn view(self: Self, coefficients: *Storage) Form(Self) {
+        pub fn view(self: Self, coefficients: *const Storage) Form(Self) {
             std.debug.assert(coefficients.mesh == self.mesh);
             return .{
                 .space = self,
@@ -47,7 +47,7 @@ pub fn Form(comptime SpaceType: type) type {
         pub const degree = SpaceType.degree;
 
         pub const StorageHandle = union(enum) {
-            borrowed: *Storage,
+            borrowed: *const Storage,
             owned: Storage,
         };
 
@@ -68,16 +68,16 @@ pub fn Form(comptime SpaceType: type) type {
             }
         }
 
-        pub fn coefficients(self: *Self) *Storage {
+        pub fn coefficientsConst(self: *const Self) *const Storage {
             return switch (self.storage) {
                 .borrowed => |borrowed| borrowed,
                 .owned => |*owned| owned,
             };
         }
 
-        pub fn coefficientsConst(self: *const Self) *const Storage {
+        pub fn coefficientsMut(self: *Self) *Storage {
             return switch (self.storage) {
-                .borrowed => |borrowed| borrowed,
+                .borrowed => @panic("cannot mutably borrow coefficients from a FEEC view"),
                 .owned => |*owned| owned,
             };
         }

--- a/src/forms/root.zig
+++ b/src/forms/root.zig
@@ -1,0 +1,6 @@
+const cochain = @import("cochain.zig");
+
+pub const Cochain = cochain.Cochain;
+pub const Primal = cochain.Primal;
+pub const Dual = cochain.Dual;
+pub const feec = @import("feec.zig");

--- a/src/operators/observers.zig
+++ b/src/operators/observers.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const testing = std.testing;
 const cochain = @import("../forms/cochain.zig");
+const feec = @import("../forms/feec.zig");
 const topology = @import("../topology/mesh.zig");
 const exterior_derivative = @import("exterior_derivative.zig");
 const wedge_product = @import("wedge_product.zig");
@@ -241,11 +242,17 @@ pub fn HelicityObserver(
             var derivative = try exterior_derivative.exterior_derivative(allocator, field.*);
             defer derivative.deinit(allocator);
 
-            var helicity_density = try wedge_product.wedge(allocator, field.*, derivative);
+            const velocity_space = feec.WhitneySpace(CochainType.MeshT, CochainType.degree).init(field.mesh);
+            const vorticity_space = feec.WhitneySpace(CochainType.MeshT, CochainType.degree + 1).init(field.mesh);
+            var helicity_density = try wedge_product.wedge(
+                allocator,
+                velocity_space.view(field),
+                vorticity_space.view(&derivative),
+            );
             defer helicity_density.deinit(allocator);
 
             var helicity: f64 = 0.0;
-            for (helicity_density.values) |value| {
+            for (helicity_density.coefficientsConst().values) |value| {
                 helicity += value;
             }
             return helicity;
@@ -411,11 +418,13 @@ test "helicity observer matches manual sum of u wedge du on tetrahedral mesh" {
 
     var derivative = try exterior_derivative.exterior_derivative(allocator, state.velocity);
     defer derivative.deinit(allocator);
-    var density = try wedge_product.wedge(allocator, state.velocity, derivative);
+    const velocity_space = feec.WhitneySpace(Mesh3D, 1).init(&mesh);
+    const vorticity_space = feec.WhitneySpace(Mesh3D, 2).init(&mesh);
+    var density = try wedge_product.wedge(allocator, velocity_space.view(&velocity), vorticity_space.view(&derivative));
     defer density.deinit(allocator);
 
     var expected: f64 = 0.0;
-    for (density.values) |value| {
+    for (density.coefficientsConst().values) |value| {
         expected += value;
     }
 
@@ -463,9 +472,11 @@ test "manual wedge for helicity produces a top form" {
 
     var derivative = try exterior_derivative.exterior_derivative(allocator, velocity);
     defer derivative.deinit(allocator);
-    var density = try wedge_product.wedge(allocator, velocity, derivative);
+    const velocity_space = feec.WhitneySpace(Mesh3D, 1).init(&mesh);
+    const vorticity_space = feec.WhitneySpace(Mesh3D, 2).init(&mesh);
+    var density = try wedge_product.wedge(allocator, velocity_space.view(&velocity), vorticity_space.view(&derivative));
     defer density.deinit(allocator);
 
-    try testing.expectEqual(@as(usize, mesh.num_tets()), density.values.len);
+    try testing.expectEqual(@as(usize, mesh.num_tets()), density.coefficientsConst().values.len);
     _ = Primal2_2D;
 }

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -14,19 +14,30 @@
 const std = @import("std");
 const testing = std.testing;
 const cochain = @import("../forms/cochain.zig");
+const feec = @import("../forms/feec.zig");
 const topology = @import("../topology/mesh.zig");
 const exterior_derivative = @import("exterior_derivative.zig");
 
 fn WedgeResult(comptime LeftType: type, comptime RightType: type) type {
+    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
+        return feec.Form(feec.WhitneySpace(LeftType.MeshT, LeftType.degree + RightType.degree));
+    }
     return cochain.Cochain(LeftType.MeshT, LeftType.degree + RightType.degree, cochain.Primal);
 }
 
 fn validateWedgeInputs(comptime LeftType: type, comptime RightType: type) void {
+    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
+        if (LeftType.MeshT != RightType.MeshT) {
+            @compileError("wedge requires both FEEC forms to use the same mesh type");
+        }
+        return;
+    }
+
     if (!@hasDecl(LeftType, "degree") or !@hasDecl(LeftType, "MeshT") or !@hasDecl(LeftType, "duality")) {
-        @compileError("wedge requires the left input to be a Cochain type");
+        @compileError("wedge requires the left input to be a Cochain type or FEEC form");
     }
     if (!@hasDecl(RightType, "degree") or !@hasDecl(RightType, "MeshT") or !@hasDecl(RightType, "duality")) {
-        @compileError("wedge requires the right input to be a Cochain type");
+        @compileError("wedge requires the right input to be a Cochain type or FEEC form");
     }
     if (LeftType.MeshT != RightType.MeshT) {
         @compileError("wedge requires both cochains to use the same mesh type");
@@ -55,6 +66,12 @@ pub fn wedge(
     const degree_right = RightType.degree;
     const degree_out = degree_left + degree_right;
     const OutputType = WedgeResult(LeftType, RightType);
+
+    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
+        var output = try OutputType.initOwned(allocator, feec.WhitneySpace(LeftType.MeshT, degree_out).init(left.space.mesh));
+        errdefer output.deinit(allocator);
+        unreachable;
+    }
 
     std.debug.assert(left.mesh == right.mesh);
 

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -261,6 +261,35 @@ test "wedge of 0-forms is pointwise multiplication" {
     }
 }
 
+test "wedge operates on FEEC Whitney forms instead of bare cochains" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    const Whitney1 = @import("../forms/feec.zig").WhitneySpace(Mesh2D, 1);
+    var alpha_coefficients = try C1.init(allocator, &mesh);
+    defer alpha_coefficients.deinit(allocator);
+    var beta_coefficients = try C1.init(allocator, &mesh);
+    defer beta_coefficients.deinit(allocator);
+
+    for (alpha_coefficients.values, 0..) |*value, i| {
+        value.* = @floatFromInt(i + 1);
+    }
+    for (beta_coefficients.values, 0..) |*value, i| {
+        value.* = @floatFromInt(2 * i + 1);
+    }
+
+    const edge_space = Whitney1.init(&mesh);
+    const alpha = edge_space.view(&alpha_coefficients);
+    const beta = edge_space.view(&beta_coefficients);
+
+    var product = try wedge(allocator, alpha, beta);
+    defer product.deinit(allocator);
+
+    try testing.expect(@TypeOf(product).SpaceT.degree == 2);
+    try testing.expect(product.coefficients().mesh == &mesh);
+}
+
 test "wedge of 0-form and 1-form averages the endpoint values" {
     const allocator = testing.allocator;
     var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -19,31 +19,18 @@ const topology = @import("../topology/mesh.zig");
 const exterior_derivative = @import("exterior_derivative.zig");
 
 fn WedgeResult(comptime LeftType: type, comptime RightType: type) type {
-    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
-        return feec.Form(feec.WhitneySpace(LeftType.MeshT, LeftType.degree + RightType.degree));
-    }
-    return cochain.Cochain(LeftType.MeshT, LeftType.degree + RightType.degree, cochain.Primal);
+    return feec.Form(feec.WhitneySpace(LeftType.MeshT, LeftType.degree + RightType.degree));
 }
 
 fn validateWedgeInputs(comptime LeftType: type, comptime RightType: type) void {
-    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
-        if (LeftType.MeshT != RightType.MeshT) {
-            @compileError("wedge requires both FEEC forms to use the same mesh type");
-        }
-        return;
-    }
-
-    if (!@hasDecl(LeftType, "degree") or !@hasDecl(LeftType, "MeshT") or !@hasDecl(LeftType, "duality")) {
-        @compileError("wedge requires the left input to be a Cochain type or FEEC form");
-    }
-    if (!@hasDecl(RightType, "degree") or !@hasDecl(RightType, "MeshT") or !@hasDecl(RightType, "duality")) {
-        @compileError("wedge requires the right input to be a Cochain type or FEEC form");
+    if (!@hasDecl(LeftType, "SpaceT") or !@hasDecl(RightType, "SpaceT")) {
+        @compileError("wedge requires FEEC form inputs rather than bare cochains");
     }
     if (LeftType.MeshT != RightType.MeshT) {
-        @compileError("wedge requires both cochains to use the same mesh type");
+        @compileError("wedge requires both FEEC forms to use the same mesh type");
     }
-    if (LeftType.duality != cochain.Primal or RightType.duality != cochain.Primal) {
-        @compileError("wedge currently supports only primal cochains");
+    if (LeftType.SpaceT.family != feec.Whitney or RightType.SpaceT.family != feec.Whitney) {
+        @compileError("wedge currently supports only Whitney FEEC spaces");
     }
     if (LeftType.degree + RightType.degree > LeftType.MeshT.topological_dimension) {
         @compileError(std.fmt.comptimePrint(
@@ -62,27 +49,37 @@ pub fn wedge(
     const RightType = @TypeOf(right);
     comptime validateWedgeInputs(LeftType, RightType);
 
+    const OutputType = WedgeResult(LeftType, RightType);
+    std.debug.assert(left.space.mesh == right.space.mesh);
+
+    var output = try OutputType.initOwned(
+        allocator,
+        feec.WhitneySpace(LeftType.MeshT, LeftType.degree + RightType.degree).init(left.space.mesh),
+    );
+    errdefer output.deinit(allocator);
+
+    try wedgeCoefficientsInto(
+        output.coefficientsMut().values,
+        left.coefficientsConst().*,
+        right.coefficientsConst().*,
+    );
+    return output;
+}
+
+fn wedgeCoefficientsInto(output_values: []f64, left: anytype, right: anytype) !void {
+    const LeftType = @TypeOf(left);
+    const RightType = @TypeOf(right);
+    std.debug.assert(left.mesh == right.mesh);
+
     const degree_left = LeftType.degree;
     const degree_right = RightType.degree;
     const degree_out = degree_left + degree_right;
-    const OutputType = WedgeResult(LeftType, RightType);
-
-    if (@hasDecl(LeftType, "SpaceT") and @hasDecl(RightType, "SpaceT")) {
-        var output = try OutputType.initOwned(allocator, feec.WhitneySpace(LeftType.MeshT, degree_out).init(left.space.mesh));
-        errdefer output.deinit(allocator);
-        unreachable;
-    }
-
-    std.debug.assert(left.mesh == right.mesh);
-
-    var output = try OutputType.init(allocator, left.mesh);
-    errdefer output.deinit(allocator);
 
     if (degree_out == 0) {
-        for (output.values, left.values, right.values) |*out, left_value, right_value| {
+        for (output_values, left.values, right.values) |*out, left_value, right_value| {
             out.* = left_value * right_value;
         }
-        return output;
+        return;
     }
 
     const left_values = left.values;
@@ -136,10 +133,8 @@ pub fn wedge(
 
             sum += @as(f64, @floatFromInt(permutationSign(degree_out + 1, permutation))) * left_value * right_value;
         }
-        output.values[out_index] = coefficient * sum;
+        output_values[out_index] = coefficient * sum;
     }
-
-    return output;
 }
 
 fn wedgeCoefficient(comptime degree_left: comptime_int, comptime degree_right: comptime_int) f64 {
@@ -243,13 +238,27 @@ const C3D1 = cochain.Cochain(Mesh3D, 1, cochain.Primal);
 const C3D2 = cochain.Cochain(Mesh3D, 2, cochain.Primal);
 const C3D3 = cochain.Cochain(Mesh3D, 3, cochain.Primal);
 
+fn whitneyView(coefficients: anytype) feec.Form(feec.WhitneySpace(@TypeOf(coefficients.*).MeshT, @TypeOf(coefficients.*).degree)) {
+    const CochainType = @TypeOf(coefficients.*);
+    const WhitneySpaceType = feec.WhitneySpace(CochainType.MeshT, CochainType.degree);
+    const space = WhitneySpaceType.init(coefficients.mesh);
+    return space.view(coefficients);
+}
+
 test "compile-time: wedge degree arithmetic yields the sum degree" {
     comptime {
-        const Result2D = WedgeResult(C1, C1);
-        try testing.expect(Result2D == C2);
+        const Whitney2D1 = feec.Form(feec.WhitneySpace(Mesh2D, 1));
+        const Result2D = WedgeResult(Whitney2D1, Whitney2D1);
+        if (Result2D.SpaceT.degree != 2) {
+            @compileError("2D FEEC wedge should produce a degree-2 FEEC form");
+        }
 
-        const Result3D = WedgeResult(C3D1, C3D2);
-        try testing.expect(Result3D == C3D3);
+        const Whitney3D1 = feec.Form(feec.WhitneySpace(Mesh3D, 1));
+        const Whitney3D2 = feec.Form(feec.WhitneySpace(Mesh3D, 2));
+        const Result3D = WedgeResult(Whitney3D1, Whitney3D2);
+        if (Result3D.SpaceT.degree != 3) {
+            @compileError("3D FEEC wedge should produce a degree-3 FEEC form");
+        }
     }
 }
 
@@ -270,10 +279,10 @@ test "wedge of 0-forms is pointwise multiplication" {
         value.* = 2.0 * @as(f64, @floatFromInt(i + 3));
     }
 
-    var product = try wedge(allocator, alpha, beta);
+    var product = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
     defer product.deinit(allocator);
 
-    for (product.values, 0..) |value, i| {
+    for (product.coefficientsConst().values, 0..) |value, i| {
         try testing.expectApproxEqAbs(alpha.values[i] * beta.values[i], value, 1e-15);
     }
 }
@@ -304,7 +313,7 @@ test "wedge operates on FEEC Whitney forms instead of bare cochains" {
     defer product.deinit(allocator);
 
     try testing.expect(@TypeOf(product).SpaceT.degree == 2);
-    try testing.expect(product.coefficients().mesh == &mesh);
+    try testing.expect(product.coefficientsConst().mesh == &mesh);
 }
 
 test "wedge of 0-form and 1-form averages the endpoint values" {
@@ -325,11 +334,11 @@ test "wedge of 0-form and 1-form averages the endpoint values" {
         value.* = @as(f64, @floatFromInt(i + 1));
     }
 
-    var product = try wedge(allocator, scalar, one_form);
+    var product = try wedge(allocator, whitneyView(&scalar), whitneyView(&one_form));
     defer product.deinit(allocator);
 
     const edges = mesh.simplices(1).items(.vertices);
-    for (product.values, edges, one_form.values) |value, edge, edge_value| {
+    for (product.coefficientsConst().values, edges, one_form.values) |value, edge, edge_value| {
         const expected = 0.5 * (scalar.values[edge[0]] + scalar.values[edge[1]]) * edge_value;
         try testing.expectApproxEqAbs(expected, value, 1e-14);
     }
@@ -350,12 +359,12 @@ test "graded commutativity holds on random 3D 1- and 2-forms" {
         for (alpha.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
         for (beta.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
 
-        var left = try wedge(allocator, alpha, beta);
+        var left = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
         defer left.deinit(allocator);
-        var right = try wedge(allocator, beta, alpha);
+        var right = try wedge(allocator, whitneyView(&beta), whitneyView(&alpha));
         defer right.deinit(allocator);
 
-        for (left.values, right.values) |lhs, rhs| {
+        for (left.coefficientsConst().values, right.coefficientsConst().values) |lhs, rhs| {
             try testing.expectApproxEqAbs(lhs, rhs, 1e-12);
         }
     }
@@ -386,17 +395,17 @@ test "associativity holds for random closed 1-forms on tetrahedral meshes" {
         var gamma = try exterior_derivative.exterior_derivative(allocator, potential_c);
         defer gamma.deinit(allocator);
 
-        var alpha_beta = try wedge(allocator, alpha, beta);
+        var alpha_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
         defer alpha_beta.deinit(allocator);
-        var left = try wedge(allocator, alpha_beta, gamma);
+        var left = try wedge(allocator, alpha_beta, whitneyView(&gamma));
         defer left.deinit(allocator);
 
-        var beta_gamma = try wedge(allocator, beta, gamma);
+        var beta_gamma = try wedge(allocator, whitneyView(&beta), whitneyView(&gamma));
         defer beta_gamma.deinit(allocator);
-        var right = try wedge(allocator, alpha, beta_gamma);
+        var right = try wedge(allocator, whitneyView(&alpha), beta_gamma);
         defer right.deinit(allocator);
 
-        for (left.values, right.values) |lhs, rhs| {
+        for (left.coefficientsConst().values, right.coefficientsConst().values) |lhs, rhs| {
             try testing.expectApproxEqAbs(lhs, rhs, 1e-11);
         }
     }
@@ -417,22 +426,22 @@ test "Leibniz rule holds on random 2D 0- and 1-forms" {
         for (alpha.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
         for (beta.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
 
-        var alpha_wedge_beta = try wedge(allocator, alpha, beta);
+        var alpha_wedge_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
         defer alpha_wedge_beta.deinit(allocator);
-        var left = try exterior_derivative.exterior_derivative(allocator, alpha_wedge_beta);
+        var left = try exterior_derivative.exterior_derivative(allocator, alpha_wedge_beta.coefficientsConst().*);
         defer left.deinit(allocator);
 
         var d_alpha = try exterior_derivative.exterior_derivative(allocator, alpha);
         defer d_alpha.deinit(allocator);
-        var d_alpha_wedge_beta = try wedge(allocator, d_alpha, beta);
+        var d_alpha_wedge_beta = try wedge(allocator, whitneyView(&d_alpha), whitneyView(&beta));
         defer d_alpha_wedge_beta.deinit(allocator);
 
         var d_beta = try exterior_derivative.exterior_derivative(allocator, beta);
         defer d_beta.deinit(allocator);
-        var alpha_wedge_d_beta = try wedge(allocator, alpha, d_beta);
+        var alpha_wedge_d_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&d_beta));
         defer alpha_wedge_d_beta.deinit(allocator);
 
-        for (left.values, d_alpha_wedge_beta.values, alpha_wedge_d_beta.values) |lhs, rhs_a, rhs_b| {
+        for (left.values, d_alpha_wedge_beta.coefficientsConst().values, alpha_wedge_d_beta.coefficientsConst().values) |lhs, rhs_a, rhs_b| {
             try testing.expectApproxEqAbs(lhs, rhs_a + rhs_b, 1e-11);
         }
     }

--- a/src/root.zig
+++ b/src/root.zig
@@ -124,6 +124,18 @@ test "FEEC context only exposes FEEC-family operators" {
     try testing.expect(!@hasDecl(FeecContext, "exteriorDerivative"));
 }
 
+test "forms API exposes FEEC spaces while keeping Cochain storage-only" {
+    const testing = @import("std").testing;
+    const Mesh2D = topology.Mesh(2, 2);
+    const C1 = @This().forms.Cochain(Mesh2D, 1, @This().forms.Primal);
+
+    try testing.expect(@hasDecl(@This().forms, "feec"));
+    try testing.expect(@hasDecl(@This().forms.feec, "WhitneySpace"));
+    try testing.expect(!@hasDecl(C1, "interpolate"));
+    try testing.expect(!@hasDecl(C1, "project"));
+    try testing.expect(!@hasDecl(C1, "space"));
+}
+
 test {
     @import("std").testing.refAllDeclsRecursive(@This());
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -54,7 +54,7 @@ pub const Error = error{
 
 // ── Submodule re-exports (for namespaced access) ────────────────────────
 
-pub const forms = @import("forms/cochain.zig");
+pub const forms = @import("forms/root.zig");
 pub const io = @import("io/root.zig");
 pub const math = struct {
     pub const sparse = @import("math/sparse.zig");


### PR DESCRIPTION
Closes #129

## What

Introduce an explicit FEEC form-space layer so cochain storage remains separate from FEEC basis semantics. The PR adds `forms.feec.Space` / `forms.feec.Form` with `WhitneySpace(...)` as the current honest family constructor, then migrates the FEEC wedge-product path and its direct consumers onto form views over shared cochain storage.

## Acceptance criterion

The codebase has an explicit abstraction boundary between cochain storage and FEEC form-space semantics, and at least one FEEC operator path uses that separation rather than overloading `Cochain` with semantic meaning.

## Tasks

- [x] Write property tests encoding the storage-vs-space boundary
- [x] Design public API (stubs)
- [x] Implement
- [x] CI green

## Decisions

- `Cochain` remains the shared coefficient-storage object.
- FEEC semantics now live in `forms.feec.Space` / `forms.feec.Form`, with `WhitneySpace(...)` as the explicit current family.
- `operators.wedge_product.wedge` now requires FEEC form inputs; the old raw-cochain FEEC interpretation survives only as a private implementation helper.

## Limitations

- The new FEEC space layer is only exercised by the Whitney wedge-product path in this PR.
- Hodge star, codifferential, Laplacian, and bridge operators still operate on raw cochains and will need follow-on migration in later milestone issues.
- Only the Whitney FEEC family is represented today; this does not yet attempt higher-order FEEC spaces.
