### PR TITLE
feat(operators): expose explicit DEC/FEEC bridge operators

### DIFF
--- a/examples/euler/three_dimensional.zig
+++ b/examples/euler/three_dimensional.zig
@@ -3,7 +3,7 @@ const flux = @import("flux");
 const common = @import("examples_common");
 
 const poisson = flux.operators.poisson;
-const feec_forms = flux.forms.feec;
+const bridges = flux.operators.bridges;
 const dec_context_mod = flux.operators.dec.context;
 const feec_context_mod = flux.operators.feec.context;
 const observers = flux.operators.observers;
@@ -158,16 +158,18 @@ pub fn stepImpl(allocator: std.mem.Allocator, state: *StateImpl, dt: f64) !void 
     defer vorticity.deinit(allocator);
     @memcpy(state.vorticity.values, vorticity.values);
 
-    const velocity_space = feec_forms.WhitneySpace(Mesh, 1).init(state.mesh);
-    const vorticity_space = feec_forms.WhitneySpace(Mesh, 2).init(state.mesh);
-    var advection_density = try wedge_product.wedge(
+    const interpolate_velocity = bridges.WhitneyInterpolation(Mesh, 1).init(state.mesh);
+    const interpolate_vorticity = bridges.WhitneyInterpolation(Mesh, 2).init(state.mesh);
+    const advection_density = try wedge_product.wedge(
         allocator,
-        velocity_space.view(&state.velocity),
-        vorticity_space.view(&state.vorticity),
+        interpolate_velocity.apply(&state.velocity),
+        interpolate_vorticity.apply(&state.vorticity),
     );
-    defer advection_density.deinit(allocator);
+    const project_density = bridges.DeRhamProjection(@TypeOf(advection_density).SpaceT).init(@TypeOf(advection_density).SpaceT.init(state.mesh));
+    var projected_density = try project_density.apply(allocator, advection_density);
+    defer projected_density.deinit(allocator);
 
-    var transport = try (try state.feec_operators.codifferential(3)).apply(allocator, advection_density.coefficientsConst().*);
+    var transport = try (try state.feec_operators.codifferential(3)).apply(allocator, projected_density);
     defer transport.deinit(allocator);
 }
 

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -271,6 +271,32 @@ all basis families.
 
 **Source:** PR #199, issue #129
 
+## 2026-04-13: DEC/FEEC bridge operators borrow on interpolation and move-or-copy on projection
+
+**Decision:** Represent the explicit bridge seam with operator values in
+`operators.bridges`: `WhitneyInterpolation` borrows simplicial cochain storage
+into a FEEC Whitney form view, while `DeRhamProjection` consumes a FEEC form and
+returns simplicial storage by moving owned coefficients or cloning borrowed
+coefficients when necessary.
+
+**Alternatives considered:**
+1. Make both bridges pure views with no owned projection result: rejected
+   because downstream DEC operators consume raw cochain values, not references
+   tied to a FEEC form's lifetime.
+2. Make both bridges allocate unconditionally: rejected because interpolation is
+   structurally just a semantic reinterpretation in the current lowest-order
+   FEEC layer, so forcing allocation there would obscure the real ownership
+   story and add avoidable cost.
+
+**Rationale:** This keeps the bridge layer honest about what changes and what
+does not. Whitney interpolation changes semantics but not storage, so borrowing
+is correct. De Rham projection returns the caller to the DEC storage path, so it
+must yield an ordinary cochain value with a stable lifetime. The move-or-copy
+rule gives that result without forcing unnecessary duplication when the FEEC
+form already owns its coefficients.
+
+**Source:** PR #200, issue #128
+
 ## 2026-04-11: Canonical geometry constructors stay honest about supported mesh types
 
 **Decision:** Add `Mesh(3, 2).sphere(allocator, radius, refinement)` as the

--- a/src/forms/feec.zig
+++ b/src/forms/feec.zig
@@ -81,5 +81,16 @@ pub fn Form(comptime SpaceType: type) type {
                 .owned => |*owned| owned,
             };
         }
+
+        pub fn intoCoefficients(self: Self, allocator: std.mem.Allocator) !Storage {
+            return switch (self.storage) {
+                .borrowed => |borrowed| blk: {
+                    const owned = try Storage.init(allocator, self.space.mesh);
+                    @memcpy(owned.values, borrowed.values);
+                    break :blk owned;
+                },
+                .owned => |owned| owned,
+            };
+        }
     };
 }

--- a/src/operators/bridges.zig
+++ b/src/operators/bridges.zig
@@ -1,0 +1,90 @@
+//! Explicit DEC/FEEC bridge operators.
+//!
+//! `WhitneyInterpolation` lifts simplicial cochain storage into a Whitney FEEC
+//! space view, and `DeRhamProjection` returns FEEC form coefficients back to
+//! simplicial storage.
+
+const std = @import("std");
+const testing = std.testing;
+const cochain = @import("../forms/cochain.zig");
+const feec = @import("../forms/feec.zig");
+const topology = @import("../topology/mesh.zig");
+
+pub fn WhitneyInterpolation(comptime MeshType: type, comptime k: comptime_int) type {
+    const SpaceType = feec.WhitneySpace(MeshType, k);
+    const Storage = cochain.Cochain(MeshType, k, cochain.Primal);
+
+    return struct {
+        const Self = @This();
+
+        space: SpaceType,
+
+        pub fn init(mesh: *const MeshType) Self {
+            return .{ .space = SpaceType.init(mesh) };
+        }
+
+        pub fn apply(self: Self, coefficients: *const Storage) feec.Form(SpaceType) {
+            return self.space.view(coefficients);
+        }
+    };
+}
+
+pub fn DeRhamProjection(comptime SpaceType: type) type {
+    const Storage = SpaceType.StorageT;
+
+    return struct {
+        const Self = @This();
+
+        space: SpaceType,
+
+        pub fn init(space: SpaceType) Self {
+            return .{ .space = space };
+        }
+
+        pub fn apply(self: Self, allocator: std.mem.Allocator, form: feec.Form(SpaceType)) !Storage {
+            std.debug.assert(form.space.mesh == self.space.mesh);
+            return form.intoCoefficients(allocator);
+        }
+    };
+}
+
+const Mesh2D = topology.Mesh(2, 2);
+const C1 = cochain.Cochain(Mesh2D, 1, cochain.Primal);
+
+test "Whitney interpolation borrows cochain storage into FEEC space" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    var coefficients = try C1.init(allocator, &mesh);
+    defer coefficients.deinit(allocator);
+    coefficients.values[0] = 3.5;
+
+    const interpolate = WhitneyInterpolation(Mesh2D, 1).init(&mesh);
+    const form = interpolate.apply(&coefficients);
+
+    try testing.expect(form.coefficientsConst().values.ptr == coefficients.values.ptr);
+    try testing.expectEqual(@as(f64, 3.5), form.coefficientsConst().values[0]);
+}
+
+test "de Rham projection preserves coefficients for Whitney forms" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.plane(allocator, 1, 1, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    var coefficients = try C1.init(allocator, &mesh);
+    defer coefficients.deinit(allocator);
+    for (coefficients.values, 0..) |*value, i| {
+        value.* = @floatFromInt(i + 1);
+    }
+
+    const Space1 = feec.WhitneySpace(Mesh2D, 1);
+    const interpolate = WhitneyInterpolation(Mesh2D, 1).init(&mesh);
+    const project = DeRhamProjection(Space1).init(Space1.init(&mesh));
+
+    const form = interpolate.apply(&coefficients);
+    var projected = try project.apply(allocator, form);
+    defer projected.deinit(allocator);
+
+    try testing.expectEqualSlices(f64, coefficients.values, projected.values);
+}

--- a/src/operators/observers.zig
+++ b/src/operators/observers.zig
@@ -9,6 +9,7 @@ const testing = std.testing;
 const cochain = @import("../forms/cochain.zig");
 const feec = @import("../forms/feec.zig");
 const topology = @import("../topology/mesh.zig");
+const bridges = @import("bridges.zig");
 const exterior_derivative = @import("exterior_derivative.zig");
 const wedge_product = @import("wedge_product.zig");
 
@@ -242,17 +243,19 @@ pub fn HelicityObserver(
             var derivative = try exterior_derivative.exterior_derivative(allocator, field.*);
             defer derivative.deinit(allocator);
 
-            const velocity_space = feec.WhitneySpace(CochainType.MeshT, CochainType.degree).init(field.mesh);
-            const vorticity_space = feec.WhitneySpace(CochainType.MeshT, CochainType.degree + 1).init(field.mesh);
-            var helicity_density = try wedge_product.wedge(
+            const interpolate_velocity = bridges.WhitneyInterpolation(CochainType.MeshT, CochainType.degree).init(field.mesh);
+            const interpolate_vorticity = bridges.WhitneyInterpolation(CochainType.MeshT, CochainType.degree + 1).init(field.mesh);
+            const helicity_density = try wedge_product.wedge(
                 allocator,
-                velocity_space.view(field),
-                vorticity_space.view(&derivative),
+                interpolate_velocity.apply(field),
+                interpolate_vorticity.apply(&derivative),
             );
-            defer helicity_density.deinit(allocator);
+            const project_density = bridges.DeRhamProjection(@TypeOf(helicity_density).SpaceT).init(@TypeOf(helicity_density).SpaceT.init(field.mesh));
+            var projected_density = try project_density.apply(allocator, helicity_density);
+            defer projected_density.deinit(allocator);
 
             var helicity: f64 = 0.0;
-            for (helicity_density.coefficientsConst().values) |value| {
+            for (projected_density.values) |value| {
                 helicity += value;
             }
             return helicity;
@@ -418,13 +421,15 @@ test "helicity observer matches manual sum of u wedge du on tetrahedral mesh" {
 
     var derivative = try exterior_derivative.exterior_derivative(allocator, state.velocity);
     defer derivative.deinit(allocator);
-    const velocity_space = feec.WhitneySpace(Mesh3D, 1).init(&mesh);
-    const vorticity_space = feec.WhitneySpace(Mesh3D, 2).init(&mesh);
-    var density = try wedge_product.wedge(allocator, velocity_space.view(&velocity), vorticity_space.view(&derivative));
-    defer density.deinit(allocator);
+    const interpolate_velocity = bridges.WhitneyInterpolation(Mesh3D, 1).init(&mesh);
+    const interpolate_vorticity = bridges.WhitneyInterpolation(Mesh3D, 2).init(&mesh);
+    const density = try wedge_product.wedge(allocator, interpolate_velocity.apply(&velocity), interpolate_vorticity.apply(&derivative));
+    const project_density = bridges.DeRhamProjection(@TypeOf(density).SpaceT).init(@TypeOf(density).SpaceT.init(&mesh));
+    var projected_density = try project_density.apply(allocator, density);
+    defer projected_density.deinit(allocator);
 
     var expected: f64 = 0.0;
-    for (density.coefficientsConst().values) |value| {
+    for (projected_density.values) |value| {
         expected += value;
     }
 
@@ -472,11 +477,13 @@ test "manual wedge for helicity produces a top form" {
 
     var derivative = try exterior_derivative.exterior_derivative(allocator, velocity);
     defer derivative.deinit(allocator);
-    const velocity_space = feec.WhitneySpace(Mesh3D, 1).init(&mesh);
-    const vorticity_space = feec.WhitneySpace(Mesh3D, 2).init(&mesh);
-    var density = try wedge_product.wedge(allocator, velocity_space.view(&velocity), vorticity_space.view(&derivative));
-    defer density.deinit(allocator);
+    const interpolate_velocity = bridges.WhitneyInterpolation(Mesh3D, 1).init(&mesh);
+    const interpolate_vorticity = bridges.WhitneyInterpolation(Mesh3D, 2).init(&mesh);
+    const density = try wedge_product.wedge(allocator, interpolate_velocity.apply(&velocity), interpolate_vorticity.apply(&derivative));
+    const project_density = bridges.DeRhamProjection(@TypeOf(density).SpaceT).init(@TypeOf(density).SpaceT.init(&mesh));
+    var projected_density = try project_density.apply(allocator, density);
+    defer projected_density.deinit(allocator);
 
-    try testing.expectEqual(@as(usize, mesh.num_tets()), density.coefficientsConst().values.len);
+    try testing.expectEqual(@as(usize, mesh.num_tets()), projected_density.values.len);
     _ = Primal2_2D;
 }

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -16,6 +16,7 @@ const testing = std.testing;
 const cochain = @import("../forms/cochain.zig");
 const feec = @import("../forms/feec.zig");
 const topology = @import("../topology/mesh.zig");
+const bridges = @import("bridges.zig");
 const exterior_derivative = @import("exterior_derivative.zig");
 
 fn WedgeResult(comptime LeftType: type, comptime RightType: type) type {
@@ -240,9 +241,7 @@ const C3D3 = cochain.Cochain(Mesh3D, 3, cochain.Primal);
 
 fn whitneyView(coefficients: anytype) feec.Form(feec.WhitneySpace(@TypeOf(coefficients.*).MeshT, @TypeOf(coefficients.*).degree)) {
     const CochainType = @TypeOf(coefficients.*);
-    const WhitneySpaceType = feec.WhitneySpace(CochainType.MeshT, CochainType.degree);
-    const space = WhitneySpaceType.init(coefficients.mesh);
-    return space.view(coefficients);
+    return bridges.WhitneyInterpolation(CochainType.MeshT, CochainType.degree).init(coefficients.mesh).apply(coefficients);
 }
 
 test "compile-time: wedge degree arithmetic yields the sum degree" {
@@ -292,7 +291,6 @@ test "wedge operates on FEEC Whitney forms instead of bare cochains" {
     var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    const Whitney1 = @import("../forms/feec.zig").WhitneySpace(Mesh2D, 1);
     var alpha_coefficients = try C1.init(allocator, &mesh);
     defer alpha_coefficients.deinit(allocator);
     var beta_coefficients = try C1.init(allocator, &mesh);
@@ -305,9 +303,9 @@ test "wedge operates on FEEC Whitney forms instead of bare cochains" {
         value.* = @floatFromInt(2 * i + 1);
     }
 
-    const edge_space = Whitney1.init(&mesh);
-    const alpha = edge_space.view(&alpha_coefficients);
-    const beta = edge_space.view(&beta_coefficients);
+    const interpolate = bridges.WhitneyInterpolation(Mesh2D, 1).init(&mesh);
+    const alpha = interpolate.apply(&alpha_coefficients);
+    const beta = interpolate.apply(&beta_coefficients);
 
     var product = try wedge(allocator, alpha, beta);
     defer product.deinit(allocator);

--- a/src/operators/wedge_product.zig
+++ b/src/operators/wedge_product.zig
@@ -239,11 +239,6 @@ const C3D1 = cochain.Cochain(Mesh3D, 1, cochain.Primal);
 const C3D2 = cochain.Cochain(Mesh3D, 2, cochain.Primal);
 const C3D3 = cochain.Cochain(Mesh3D, 3, cochain.Primal);
 
-fn whitneyView(coefficients: anytype) feec.Form(feec.WhitneySpace(@TypeOf(coefficients.*).MeshT, @TypeOf(coefficients.*).degree)) {
-    const CochainType = @TypeOf(coefficients.*);
-    return bridges.WhitneyInterpolation(CochainType.MeshT, CochainType.degree).init(coefficients.mesh).apply(coefficients);
-}
-
 test "compile-time: wedge degree arithmetic yields the sum degree" {
     comptime {
         const Whitney2D1 = feec.Form(feec.WhitneySpace(Mesh2D, 1));
@@ -278,7 +273,8 @@ test "wedge of 0-forms is pointwise multiplication" {
         value.* = 2.0 * @as(f64, @floatFromInt(i + 3));
     }
 
-    var product = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
+    const interpolate = bridges.WhitneyInterpolation(Mesh2D, 0).init(&mesh);
+    var product = try wedge(allocator, interpolate.apply(&alpha), interpolate.apply(&beta));
     defer product.deinit(allocator);
 
     for (product.coefficientsConst().values, 0..) |value, i| {
@@ -332,7 +328,13 @@ test "wedge of 0-form and 1-form averages the endpoint values" {
         value.* = @as(f64, @floatFromInt(i + 1));
     }
 
-    var product = try wedge(allocator, whitneyView(&scalar), whitneyView(&one_form));
+    const interpolate_scalar = bridges.WhitneyInterpolation(Mesh2D, 0).init(&mesh);
+    const interpolate_one_form = bridges.WhitneyInterpolation(Mesh2D, 1).init(&mesh);
+    var product = try wedge(
+        allocator,
+        interpolate_scalar.apply(&scalar),
+        interpolate_one_form.apply(&one_form),
+    );
     defer product.deinit(allocator);
 
     const edges = mesh.simplices(1).items(.vertices);
@@ -357,9 +359,11 @@ test "graded commutativity holds on random 3D 1- and 2-forms" {
         for (alpha.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
         for (beta.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
 
-        var left = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
+        const interpolate_one = bridges.WhitneyInterpolation(Mesh3D, 1).init(&mesh);
+        const interpolate_two = bridges.WhitneyInterpolation(Mesh3D, 2).init(&mesh);
+        var left = try wedge(allocator, interpolate_one.apply(&alpha), interpolate_two.apply(&beta));
         defer left.deinit(allocator);
-        var right = try wedge(allocator, whitneyView(&beta), whitneyView(&alpha));
+        var right = try wedge(allocator, interpolate_two.apply(&beta), interpolate_one.apply(&alpha));
         defer right.deinit(allocator);
 
         for (left.coefficientsConst().values, right.coefficientsConst().values) |lhs, rhs| {
@@ -393,14 +397,15 @@ test "associativity holds for random closed 1-forms on tetrahedral meshes" {
         var gamma = try exterior_derivative.exterior_derivative(allocator, potential_c);
         defer gamma.deinit(allocator);
 
-        var alpha_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
+        const interpolate_one = bridges.WhitneyInterpolation(Mesh3D, 1).init(&mesh);
+        var alpha_beta = try wedge(allocator, interpolate_one.apply(&alpha), interpolate_one.apply(&beta));
         defer alpha_beta.deinit(allocator);
-        var left = try wedge(allocator, alpha_beta, whitneyView(&gamma));
+        var left = try wedge(allocator, alpha_beta, interpolate_one.apply(&gamma));
         defer left.deinit(allocator);
 
-        var beta_gamma = try wedge(allocator, whitneyView(&beta), whitneyView(&gamma));
+        var beta_gamma = try wedge(allocator, interpolate_one.apply(&beta), interpolate_one.apply(&gamma));
         defer beta_gamma.deinit(allocator);
-        var right = try wedge(allocator, whitneyView(&alpha), beta_gamma);
+        var right = try wedge(allocator, interpolate_one.apply(&alpha), beta_gamma);
         defer right.deinit(allocator);
 
         for (left.coefficientsConst().values, right.coefficientsConst().values) |lhs, rhs| {
@@ -424,19 +429,21 @@ test "Leibniz rule holds on random 2D 0- and 1-forms" {
         for (alpha.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
         for (beta.values) |*value| value.* = rng.random().float(f64) * 2.0 - 1.0;
 
-        var alpha_wedge_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&beta));
+        const interpolate_zero = bridges.WhitneyInterpolation(Mesh2D, 0).init(&mesh);
+        const interpolate_one = bridges.WhitneyInterpolation(Mesh2D, 1).init(&mesh);
+        var alpha_wedge_beta = try wedge(allocator, interpolate_zero.apply(&alpha), interpolate_one.apply(&beta));
         defer alpha_wedge_beta.deinit(allocator);
         var left = try exterior_derivative.exterior_derivative(allocator, alpha_wedge_beta.coefficientsConst().*);
         defer left.deinit(allocator);
 
         var d_alpha = try exterior_derivative.exterior_derivative(allocator, alpha);
         defer d_alpha.deinit(allocator);
-        var d_alpha_wedge_beta = try wedge(allocator, whitneyView(&d_alpha), whitneyView(&beta));
+        var d_alpha_wedge_beta = try wedge(allocator, interpolate_one.apply(&d_alpha), interpolate_one.apply(&beta));
         defer d_alpha_wedge_beta.deinit(allocator);
 
         var d_beta = try exterior_derivative.exterior_derivative(allocator, beta);
         defer d_beta.deinit(allocator);
-        var alpha_wedge_d_beta = try wedge(allocator, whitneyView(&alpha), whitneyView(&d_beta));
+        var alpha_wedge_d_beta = try wedge(allocator, interpolate_zero.apply(&alpha), bridges.WhitneyInterpolation(Mesh2D, 2).init(&mesh).apply(&d_beta));
         defer alpha_wedge_d_beta.deinit(allocator);
 
         for (left.values, d_alpha_wedge_beta.coefficientsConst().values, alpha_wedge_d_beta.coefficientsConst().values) |lhs, rhs_a, rhs_b| {

--- a/src/root.zig
+++ b/src/root.zig
@@ -73,7 +73,7 @@ pub const operators = struct {
         pub const laplacian = @import("operators/laplacian.zig");
         pub const whitney_mass = @import("operators/whitney_mass.zig");
     };
-    pub const bridges = struct {};
+    pub const bridges = @import("operators/bridges.zig");
     pub const boundary_conditions = @import("operators/boundary_conditions.zig");
     pub const codifferential = @import("operators/codifferential.zig");
     pub const compose = @import("operators/compose.zig");
@@ -134,6 +134,13 @@ test "forms API exposes FEEC spaces while keeping Cochain storage-only" {
     try testing.expect(!@hasDecl(C1, "interpolate"));
     try testing.expect(!@hasDecl(C1, "project"));
     try testing.expect(!@hasDecl(C1, "space"));
+}
+
+test "operators API exposes explicit DEC/FEEC bridge operators" {
+    const testing = @import("std").testing;
+
+    try testing.expect(@hasDecl(@This().operators.bridges, "WhitneyInterpolation"));
+    try testing.expect(@hasDecl(@This().operators.bridges, "DeRhamProjection"));
 }
 
 test {


### PR DESCRIPTION
Closes #128

## What

Expose explicit Whitney interpolation and de Rham projection bridge operators between DEC cochain storage and FEEC form spaces. The PR adds `operators.bridges.WhitneyInterpolation` and `operators.bridges.DeRhamProjection`, then rewrites the current Whitney-derived wedge consumers to use those bridge operators explicitly instead of constructing FEEC views ad hoc.

## Acceptance criterion

A caller can explicitly construct or invoke Whitney interpolation and de Rham projection at the operator layer, and at least one existing FEEC-derived operator path can be expressed through those bridge operators without changing its numerical result.

## Tasks

- [x] Add tests that pin the interpolation/projection contracts on supported lowest-order cases
- [x] Expose explicit public bridge operators for Whitney interpolation and de Rham projection
- [x] Rewrite at least one existing path to use the explicit bridge operators rather than hidden interpolation/projection structure
- [x] Verify existing numerical results remain unchanged

## Decisions

- `WhitneyInterpolation` is a borrowing bridge from DEC storage into a FEEC Whitney form view.
- `DeRhamProjection` consumes a FEEC form and returns simplicial storage by moving owned coefficients or cloning borrowed coefficients.
- The first explicit bridged path is the 3D Euler advection-density route and the matching helicity observer path.

## Limitations

- The bridge layer currently covers only the lowest-order Whitney family represented by `forms.feec.WhitneySpace`.
- The FEEC wedge path is now explicitly bridged, but `hodge_star`, `codifferential`, and `laplacian` still operate on raw cochains and will need later migration.
- Projection currently clones borrowed FEEC forms when returning to cochain storage; no zero-copy borrowed DEC projection view is exposed.
