### PR TITLE
docs: add architecture canon and skill wiring

### DIFF
--- a/.agents/skills/audit-abstraction/SKILL.md
+++ b/.agents/skills/audit-abstraction/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: audit-abstraction
+description: Audit the codebase for weak abstractions, policy-shaped APIs, redundant wrappers, and cross-component seams that should be simplified by deletion, consolidation, or stronger structural nouns and verbs.
+---
+
+Audit the codebase for abstraction quality. This lens is broader than cleanup:
+it looks for places where the public or internal design has drifted away from a
+coherent domain language and should be simplified, generalized, or deleted.
+
+Usage: /audit-abstraction [component]
+
+If a component is specified, start there per `project/components.md`, but do
+not stop at the boundary if the abstraction problem is created by duplicated or
+conflicting seams across components. Cross-component findings are allowed when
+they materially simplify the tree.
+
+Before proposing new issues, check the current open GitHub issues for overlap.
+Prefer extending or linking existing cleanup or refactor issues over filing
+duplicates.
+
+Before diving into code, read the relevant canonical architecture notes in
+`project/docs/architecture_*.md` and any targeted design note in `project/docs/`
+for the area being audited. Audit against the intended language, not only the
+current implementation.
+
+## First principles
+
+- Favor deletion over addition. The default fix for a weak abstraction is to
+  remove a layer or collapse duplicate concepts, not to introduce a wrapper.
+- Favor one obvious way. Parallel APIs, transitional convenience paths, and
+  duplicate public nouns are presumed guilty until justified.
+- Favor structural nouns and strong verbs. Policy-shaped wrappers and
+  case-specific names are usually evidence that the real abstraction has not
+  been named yet.
+- Favor generalization that removes code. Do not reward “generic” refactors
+  that add indirection, forwarding, or more surface area than they delete.
+- Strike while the iron is hot. If you are already in a seam and can see a
+  stronger local API that simplifies the area you are touching, surface that
+  opportunity immediately instead of paving over it for later.
+- Keep shared memory alive. If the audit reveals a durable reusable pattern,
+  stale canonical note, or missing architecture note, say so explicitly and
+  recommend the write target in `project/docs/`.
+
+## What to look for
+
+### Weak public language
+- Public APIs whose nouns, verbs, and adjectives do not form a small coherent
+  domain language
+- Near-synonym public types that should be one noun with adjectives or one noun
+  plus a stronger verb
+- Builder or context layers that mirror underlying operations without imposing
+  a stronger invariant
+- API surfaces that expose implementation accidents rather than mathematical or
+  computational structure
+
+### Additive cleanup smells
+- A “cleanup” that added a wrapper instead of removing a weak seam
+- Compatibility aliases, shims, or helper overloads in pre-release code
+- Convenience and expert APIs that both express the same capability
+- Public names added only to avoid deleting an older one
+
+### Cross-component abstraction drift
+- Duplication created at component boundaries because the boundary is drawn in
+  the wrong place
+- Similar ownership models expressed differently across neighboring modules
+- Examples or benchmarks carrying concepts that should be library-level nouns
+- Library abstractions that exist only to compensate for awkward example or
+  benchmark entry points
+
+### False genericity
+- APIs presented as general but implemented by manual case tables over today's
+  dimensions, degrees, families, or variants
+- Generic wrappers with only one meaningful consumer
+- Abstractions that would require another branch, noun, or file family as soon
+  as one more PDE, degree, or mesh variant is added
+
+### Deletion candidates
+- Deprecated, fallback, legacy, or transitional code
+- Thin forwarding helpers with no new invariant
+- Stubs, placeholder surfaces, AI-generated filler, or comments narrating code
+  churn instead of helping a new reader
+- Tests that only exist because the API is awkward rather than because they
+  protect a unique invariant
+
+## Pressure tests
+
+For each suspected abstraction problem, ask:
+
+- What should cease to exist if we did this right?
+- What is the stable noun here?
+- What is the real verb?
+- Which qualifiers are adjectives rather than reasons to mint a new noun?
+- If we add one more supported case tomorrow, would the design extend naturally
+  or would we add another wrapper, switch branch, or sibling type?
+- Is this actually flux's job, or is the code compensating for a missing lower
+  layer or an overly opinionated upper layer?
+
+If the likely fix adds code, justify why deletion or consolidation would fail.
+If that justification is weak, the finding should recommend removal instead.
+
+When the right pattern depends on broader Zig practice and local repo context is
+not enough, do targeted external research before making a strong recommendation.
+Prefer:
+- Zig language and standard library documentation
+- established Zig projects whose style is relevant to the pattern under review
+- a small number of primary sources rather than broad blog-search churn
+
+Bring the result back into flux's own language. Do not cargo-cult a community
+pattern if it conflicts with the project's architecture notes.
+
+## Output format
+
+```
+## Abstraction Audit: <scope>
+
+Date: YYYY-MM-DD
+
+### High-confidence deletions
+- <file:line> — <layer or path>. Why it should cease to exist. Proposed simpler shape.
+
+### Consolidations
+- <file1:line> and <file2:line> — <duplicated concept>. Proposed single noun/verb boundary.
+
+### Cross-component seams
+- <component(s)> / <file:line> — <boundary problem>. Why the current split creates duplication or weak APIs.
+
+### Keep intentionally
+- <file:line> — <layer that looks redundant>. What invariant it actually enforces.
+
+### Shared-memory updates
+- <doc or skill path> — <what is stale or missing>. Recommended update.
+
+### Recommended issues
+| # | Title | Category | Component | Priority |
+|---|-------|----------|-----------|----------|
+| 1 | ... | abstraction-cleanup | operators/forms | high |
+```
+
+For each finding, classify it as one of:
+- **Fix now** — local deletion, consolidation, rename, or seam tightening with
+  low design risk
+- **File/refine issue** — multi-file or public abstraction change that needs
+  sequencing
+- **Keep intentionally** — the layer enforces a real invariant and should stay
+
+Prefer a few high-signal findings over a long list of nits.
+
+When the audit converges on an obvious low-risk shared-memory or issue update,
+perform it by default instead of stopping at recommendation only. Typical
+examples:
+- extend an existing issue whose scope clearly should absorb the finding
+- update a canonical architecture note to capture the conclusion
+- patch a stale skill definition that the audit directly exposed
+
+Only stop at recommendation when the write target is genuinely ambiguous or the
+change would commit the project to a direction the user has not yet endorsed.
+
+## Relationship to other audit lenses
+
+- Use `/audit-cleanup` for broad simplification, deduplication, and file/module
+  cleanup.
+- Use this skill when the main question is whether the *abstraction language*
+  itself is wrong, too additive, too wrapper-heavy, or split at the wrong seam.
+- If a finding is mostly about naming or comments, it belongs in
+  `/audit-style`.
+- If a finding is mostly about unused code or performance, route it to the
+  appropriate lens and keep this audit focused on structure.

--- a/.agents/skills/audit-cleanup/SKILL.md
+++ b/.agents/skills/audit-cleanup/SKILL.md
@@ -11,6 +11,11 @@ If a component is specified, scope to that component per `project/components.md`
 
 Before proposing new issues, check the current open GitHub issues for overlapping cleanup/refactor work. Prefer extending or linking existing issues over filing duplicates.
 
+Read the relevant canonical architecture note in `project/docs/architecture_*.md`
+before concluding that a cleanup is worthwhile. Cleanup should move the tree
+toward the intended language and ownership boundaries, not just reduce local
+mess.
+
 ## What to look for
 
 ### Public API compression
@@ -115,3 +120,7 @@ For each finding, classify it as one of:
 - **Keep intentionally** — a layer that looks redundant but currently enforces a real invariant; explain why
 
 Prefer findings that materially simplify the consumer experience or delete maintenance burden. Avoid low-signal nits that belong in `/audit-style`.
+
+If a cleanup finding reveals a stale canonical note, targeted design note, or
+skill definition, call that out explicitly. Shared doc/process drift is part of
+maintainability.

--- a/.agents/skills/audit-perf/SKILL.md
+++ b/.agents/skills/audit-perf/SKILL.md
@@ -9,6 +9,10 @@ Usage: /audit-perf [component]
 
 If a component is specified, scope to that component per `project/components.md`. Otherwise, audit the full `src/` tree.
 
+Read the relevant canonical architecture note in `project/docs/architecture_*.md`
+and benchmark-policy guidance in `AGENTS.md` before recommending structural perf
+changes. Performance advice should reinforce the intended execution model.
+
 ## What to look for
 
 ### Memory layout
@@ -81,3 +85,7 @@ Benchmark hygiene is part of the audit:
 - Prefer durable evidence: unchanged benchmark rows for base-vs-PR comparisons, plus same-run comparison benchmarks when a new benchmark is introduced.
 
 Ask the user which findings warrant issues.
+
+If the hot paths the audit identifies contradict the project's current setup or
+execution language, say so explicitly and name the canonical note that should be
+updated.

--- a/.agents/skills/audit-safety/SKILL.md
+++ b/.agents/skills/audit-safety/SKILL.md
@@ -9,6 +9,11 @@ Usage: /audit-safety [component]
 
 If a component is specified (e.g., `operators`), scope to that component per `project/components.md`. Otherwise, audit the full `src/` tree.
 
+Read the relevant canonical architecture note in `project/docs/architecture_*.md`
+when the audited area has an explicit ownership, execution, or abstraction
+boundary. Safety findings are stronger when they reference the intended design,
+not only the current implementation.
+
 ## What to look for
 
 ### Assertion coverage
@@ -63,3 +68,7 @@ For each critical or warning finding, propose whether it should be:
 - **Filed as an issue** (requires design thought or touches multiple files)
 
 Ask the user which findings to act on before creating any issues.
+
+If a safety finding exposes stale shared docs, missing invariant documentation,
+or a drift between the code and the canonical architecture notes, call that out
+explicitly.

--- a/.agents/skills/audit-style/SKILL.md
+++ b/.agents/skills/audit-style/SKILL.md
@@ -9,6 +9,10 @@ Usage: /audit-style [component]
 
 If a component is specified, scope to that component per `project/components.md`. Otherwise, audit the full `src/` tree.
 
+Read the relevant canonical architecture note in `project/docs/architecture_*.md`
+for the audited area so naming and structural-consistency findings are judged
+against the intended language, not only the local code.
+
 ## What to look for
 
 ### Naming
@@ -86,3 +90,6 @@ For each finding, propose whether it should be:
 - **Filed as an issue** (duplication that needs a shared abstraction, structural inconsistency)
 
 Ask the user which findings to act on before making changes or creating issues.
+
+If naming or comment drift reflects stale shared docs or skill language rather
+than only local style, say so explicitly.

--- a/.agents/skills/audit-tests/SKILL.md
+++ b/.agents/skills/audit-tests/SKILL.md
@@ -9,6 +9,10 @@ Usage: /audit-tests [component]
 
 If a component is specified, scope to that component per `project/components.md`. Otherwise, audit the full `src/` tree.
 
+Read the relevant canonical architecture note in `project/docs/architecture_*.md`
+before auditing generic or pattern-heavy test surfaces. The question is not only
+what the code does today, but what the API claims to be.
+
 ## What to look for
 
 ### Coverage gaps
@@ -79,6 +83,10 @@ For each finding, propose whether it should be:
 - **Filed as an issue** (new property test, convergence test, coverage expansion)
 
 Convergence tests and property tests should always be filed as issues — they require careful mathematical thought, not quick fixes.
+
+If a cluster of weak or redundant tests exists only because a wrapper or stale
+shared pattern exists, call that out explicitly and cross-link the abstraction
+or cleanup issue rather than treating the tests in isolation.
 
 If an API presents itself as a generic noun with adjective parameters, ask
 whether the tests actually exercise more than one meaningful adjective

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: audit
-description: Run all four audit lenses in parallel and consolidate the findings for this repository or a selected component.
-description: Run all five audit lenses in parallel and consolidate the findings for this repository or a selected component.
+description: Run all six audit lenses in parallel and consolidate the findings for this repository or a selected component.
 ---
 
-Run all five audit lenses in parallel and consolidate the results.
+Run all six audit lenses in parallel and consolidate the results.
 
 Usage: /audit [component]
 
@@ -12,21 +11,23 @@ If a component is specified (e.g., `operators`), pass it to each sub-audit. Othe
 
 ## Execution
 
-Spawn five agents in parallel, one for each audit lens:
+Spawn six agents in parallel, one for each audit lens:
 
 1. **Safety** — run `/audit-safety` (assertions, bounds, memory, numerical safety)
 2. **Style** — run `/audit-style` (naming, dead code, stale references, duplication)
 3. **Cleanup** — run `/audit-cleanup` (API sprawl, indirection, shims, deduplication, structure)
-4. **Performance** — run `/audit-perf` (layout, allocations, algorithmic efficiency)
-5. **Tests** — run `/audit-tests` (coverage, property test quality, redundancy)
+4. **Abstraction** — run `/audit-abstraction` (weak nouns and verbs, wrapper layers, policy-shaped APIs, cross-component seams)
+5. **Performance** — run `/audit-perf` (layout, allocations, algorithmic efficiency)
+6. **Tests** — run `/audit-tests` (coverage, property test quality, redundancy)
 
 Each agent should:
 - Read `project/components.md` to understand scope
+- Read any relevant canonical architecture note in `project/docs/architecture_*.md` for the scope being audited
 - If a component was specified, scope to that component's files and dependencies
 - Produce findings in the format defined by its respective skill
 - Return its findings to the parent
 
-Across all five lenses, keep one shared abstraction question in view:
+Across all six lenses, keep one shared abstraction question in view:
 - What are the nouns?
 - What are the verbs?
 - What are the adjectives/qualifiers?
@@ -35,7 +36,7 @@ Use that to distinguish true structural problems from isolated local symptoms.
 
 ## Consolidation
 
-After all four agents complete, consolidate into a single report:
+After all six agents complete, consolidate into a single report:
 
 ```
 ## Full Audit: <scope>
@@ -54,6 +55,10 @@ Date: YYYY-MM-DD
 <summary>
 <top findings>
 
+### Abstraction
+<summary>
+<top findings>
+
 ### Performance
 <summary>
 <top findings>
@@ -66,8 +71,9 @@ Date: YYYY-MM-DD
 
 | # | Title | Lens | Severity | Component |
 |---|-------|------|----------|-----------|
-| 1 | ... | safety | critical | operators |
-| 2 | ... | tests | warning | topology |
+| 1 | ... | abstraction | high | operators/forms |
+| 2 | ... | safety | critical | operators |
+| 3 | ... | tests | warning | topology |
 ...
 ```
 
@@ -75,6 +81,10 @@ Present the consolidated report to the user. Ask which findings they want filed 
 - `type/bug` for safety criticals, `type/refactor` for style or cleanup, `type/perf` for performance, `type/test` for test gaps
 - Appropriate `domain/` label from the component
 - `priority/high` for criticals, `priority/medium` for warnings
+
+If multiple lenses point to the same stale canonical note, targeted design note,
+or skill definition, call that out explicitly. Shared process/doc drift is a
+real finding, not incidental noise.
 
 ## Constraints
 

--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -21,11 +21,12 @@ This skill is primarily **agent-invoked during `/tackle`** when a non-obvious de
 
 1. Identify the current epoch by reading `project/` directory structure.
 2. Read the existing `project/epoch_N/decision_log.md` to understand what's already been logged and to avoid duplication.
-3. If the context is not already clear (e.g., the user invoked this directly without prior discussion), ask for:
+3. Read any relevant canonical architecture note in `project/docs/architecture_*.md` when the decision touches a durable public abstraction, ownership boundary, or recurring pattern.
+4. If the context is not already clear (e.g., the user invoked this directly without prior discussion), ask for:
    - The decision made (what was chosen)
    - Alternatives that were considered (at least one)
    - The rationale — why this option over the alternatives
-4. Append the decision to `project/epoch_N/decision_log.md` in this format:
+5. Append the decision to `project/epoch_N/decision_log.md` in this format:
 
 ```
 ## YYYY-MM-DD: <short imperative title>
@@ -46,3 +47,8 @@ Today's date is available in the system context. Use it.
 Do not editorialize or second-guess the decision. Record it faithfully. The log is a historical record, not a critique.
 
 When invoked during `/tackle`, commit the decision log update alongside the code it pertains to — don't make a separate commit just for the log entry.
+
+If the decision changes the *current intended architecture* rather than only the
+local implementation path, update the relevant canonical note in
+`project/docs/architecture_*.md` in the same change when practical. If no such
+note exists yet, say so explicitly and recommend creating or updating one.

--- a/.agents/skills/epoch/SKILL.md
+++ b/.agents/skills/epoch/SKILL.md
@@ -12,10 +12,11 @@ Before saying anything else:
 2. Read the most recent `project/epoch_*/retrospective.md` — its recommendations feed directly into this planning session.
 3. Read `project/initial.md` as the reference architecture.
 4. Read `project/horizons.md` to know which future directions must not be precluded by this epoch's work.
-5. Read `project/components.md` to understand the current codebase structure.
-6. Run `gh api "repos/harnesslabs/flux/milestones?state=all"` and `gh issue list --state open --repo harnesslabs/flux` to see live GitHub state.
-7. Present a brief, direct summary of current state (what epoch we're on, what's done, what's open).
-8. Ask the user: what should this epoch accomplish? What is the north star?
+5. Read relevant canonical architecture notes in `project/docs/architecture_*.md` to understand the current intended design, not only the historical plan.
+6. Read `project/components.md` to understand the current codebase structure.
+7. Run `gh api "repos/harnesslabs/flux/milestones?state=all"` and `gh issue list --state open --repo harnesslabs/flux` to see live GitHub state.
+8. Present a brief, direct summary of current state (what epoch we're on, what's done, what's open).
+9. Ask the user: what should this epoch accomplish? What is the north star?
 
 ## During the conversation
 
@@ -53,6 +54,7 @@ Ask about the direction beyond the current epoch — architecture decisions made
    - `project/epoch_N/roadmap.md` — structured list of milestones with goals, acceptance criteria, issue lists, and ordering. Include a one-paragraph epoch goal at the top.
    - `project/epoch_N/decision_log.md` — empty template with header only.
    - `project/epoch_N/retrospective.md` — empty template (filled at epoch end via `/retro`).
+   - If the epoch introduces a new durable architectural thread not already covered by the canon, create or update the relevant note in `project/docs/`.
 3. Create a GitHub issue to track the planning artifact:
    ```sh
    gh issue create \
@@ -80,6 +82,10 @@ Ask about the direction beyond the current epoch — architecture decisions made
    ```
 7. Report the epoch document paths, issue URL, and draft PR URL.
 8. Tell the user to run `/milestone` for each milestone when ready to create GitHub Milestones and issues.
+
+Planning should cross-pollinate with the canon:
+- If the epoch depends on a stable architecture language or recurring pattern, cite the relevant `project/docs/architecture_*.md` note.
+- If planning exposes a missing canonical note, say so explicitly rather than leaving the gap implicit.
 
 ## Templates
 

--- a/.agents/skills/ideate/SKILL.md
+++ b/.agents/skills/ideate/SKILL.md
@@ -14,7 +14,8 @@ Before responding:
 2. Read `project/horizons.md` to know what future directions are already validated.
 3. Read the current epoch's `roadmap.md` (find the latest `project/epoch_N/`) to understand what's already planned.
 4. Read the current epoch's `decision_log.md` to know what's already been decided.
-5. Skim the codebase structure (`src/`) to understand what exists today.
+5. Read any relevant canonical architecture notes in `project/docs/architecture_*.md` and targeted design notes in `project/docs/` that touch the ideas under discussion.
+6. Skim the codebase structure (`src/`) to understand what exists today.
 
 Do NOT dump all of this back at the user. Internalize it silently so your responses are informed.
 
@@ -97,6 +98,13 @@ Date: YYYY-MM-DD
 
 Create the `project/ideation/` directory if it doesn't exist.
 
+If the discussion produces a durable change to the project's architecture
+language, ownership model, or recurring design patterns, say so explicitly and
+recommend the relevant next write target:
+- `project/docs/architecture_*.md` for canonical current design
+- `project/horizons.md` for validated but unscheduled future direction
+- `project/epoch_N/decision_log.md` for a concrete active decision
+
 ## Guidelines
 
 - **Be honest, not encouraging.** If an idea doesn't fit, say so directly. "This is interesting but it's a different project" is a valid and helpful response.
@@ -104,3 +112,8 @@ Create the `project/ideation/` directory if it doesn't exist.
 - **Think in types.** Many of these ideas (dimensionful equations, k-form safety) have natural `comptime` expressions in Zig. When an idea maps to a type-level guarantee, say so — that's a strong signal it belongs.
 - **No commitments.** This skill produces analysis, not plans. The output is input to `/epoch`, not a substitute for it.
 - **Follow the user's energy.** If they're excited about one idea, go deep on it. Don't mechanically march through the list.
+- **Keep the canon alive.** If an architecture note or pattern doc is clearly stale relative to the discussion, name that explicitly rather than leaving the drift implicit.
+- **Close the loop when obvious.** The skill is still analysis-first, but if the
+  user clearly endorses a low-risk documentation or issue-scope update that
+  falls directly out of the discussion, make that update instead of stopping one
+  step short.

--- a/.agents/skills/milestone/SKILL.md
+++ b/.agents/skills/milestone/SKILL.md
@@ -9,15 +9,16 @@ Plan and create a new GitHub milestone for the current epoch.
 
 1. Read `project/epoch_N/roadmap.md` for the current epoch to understand existing milestones.
 2. Read `project/components.md` to understand scope boundaries for issues.
-3. Run `gh milestone list` to see what's already on GitHub.
-4. If the user has not stated a milestone goal, ask for it.
-5. Propose a single-sentence acceptance criterion — a concrete mathematical or behavioral invariant
+3. Read any relevant canonical architecture notes in `project/docs/architecture_*.md` and targeted design notes in `project/docs/` that affect the milestone's abstractions or boundaries.
+4. Run `gh milestone list` to see what's already on GitHub.
+5. If the user has not stated a milestone goal, ask for it.
+6. Propose a single-sentence acceptance criterion — a concrete mathematical or behavioral invariant
    that, when passing in CI, means the milestone is done. Examples:
    - "dd = 0 holds exactly for all k on a uniform 2D triangular mesh with random cochain inputs"
    - "A radiating dipole simulation produces ∇·B = 0 to machine precision at every time step"
    Get explicit confirmation before proceeding.
 
-6. Draft 5–10 GitHub issues. Each issue must:
+7. Draft 5–10 GitHub issues. Each issue must:
    - Deliver a **complete capability** (not a single task)
    - Own 3–5 tasks as checkboxes in the issue body
    - At minimum: one test task, one implementation task
@@ -36,13 +37,14 @@ Plan and create a new GitHub milestone for the current epoch.
      - Task checklist (3–5 items)
      - Component scope (from `project/components.md`)
      - References to relevant files, issues, or horizons
+     - References to relevant canonical architecture notes when the issue touches a durable abstraction
 
    **Sizing check:** If an issue has only 1 task, it's too small — bundle it.
    If it has more than 7 tasks, it's too big — split it.
 
-7. Show the full issue list to the user and get confirmation before creating anything on GitHub.
+8. Show the full issue list to the user and get confirmation before creating anything on GitHub.
 
-8. On confirmation:
+9. On confirmation:
    a. Create the GitHub milestone:
       ```sh
       gh milestone create --title "<name>" --description "<acceptance criterion>"
@@ -62,7 +64,11 @@ Plan and create a new GitHub milestone for the current epoch.
       Find the project number with: `gh project list --owner harnesslabs`
    d. Append the milestone to `project/epoch_N/roadmap.md` with its acceptance criterion and milestone URL.
 
-9. Report: milestone URL, issue count, acceptance criterion, and a link to the GitHub Project board.
+10. Report: milestone URL, issue count, acceptance criterion, and a link to the GitHub Project board.
+
+If milestone planning reveals a durable architectural gap or a stale canonical
+note, name that explicitly. Milestones should consume the canon and also expose
+when it needs to be updated.
 
 ## Label taxonomy (for reference when assigning)
 

--- a/.agents/skills/retro/SKILL.md
+++ b/.agents/skills/retro/SKILL.md
@@ -13,7 +13,8 @@ If no epoch number is given, use the most recent epoch (highest N in `project/ep
 
 1. Read the epoch's `roadmap.md` to understand what was planned.
 2. Read the epoch's `decision_log.md` to see what was explicitly logged.
-3. Get the full history of work done in the epoch:
+3. Read the relevant canonical architecture notes in `project/docs/architecture_*.md` and any targeted design notes in `project/docs/` that the epoch touched.
+4. Get the full history of work done in the epoch:
    ```sh
    # All closed issues for each milestone in the epoch
    gh milestone list --state all --json title,number
@@ -21,11 +22,11 @@ If no epoch number is given, use the most recent epoch (highest N in `project/ep
    gh issue list --state closed --milestone "<milestone>" --json number,title,labels,closedAt
    gh issue list --state open --milestone "<milestone>" --json number,title,labels
    ```
-4. Get the PR history:
+5. Get the PR history:
    ```sh
    gh pr list --state merged --json number,title,mergedAt,additions,deletions,commits
    ```
-5. Read the git log for the epoch's timeframe to understand the actual sequence of work:
+6. Read the git log for the epoch's timeframe to understand the actual sequence of work:
    ```sh
    git log --oneline --since="<epoch start date>" --until="<epoch end date or now>"
    ```
@@ -102,6 +103,10 @@ Duration: <actual time from first commit to last merge>
 
 Present the draft to the user for review. The retrospective is a shared document — the agent writes it, the user edits and approves it.
 
+Alongside the retrospective, propose the canonical doc updates that should be
+made to `project/docs/` so the enduring architecture is not trapped only in the
+epoch journal.
+
 ## Phase 3.5: Close milestones
 
 After the retrospective is written, close all milestones belonging to the epoch on GitHub:
@@ -122,6 +127,7 @@ Based on the retrospective, propose specific changes:
 - Skills that should be removed or merged
 - Changes to issue templates, labels, or GitHub configuration
 - Horizon entries that should be added or updated based on what was learned
+- Canonical architecture notes that should be created, updated, merged, or retired
 
 These proposals are input to the next `/epoch` session. Do not make the changes directly — present them for discussion.
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -22,11 +22,13 @@ Structure your review accordingly: lead with the implementation-detail findings 
    gh pr view <number> --json number,title,body,labels,headRefName,additions,deletions,files
    ```
 2. Extract the linked issue number from `Closes #N` in the PR body.
-3. Read the full issue: `gh issue view <N>` — get the acceptance criterion and references.
-4. Read the epoch roadmap to understand where this fits: `project/epoch_*/roadmap.md`.
-5. Read `project/components.md` to map the changed files to their expected component scope. Flag if the PR touches files outside that scope without justification.
-6. Read only the changed files and the direct dependency files required to review them.
-7. Fetch targeted diff context for the touched files. Avoid reading the full PR diff unless the PR is small enough that the broad diff is itself the smallest sufficient context.
+3. Read the full issue and its comments: `gh issue view <N> --comments` — get the acceptance criterion, references, and any later clarifications.
+4. Read PR comments and review comments when present; thread context is part of the review contract, not optional background.
+5. Read the epoch roadmap to understand where this fits: `project/epoch_*/roadmap.md`.
+6. Read any relevant canonical architecture note in `project/docs/architecture_*.md` when the PR touches public abstractions, ownership boundaries, or recurring patterns.
+7. Read `project/components.md` to map the changed files to their expected component scope. Flag if the PR touches files outside that scope without justification.
+8. Read only the changed files and the direct dependency files required to review them.
+9. Fetch targeted diff context for the touched files. Avoid reading the full PR diff unless the PR is small enough that the broad diff is itself the smallest sufficient context.
 
 ## Review lenses
 
@@ -66,6 +68,11 @@ These are the findings the user is least likely to catch:
 - Redundant computation that could be hoisted or cached
 - Unnecessary allocations in hot paths
 - Code that duplicates logic existing elsewhere in the component
+- Weak abstractions introduced under implementation pressure: wrapper nouns,
+  builder layers, policy-shaped types, or convenience paths that should have
+  been a stronger verb or a direct concept boundary instead
+- Cross-component leaks where example or benchmark code is compensating for a
+  library seam instead of exercising a coherent public language
 
 ### 6. Process
 - PR body has `Closes #N`?
@@ -75,10 +82,16 @@ These are the findings the user is least likely to catch:
 - If benchmark methodology did not change, did the PR preserve base-vs-PR comparability instead of hiding behind a version bump?
 - If the claimed perf win comes from a new benchmark with no base counterpart, is there an explicit same-run comparison showing the win?
 - Were any non-obvious architectural decisions made? If yes, are they in the decision log?
+- If the PR changes the current intended architecture, was the relevant
+  canonical note in `project/docs/architecture_*.md` updated?
+- Does the PR reveal that a canonical note, design note, or skill definition is
+  now stale even if the code change itself is acceptable?
 - Labels correct: `type/`, `domain/`, `priority/` all set?
 - Does this introduce an interface that conflicts with a known horizon in `project/horizons.md`?
 - Do the public names form a coherent abstraction language: stable nouns,
   meaningful verbs, and qualifiers/adjectives in the right place?
+- Did this PR miss a chance to remove a weak abstraction that became obvious
+  while the seam was already open?
 - Are there follow-on issues that should be opened before this merges?
 - If review exposes **non-blocking but real** follow-on work that should not bloat the current PR:
   - Check whether it is already tracked

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -8,15 +8,16 @@ Check the current epoch and milestone status for the flux project.
 ## Steps
 
 1. Read `project/epoch_*/roadmap.md` for the most recent epoch — get the current milestone name and its acceptance criterion.
-2. Read `project/components.md` for component context.
-3. Run the following gh commands to get live state:
+2. Read relevant canonical architecture notes in `project/docs/architecture_*.md` if current work is clearly clustered around one architectural thread.
+3. Read `project/components.md` for component context.
+4. Run the following gh commands to get live state:
    ```sh
    gh milestone list --state open
    gh issue list --state open --label "priority/high"
    gh issue list --state open --milestone "<current milestone name>"
    gh issue list --state closed --milestone "<current milestone name>"
    ```
-4. Check for tests covering the acceptance criterion: `zig build test --summary all`
+5. Check for tests covering the acceptance criterion: `zig build test --summary all`
 
 Report, in order:
 1. **Current epoch** — goal and epoch document path
@@ -26,7 +27,8 @@ Report, in order:
 5. **High-priority open issues** — list them with their `domain/` and `type/` labels
 6. **Acceptance criterion status** — passing or not, based on test output
 7. **Decision log health** — are there entries since last check? If the milestone has had PRs merged but no decisions logged, flag it.
-8. **Recommended next action** — name a specific issue number or suggest `/tackle`
+8. **Architecture doc health** — do the canonical notes in `project/docs/` look current for the active work, or is there obvious drift?
+9. **Recommended next action** — name a specific issue number or suggest `/tackle`
 
 Label reference for filtering:
 - `type/invariant` — math property work (usually on the critical path)

--- a/.agents/skills/tackle/SKILL.md
+++ b/.agents/skills/tackle/SKILL.md
@@ -11,13 +11,14 @@ Find and work the highest-priority open issue to completion — one issue, one b
 2. Read `project/epoch_*/roadmap.md` for the current epoch to understand milestone priorities and acceptance criteria.
 3. Read `project/horizons.md` — before writing any interface, check that it does not preclude a known future direction.
 4. Read `project/vision.md` when the work introduces or reshapes a public abstraction. Treat issue wording as the local symptom, not automatically as the correct abstraction boundary.
-5. Get live state:
+5. Read any relevant canonical architecture notes in `project/docs/architecture_*.md` when the issue touches public nouns, ownership boundaries, execution patterns, or recurring design rules.
+6. Get live state:
    ```sh
    gh milestone list --state open
    gh issue list --state open --label "priority/high" --json number,title,labels,milestone
    gh issue list --state open --label "status/blocked" --json number,title,labels,milestone
    ```
-6. Select the best issue to work next using this priority order:
+7. Select the best issue to work next using this priority order:
    - On the current milestone (check which milestone is earliest in the roadmap)
    - `type/invariant` preferred — these are on the critical path for acceptance criteria
    - `priority/high` over `priority/medium`
@@ -25,13 +26,19 @@ Find and work the highest-priority open issue to completion — one issue, one b
    - Skip `status/blocked` issues (they can't be worked until unblocked)
    - Non-epoch bugs (`type/bug`) may take priority if they are breaking something
 
-7. Present the chosen issue to the user: number, title, acceptance criterion, and a one-sentence rationale for why this one. Ask for confirmation or redirection.
+8. Present the chosen issue to the user: number, title, acceptance criterion, and a one-sentence rationale for why this one. Ask for confirmation or redirection.
 
 ## Scope the work
 
 On confirmation:
 
 1. Read the full issue body: `gh issue view <number>`
+   Then read the issue comments as part of the active contract:
+   ```sh
+   gh issue view <number> --comments
+   ```
+   If there is an open PR already associated with the issue or prior review
+   context that materially affects scope, read that thread too.
 2. Identify the **component scope** from `project/components.md` based on the issue's `domain/` label. Name the component and direct dependencies explicitly before opening source files.
 3. State the deeper structural concept you expect the issue to touch. If the issue title/body names a policy or one example family, ask whether that is the real abstraction or only the current manifestation.
 4. Create a branch and immediately open a draft PR:
@@ -112,6 +119,8 @@ Design the public interface before implementing internals.
 8. If a non-obvious design choice was made (struct layout, ownership model, comptime parameter choice), log it immediately:
    - Read the current epoch's `decision_log.md`
    - Append the decision in the standard format (see `/decide`)
+   - If the decision changes durable architecture, update the relevant
+     `project/docs/architecture_*.md` note in the same change when practical
    - Commit the decision log alongside the stubs
 9. Commit and push:
    ```sh
@@ -141,6 +150,7 @@ Fill in the stubs until tests pass.
    - Do **not** expand the current PR to include these unless they are required to finish the issue correctly
    - Before creating anything, check whether the follow-on is already tracked
    - If it is real, untracked, and worth doing later, open a **non-milestone** GitHub issue with the normal labels (`type/`, `domain/`, `priority/`) and explicitly leave milestone unset
+   - If the follow-on is really a stale shared doc, pattern note, or skill definition, update it directly when the fix is small and clearly correct; otherwise open a docs/refactor issue instead of leaving the drift implicit
 
 10. If the implementation solves the issue by introducing a narrow policy-shaped abstraction, stop and redesign before finalizing. The goal is to remove the symptom by exposing the deeper reusable concept, not by wrapping today's special case in a new public type.
 
@@ -155,10 +165,13 @@ The rhythm is: **write → test → commit → push → repeat**.
    - Add a "## Limitations" section for known gaps
 3. Answer the molecule checklist:
    - Does this introduce an interface that conflicts with a known horizon in `project/horizons.md`?
+   - Does this change the current intended architecture recorded in `project/docs/architecture_*.md`?
    - Does existing documentation need updating?
    - Does this change the public API in a way that affects other modules?
    - Are there follow-on issues that should be opened?
 4. If you discovered real follow-on work during implementation and it is not already tracked, open the non-milestone issue(s) now and mention them in the PR description.
+   If existing issue comments or PR discussion already capture the follow-on
+   precisely, prefer updating or linking that thread over opening a duplicate.
 5. Mark the PR as ready for review:
    ```sh
    gh pr ready <number>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,18 @@ Read in this order:
 3. Only the artifact that matches the current assignment:
    - implementation: the current issue/PR, then only the relevant component files
    - planning: the latest `project/epoch_*/roadmap.md`
-   - design alignment: `project/vision.md` and `project/horizons.md`
+   - design alignment: `project/vision.md`, `project/horizons.md`, and any
+     relevant canonical architecture note in `project/docs/architecture_*.md`
    - decision logging: the current `project/epoch_N/decision_log.md`
 4. Expand scope only when the current artifact proves you need more context.
 
 Default rule: before any exploratory tool call, ask what the **smallest sufficient document or file set** is for the current task.
+
+When GitHub artifacts are involved, "the artifact" includes its discussion
+thread, not just the top-level body. Read relevant issue comments, PR comments,
+and review comments when they may contain design clarifications, follow-up
+constraints, or scope changes. Do not assume the issue body alone is the full
+current contract.
 
 Do not read unrelated `src/` files "just to learn the repo". Learn the repo through `project/components.md`, then open only the component and direct dependencies that the task actually touches.
 
@@ -29,6 +36,38 @@ When designing APIs, prefer **one obvious way** to do something. Do not keep
 parallel convenience and "real" APIs unless there is a concrete current need.
 The project is pre-release; correctness and coherence matter more than
 backward compatibility with transitional interfaces.
+
+Prefer **concept-only boundaries** over concept-plus-wrapper designs when the
+wrapper only re-validates the same interface and forwards calls. A wrapper must
+earn its existence by adding owned state, caching, a stronger invariant, or a
+real representation boundary. Otherwise, validate the comptime concept at the
+consumer boundary and pass the conforming type directly.
+
+Default cleanup instinct: **delete or consolidate before adding**. When a seam
+looks weak, first ask what can cease to exist. Do not add a wrapper, alias,
+builder, or helper layer if removing or collapsing the existing weak shape
+would produce a cleaner API.
+
+Strike while the iron is hot. If you are already working in a part of the
+codebase and discover a clear local abstraction improvement, stop and surface
+it immediately instead of silently paving over it with another layer. Prefer a
+short explicit proposal such as: "I found a weaker API seam here; I can remove
+or consolidate it as part of this change if you want."
+
+Keep the shared agent memory synchronized. Durable architecture belongs in
+`project/docs/architecture_*.md`, active local decisions belong in the current
+epoch `decision_log.md`, and targeted forward-looking threads belong in scoped
+notes under `project/docs/`. If work exposes stale skills, stale docs, or a
+missing canonical note, update them when the fix is small and clearly correct;
+otherwise open or recommend a follow-on issue instead of leaving the drift
+implicit.
+
+Complete the obvious follow-through. If the right next action is clear and
+low-risk — for example updating a canonical doc, extending an existing issue,
+or aligning a skill definition with the conclusion just reached — do it by
+default and report it. Only stop to ask when the next action is materially
+ambiguous, high-cost to unwind, or changes project direction in a nontrivial
+way.
 
 When extracting an abstraction from an issue or a duplicated example pattern,
 do **not** stop at the nearest working seam. Pressure-test the candidate API

--- a/project/docs/architecture_language.md
+++ b/project/docs/architecture_language.md
@@ -1,0 +1,239 @@
+# Architecture Language
+
+Date: 2026-04-15
+
+## Purpose
+
+This note defines the preferred public language for setting up and executing
+problems in flux. It is the canonical destination for the durable parts of the
+problem-setup ideation work.
+
+The goal is not to freeze every API detail today. The goal is to make the
+structural nouns, verbs, and qualifiers explicit so new APIs converge toward one
+coherent language instead of growing ad hoc.
+
+## Core rule
+
+Users should be able to read a flux setup and recognize:
+
+- what is topology
+- what is geometry
+- what is metric structure
+- what is the PDE system
+- what is the execution or solve mechanism
+
+If a setup reads like a pile of helper types, wrappers, builders, or
+case-specific names, the language is still wrong.
+
+## Preferred top-level nouns
+
+### `Mesh`
+
+`Mesh` is the concrete discrete domain constructor and storage object.
+
+Today it may still carry both topology and some geometry-derived data. That is
+acceptable as an implementation reality, but the public language should not
+pretend those concerns are fundamentally identical.
+
+`Mesh` should stay a structural noun, refined by adjectives or comptime
+parameters such as:
+
+- embedding dimension
+- topological dimension
+- family of canonical geometry constructor
+
+### `Geometry`
+
+`Geometry` is the noun for embedding-dependent geometric structure and, later,
+mesh motion.
+
+This layer should eventually make it possible to distinguish:
+
+- fixed embedding-derived geometry
+- prescribed geometry on fixed topology
+- moving geometry whose state evolves in time
+
+The existence of this noun matters even before a fully separate runtime object
+exists everywhere in the implementation. It is the right mental boundary for
+future API design.
+
+### `Metric`
+
+`Metric` is the noun for the inner-product structure used by metric-dependent
+operators such as `★`, codifferentials, and Laplacians.
+
+The default special case should be explicit:
+
+- `Metric(.euclidean)`
+- `Metric(.riemannian, g)`
+
+This is preferred over vague “mode” flags because it names the mathematical
+object rather than the policy choice.
+
+`Metric` is likely not the whole geometry story by itself. It should be treated
+as one structural layer inside a broader geometry boundary.
+
+### `System`
+
+`System` is the noun for one PDE setup over a mesh, geometry, and metric.
+
+The system owns:
+
+- the chosen mathematical family or families
+- assembled operators and boundary-conditioned variants
+- PDE-specific state shape
+- problem-specific setup semantics
+
+Flux should provide the language for defining systems cleanly. It should not
+grow into a built-in catalog of named PDE APIs such as “Maxwell system,”
+“Euler system,” and so on as first-class core-library nouns.
+
+The library should instead let users define those systems against a stable
+structural language.
+
+### `State`
+
+`State` is the evolving or solved-for discrete unknown associated with a
+`System`.
+
+It should be named by mathematical role, not by framework plumbing. For
+example, a state may contain fields, forms, or coefficients, but it should not
+exist only to satisfy a wrapper seam.
+
+### `Evolution` / `Solver`
+
+Execution nouns should reflect the actual job being done:
+
+- `Evolution` for repeated time stepping
+- `Solver` for linear, nonlinear, or implicit solve processes
+
+Do not invent extra nouns when a strong verb on an existing structural noun
+would do. If an execution object exists, it should own real orchestration state,
+not only forward to another type.
+
+`Evolution` should usually be a capability over a `System`, not the same noun.
+The separation matters:
+
+- `System` defines the PDE/model structure and state semantics
+- `Evolution` defines one repeated-step execution story over systems that
+  support stepping
+
+Some systems do not evolve in time at all. Others may admit multiple execution
+stories (explicit, implicit, split, multirate) over the same underlying system.
+For that reason, the project should resist collapsing `System` and `Evolution`
+into one default public noun.
+
+The tighter direction is:
+
+- keep `System` and `Evolution` separate
+- make `Evolution` depend on a direct evolvable-system contract
+- avoid extra wrapper nouns between the system, the stepper concept, and the
+  orchestration object
+
+## Family choice
+
+The mathematical family choice should sit at the system layer.
+
+Users should not have to manually assemble a bag of DEC and FEEC operators just
+to express a standard problem. The setup should name the family directly, while
+still allowing:
+
+- user-defined PDE systems
+- mixed FEEC/DEC formulations when the semantics genuinely differ
+- explicit expert composition when a problem really needs it
+
+The project should resist carrying parallel public APIs that express the same
+operation twice merely because one path is older or more convenient.
+
+## Preferred verbs
+
+The language should lean on a small set of strong verbs:
+
+- `init`
+- `assemble`
+- `advance`
+- `solve`
+- `observe`
+- `project`
+- `lift`
+
+These verbs should sit on stable nouns. Avoid creating a new noun when the real
+operation is simply “do X to this object.”
+
+## Qualifiers should usually be adjectives
+
+Many distinctions in flux are qualifiers, not reasons to mint fresh public
+nouns. Prefer adjectives or comptime parameters for:
+
+- dimension
+- degree
+- primal versus dual
+- scalar type
+- DEC versus FEEC family choice
+- Euclidean versus Riemannian metric choice
+
+Create a new noun only when the underlying mathematical or computational role is
+different, not merely because one more policy axis was introduced.
+
+## Ownership and cache boundaries
+
+The language should make the following ownership boundaries legible:
+
+- topology-owned: incidence and purely topological structure
+- geometry-owned: embedding-derived measures and geometric updates
+- metric-owned: metric-dependent structure
+- system-owned: assembled operators, boundary-conditioned variants, and
+  problem-local caches
+- execution-owned: repeated-step orchestration, solver state, observer staging
+
+This is the main reason the project should avoid mesh-owned operator caches as a
+default public model. What users want is a coherent setup language, not blurred
+ownership.
+
+## Example pressure tests
+
+A good setup language should support at least these three shapes cleanly:
+
+1. User-defined fixed-mesh hyperbolic system
+2. User-defined metric-aware elliptic or parabolic system
+3. User-defined moving-geometry or ALE-flavored system
+
+If one of those forces a pile of builders, wrappers, or example-only helper
+nouns, the language needs revision.
+
+## Benchmark implication
+
+Benchmarks should be chosen from the hot paths implied by this language:
+
+- setup and assembly cost
+- repeated operator application cost
+- repeated solve cost
+- observer overhead
+- invalidation and reassembly cost under geometry or metric changes
+
+This is stronger than benchmarking whichever functions happen to exist. The
+benchmark suite should measure user-relevant execution paths.
+
+## API review checklist
+
+Before adding a new public type or helper, ask:
+
+1. Is this a stable structural noun?
+2. Could this instead be an adjective on an existing noun?
+3. Could this instead be a verb on an existing noun?
+4. Does this clarify topology, geometry, metric, system, state, or execution?
+5. Would the new shape make example setups smaller and clearer?
+
+If the answer is weak, do not add the new noun.
+
+## Open edges
+
+The following points are intentionally not frozen yet:
+
+- whether `Geometry` should become a first-class runtime object immediately
+- where mixed FEEC/DEC formulations should appear in the public setup surface
+- the final naming split between `Evolution`, `Stepper`, and `Solver`
+- the exact direct contract between `System` and `Evolution`
+- the exact boundary between system-level and lower-level boundary-condition APIs
+
+These should evolve under this language, not around it.

--- a/project/docs/architecture_memory.md
+++ b/project/docs/architecture_memory.md
@@ -1,0 +1,275 @@
+# Architecture Memory Proposal
+
+Date: 2026-04-15
+
+## Problem
+
+The current project memory model is write-optimized but not read-optimized.
+
+Today, non-obvious decisions are recorded in the current epoch's
+`decision_log.md`. That is useful while the work is active, but weak as a
+durable reference because it mixes several different kinds of information:
+
+- enduring architectural commitments
+- temporary sequencing choices
+- issue-local rationale
+- experiments that were later superseded
+
+As the project grows, this produces the wrong reading experience:
+
+- too much low-level history to find the durable point
+- sparse entries spread across epochs
+- repeated context reconstruction when revisiting an area months later
+
+The result is that the decision log is still valuable as a journal, but is not
+serving well as the main architecture reference.
+
+## Goal
+
+Keep the discipline of logging non-obvious decisions during active work, while
+creating a smaller set of read-optimized documents that preserve the durable
+architecture of the project.
+
+The target properties are:
+
+- easy to read after a long context gap
+- organized by concept rather than chronology
+- explicit about what is current versus superseded
+- small enough that agents and humans will actually consult it
+
+## Proposed model
+
+Flux should maintain three distinct documentation layers.
+
+### 1. Journal: epoch decision logs
+
+Location:
+- `project/epoch_N/decision_log.md`
+
+Purpose:
+- write-optimized record during active work
+- capture non-obvious decisions quickly while context is fresh
+- preserve alternatives and immediate rationale
+
+What belongs here:
+- issue-level design choices
+- temporary tradeoffs against the vision
+- sequencing choices that matter during the epoch
+- local rationale that may later be compressed away
+
+What does not need to survive here forever:
+- every transient implementation fork once the durable outcome is known
+
+### 2. Canon: read-optimized architecture notes
+
+Location:
+- `project/docs/architecture_*.md`
+
+Purpose:
+- durable reference for the current intended design
+- concept-oriented, not chronological
+- first place to look when re-entering a subsystem
+
+What belongs here:
+- stable public nouns and verbs
+- ownership boundaries
+- cache and invalidation rules
+- family distinctions such as DEC vs FEEC
+- geometry/metric/topology splits
+- benchmark-method policy when it is architectural rather than merely procedural
+
+What does not belong here:
+- full local history
+- issue-by-issue narration
+- every discarded alternative
+
+### 3. Design notes: targeted forward-looking documents
+
+Location:
+- `project/docs/<topic>.md`
+
+Purpose:
+- focused notes for one architectural thread that is too important to bury in a
+  journal entry but not yet broad enough for the canon
+
+Examples:
+- wedge / Whitney nonlinear operator direction
+- problem setup language
+- future geometry/metric API shape
+
+These documents can later either:
+- graduate into the architecture canon, or
+- remain as scoped references if the topic stays specialized
+
+## Recommended file structure
+
+```text
+project/
+  docs/
+    architecture_overview.md
+    architecture_language.md
+    architecture_operators.md
+    architecture_geometry.md
+    architecture_execution.md
+    wedge_product_whitney_plan.md
+```
+
+The exact split can evolve, but it should stay intentionally small. The point is
+not to create a second sprawling doc tree.
+
+## Recommended canonical notes
+
+### `architecture_overview.md`
+
+Purpose:
+- short entry point for the durable mental model
+
+Contents:
+- what flux is
+- the primary abstraction hierarchy
+- how to navigate the other architecture notes
+- a short “current shape” summary
+
+### `architecture_language.md`
+
+Purpose:
+- define the stable public nouns, verbs, and adjectives
+
+Contents:
+- `Mesh`, `Geometry`, `Metric`, `System`, `State`, `Evolution` or `Solver`
+- criteria for introducing a new public noun
+- when qualifiers should be adjectives or comptime parameters
+- relationship between examples and public language
+
+This should absorb the durable part of the problem-setup-language ideation.
+
+### `architecture_operators.md`
+
+Purpose:
+- define operator-family boundaries and composition rules
+
+Contents:
+- DEC versus FEEC roles
+- bridge operators
+- what belongs in operator contexts
+- what should remain family-specific versus family-agnostic
+
+### `architecture_geometry.md`
+
+Purpose:
+- define topology, geometry, metric, and motion boundaries
+
+Contents:
+- what is purely topological
+- what depends on embedding
+- what depends on metric
+- invalidation rules for moving geometry
+- how flat and Riemannian cases relate
+
+### `architecture_execution.md`
+
+Purpose:
+- define setup cost, caching, solve/evolution ownership, and benchmark meaning
+
+Contents:
+- setup versus hot-path execution
+- cache ownership and invalidation
+- benchmark selection principles
+- how observers, solvers, and integrators fit the model
+
+## Lifecycle
+
+### During an issue
+
+1. Log non-obvious decisions in the current epoch journal.
+2. If a targeted topic needs more room, add or update a scoped note in
+   `project/docs/`.
+3. If the change alters durable architecture, mark the affected canonical note
+   for update before the PR is considered complete.
+
+### During milestone or epoch review
+
+1. Distill the journal into the affected canonical notes.
+2. Remove or compress entries whose only remaining value is historical.
+3. Record superseded or temporary decisions in the retrospective rather than
+   keeping them prominent in the canon.
+
+### When a decision is reversed
+
+Do not silently patch the canon and pretend the older design never existed.
+Instead:
+- update the canonical note to the new current shape
+- leave a short “superseded by” pointer in the old scoped note or journal entry
+- keep the detailed chronology in the epoch journal or retrospective
+
+This preserves truth without forcing every future reader through the whole
+timeline.
+
+## Retention policy
+
+The journal should remain complete within an active epoch, but older journals do
+not need to remain the primary reference surface forever.
+
+Recommended policy:
+
+- keep raw epoch logs in place for archival truth
+- treat them as append-only historical records, not as the main onboarding path
+- periodically distill durable content into the canonical notes
+- use retrospectives to summarize what mattered and what did not
+
+This is intentionally conservative: it avoids deleting history while still
+making the live architecture easier to read.
+
+## Rules of thumb for what belongs where
+
+Put something in the journal if:
+- it was a real decision made under active local context
+- the rationale may matter in the next few weeks
+- the right answer is still somewhat provisional
+
+Put something in the canon if:
+- future work in that area should start from this as the default assumption
+- a new contributor or agent would waste time without this context
+- the information is organized better by concept than by date
+
+Put something in a scoped design note if:
+- it is too large for a journal entry
+- it is too specialized or immature for the canon
+- multiple future issues are likely to depend on it
+
+## Implications for agent behavior
+
+Agents should stop treating `decision_log.md` as the only architecture memory.
+Recommended lookup order for design-sensitive work:
+
+1. `AGENTS.md`
+2. `project/components.md`
+3. `project/vision.md`
+4. relevant canonical architecture note(s) in `project/docs/`
+5. current epoch `decision_log.md`
+6. targeted scoped note(s) if the topic requires them
+
+That order preserves the current workflow while adding a durable layer between
+vision and raw journal history.
+
+## Near-term migration plan
+
+1. Keep writing to `project/epoch_2/decision_log.md` as usual.
+2. Promote the durable part of `2026-04-15-problem-setup-language.md` into
+   `project/docs/architecture_language.md`. Completed on 2026-04-15.
+3. Keep `wedge_product_whitney_plan.md` as a targeted design note.
+4. Add `project/docs/architecture_geometry.md` once the topology/geometry/metric
+   split is clearer.
+5. Update `AGENTS.md` orientation guidance once the first canonical notes exist,
+   so the docs are actually consulted.
+
+## Verdict
+
+The project should keep the epoch decision log as a journal, but stop treating
+it as the durable architecture reference. The right model is:
+
+- journal for active truth
+- canon for current design
+- scoped notes for forward-looking or specialized threads
+
+That gives flux a memory structure that is both honest and usable.

--- a/project/docs/architecture_patterns.md
+++ b/project/docs/architecture_patterns.md
@@ -1,0 +1,191 @@
+# Architecture Patterns
+
+Date: 2026-04-15
+
+## Purpose
+
+This note records preferred recurring design patterns for flux. The goal is not
+to catalog every possible Zig idiom, but to keep the project consistent around a
+small number of structural choices that fit the library's design philosophy.
+
+These patterns should be read as defaults. A deviation is allowed, but it
+should be justified explicitly.
+
+## Pattern: concept as boundary, not wrapper bait
+
+When a comptime interface check exists, the default design is:
+
+- define the concept
+- validate it at the consumer boundary
+- pass the conforming type directly
+
+Do **not** automatically introduce a second wrapper type whose only job is to
+re-check the concept and forward calls.
+
+In Rust terms, the concept is trait-like. The usual shape should be:
+
+- consumer requires `StepperConcept(Stepper)`
+- consumer calls `Stepper.step(...)` directly
+
+not:
+
+- strategy satisfies `StepperConcept`
+- `Wrapper(Strategy)` re-validates the same concept
+- callers use the wrapper instead of the original type
+
+### Why
+
+A pure forwarding wrapper usually adds no real value:
+
+- no ownership boundary
+- no cached state
+- no erased representation
+- no stronger invariant
+- no simplification of the public language
+
+Instead, it creates:
+
+- another noun users must learn
+- another layer for tests and examples to route through
+- another place for documentation and examples to drift
+- more indirection in places that should read directly
+
+### Wrapper admission rule
+
+A wrapper type should exist only if it adds at least one of:
+
+- owned state or lifetime management
+- caching or assembled data
+- a materially stronger invariant than the underlying type
+- a representation change the caller should not see
+- a meaningful reduction in user complexity that cannot be achieved by the
+  concept alone
+
+If none of those are present, the wrapper is probably dead weight.
+
+## Case study: `TimeStepStrategy` and `TimeStepper`
+
+The current `src/time_stepper.zig` shape likely violates the rule above.
+
+Today:
+
+- `TimeStepStrategy(S)` validates the required `State` and `step` declarations
+- `TimeStepper(S)` re-validates the same concept and forwards `State` and `step`
+
+That means the wrapper adds no owned state, no caching, and no stronger
+interface. It is just another noun around the same contract.
+
+This then leaks outward:
+
+- tests end up proving that the forwarding wrapper forwards
+- examples and helpers start growing indirect “builder to stepper to step”
+  structures
+- the user-facing language becomes more ceremonial than structural
+
+The stronger default pattern would be:
+
+- keep the concept
+- require that concept where a system, runner, or evolution type accepts a
+  stepper
+- pass the conforming stepper directly
+
+In other words, the interface boundary should be the concept check, not the
+wrapper.
+
+## Pattern: test the behavior or the invariant, not the forwarding layer
+
+When a design introduces a forwarding wrapper, it tends to attract tests that
+prove plumbing rather than the actual behavior.
+
+Weak:
+
+- “wrapper forwards to inner type”
+- “builder returns wrapper”
+
+Stronger:
+
+- the integrator advances state correctly
+- the consumer rejects a non-conforming type at comptime
+- the PDE invariant holds over repeated steps
+
+This is not an argument against small tests. It is an argument against tests
+whose only purpose is to justify an unnecessary layer.
+
+## Pattern: builder types must own real staging complexity
+
+Builder types are allowed, but only when they package real staged setup:
+
+- partially specified configuration
+- multi-step assembly with lifetime concerns
+- resource ownership that cannot be expressed cleanly with a direct `init`
+
+They should not exist merely to manufacture another thin object whose methods
+could have been exposed directly.
+
+If a builder only:
+
+- stores references
+- forwards one `initX` call
+- returns a thin runtime object
+
+then it is probably an API smell rather than a useful pattern.
+
+## Pattern: examples should reveal the pattern, not compensate for it
+
+Examples are one of the fastest ways to detect a weak standard pattern.
+
+If examples start reading like:
+
+- builder boilerplate
+- wrapper boilerplate
+- indirection whose only purpose is to satisfy a framework seam
+
+then the framework seam is probably wrong.
+
+The right standard pattern should make examples *shrink*.
+
+## Working rule for future API reviews
+
+Before introducing a new public or semi-public type, ask:
+
+1. Is this a real structural noun?
+2. If not, could this be a concept check on an existing noun instead?
+3. If it is still a wrapper, what concrete invariant or ownership boundary does
+   it add?
+4. Would deleting this type make the examples cleaner?
+
+If the answers are weak, do not add the type.
+
+## Current likely follow-up
+
+The `TimeStepStrategy` / `TimeStepper` split should be revisited with this note
+in mind. The likely end state is:
+
+- keep the concept
+- remove the pure forwarding wrapper
+- validate the concept at consumer boundaries such as evolution or system setup
+
+This note does not itself change the implementation. It defines the preferred
+pattern so future cleanup and refactors converge toward one consistent shape.
+
+## Pattern: separate model nouns from execution nouns
+
+`System` and `Evolution` are adjacent, but they should not be collapsed by
+default.
+
+- `System` is the model/PDE noun
+- `Evolution` is the repeated-step execution noun
+
+The right way to simplify this seam is usually not to merge them, but to make
+their contract more direct.
+
+That means:
+
+- avoid extra wrapper nouns between the two
+- let `Evolution` validate the direct contract it needs from an evolvable system
+- keep room for systems that do not evolve and systems that admit multiple
+  execution strategies
+
+If a proposed simplification merges `System` and `Evolution`, the burden of
+proof is high. It must show that the merge removes real complexity without
+hardwiring one execution story into every system.

--- a/project/ideation/2026-04-15-api-language-audit-and-architecture-memory.md
+++ b/project/ideation/2026-04-15-api-language-audit-and-architecture-memory.md
@@ -1,0 +1,170 @@
+# Ideation: API Language, Abstraction Audit, and Architecture Memory
+
+Date: 2026-04-15
+
+## Context
+
+This ideation session started from a backlog of notes collected during recent
+example and API cleanup work. The discussion focused on which notes still
+describe real design pressure, which were already resolved by newer
+abstractions, and which should drive the next project artifacts.
+
+## Ideas explored
+
+### Mesh-owned operators
+
+**Layer:** architecture
+**Vision alignment:** conflicts
+**Summary:** The original note suggested that operators should become methods on
+the mesh or otherwise be mesh-owned because operators feel intrinsic to the
+mesh. After review, this was judged stale. The current direction with explicit
+operator contexts is stronger because it keeps topology ownership separate from
+assembled, family-specific, and problem-specific operator state.
+**Key tension:** A mesh-centric user experience is desirable, but mesh-owned
+numerical state would blur topology, geometry, metric dependence, and assembly
+policy in exactly the place the architecture needs explicit separation.
+**Verdict:** reject
+**Next action:** None. Preserve the current operator/context ownership model.
+
+### FEEC and DEC as explicit operator families
+
+**Layer:** architecture
+**Vision alignment:** extends
+**Summary:** FEEC and DEC should remain explicit public mathematical families,
+with room for mixed formulations where strong-form DEC is the right tool in one
+part of a problem and weak-form FEEC is the right tool elsewhere. The
+distinction should remain semantic rather than historical: both families can be
+present, but not as duplicate legacy surfaces for the same operation.
+**Key tension:** The project wants both mathematical honesty and one obvious way
+to do things. That means mixed FEEC/DEC composition is acceptable only when the
+underlying semantics genuinely differ.
+**Verdict:** pursue
+**Next action:** Keep pressure-testing milestone work against the question: does
+mixed user code read like one coherent domain language rather than glue between
+two sub-libraries?
+
+### Explicit metric and geometry semantics
+
+**Layer:** constraint
+**Vision alignment:** aligned
+**Summary:** The discussion converged on explicit structural nouns such as
+`Metric(.euclidean)` and `Metric(.riemannian, g)` rather than vague mode flags.
+At the same time, this likely points to a broader split between topology,
+geometry/embedding, and metric-dependent structure. Euclidean geometry is a
+special case, but the architecture should not flatten that distinction too
+early.
+**Key tension:** A clean `Metric` noun is attractive, but moving meshes and ALE
+support may require `Metric` to sit inside a larger `Geometry` or equivalent
+object rather than carry all geometric meaning itself.
+**Verdict:** pursue
+**Next action:** Use the problem-setup design exercise to determine the right
+top-level nouns before committing to an API.
+
+### Problem-setup-first API design
+
+**Layer:** ux
+**Vision alignment:** aligned
+**Summary:** The strongest insight from the conversation is that the project has
+sometimes been designing APIs backward from implementation and examples instead
+of first writing the ideal simulation-setup surface. The next design artifact
+should therefore be a note with 2-3 idealized setup sketches that force the
+project to name its structural nouns, verbs, compile-time parameters, cache
+boundaries, and intended hot paths.
+**Key tension:** This is not merely documentation work. If treated as docs too
+early, it will describe the current API instead of revealing the better one.
+**Verdict:** pursue
+**Next action:** Create a problem-setup design note with idealized API sketches
+for fixed-mesh Maxwell, a metric-aware elliptic/parabolic problem, and one
+moving-geometry or ALE-flavored toy problem.
+
+### Benchmark design from user hot paths
+
+**Layer:** constraint
+**Vision alignment:** aligned
+**Summary:** Benchmark priorities should come from intended user workflows and
+dominant execution paths, not from whichever functions are easiest to time.
+This ties benchmark design to the same setup-language exercise: the code path
+that matters most to the user should be visible from the problem setup and
+execution model.
+**Key tension:** Optimization is not the top priority, but benchmark choices
+shape engineering attention. Measuring implementation accidents instead of
+product-critical paths would quietly distort the library.
+**Verdict:** pursue
+**Next action:** When the setup sketches exist, derive benchmark targets from
+their hot paths and setup costs.
+
+### Abstraction-audit skill focused on deletion and consolidation
+
+**Layer:** architecture
+**Vision alignment:** extends
+**Summary:** The existing audit lenses are useful, but the project needs a
+dedicated abstraction-focused audit that maps public nouns, verbs, and
+ownership boundaries, then defaults toward simplification by deletion rather
+than additive wrappers. This should explicitly fight the common LLM failure mode
+of cleaning up by introducing another layer instead of removing the weak one.
+**Key tension:** Cleanup often crosses component boundaries, while the current
+scope discipline intentionally narrows local context. The skill must preserve
+focus without becoming blind to duplication or bad seams created at component
+boundaries.
+**Verdict:** pursue
+**Next action:** Design an abstraction-audit skill and update broader agent
+guidance so in-flight implementation work also prefers removal, consolidation,
+and immediate local API strengthening when the seam is already open.
+
+### Redundant tests
+
+**Layer:** constraint
+**Vision alignment:** aligned
+**Summary:** The concern is not with the existence of many tests, but with truly
+redundant tests that restate weaker guarantees and increase maintenance cost.
+The distinction between mathematical proof obligations, API behavior checks, and
+optimized-path regressions remains important.
+**Key tension:** Aggressive pruning can accidentally delete useful coverage if
+the suite is not first classified by what invariant each test uniquely protects.
+**Verdict:** park
+**Next action:** Revisit after the abstraction-audit and setup-language work,
+when the intended surfaces and invariants are clearer.
+
+### Read-optimized architecture memory
+
+**Layer:** architecture
+**Vision alignment:** conflicts
+**Summary:** The current decision log is useful as a write-optimized journal but
+weak as durable project memory. The discussion converged on keeping the raw log
+during active work while periodically distilling durable outcomes into a smaller
+read-optimized architecture record.
+**Key tension:** The current project doctrine says every non-obvious decision is
+logged. The improvement is not to stop logging, but to stop treating the raw
+journal as the primary long-term reference.
+**Verdict:** pursue
+**Next action:** After the setup-language artifact and abstraction-audit design,
+draft a proposal for a distilled architecture record and the retention/compression
+policy for epoch logs.
+
+## Connections
+
+The discussion converged on one primary dependency chain:
+
+1. Write the ideal problem-setup sketches first.
+2. Use those sketches to define the abstraction-audit lens and its deletion-first
+   philosophy.
+3. Use both of those to decide what durable architectural knowledge should be
+   preserved in a read-optimized form.
+
+Metric/geometry semantics, FEEC/DEC composition, and benchmark priorities all
+feed into the setup-language exercise. The abstraction-audit work then turns the
+resulting language into a cleanup and simplification discipline. The architecture
+memory proposal comes last because it should preserve the refined language, not
+the raw exploratory churn.
+
+## Open questions
+
+- Is `Metric` the right top-level noun, or should it be one field inside a
+  broader `Geometry` object?
+- For mixed FEEC/DEC problems, what are the stable user-facing nouns and verbs
+  that keep the composition coherent instead of feeling like interop glue?
+- How should abstraction-focused cleanup intentionally cross component
+  boundaries without collapsing back into “scan the whole repo” behavior?
+- Which agent instructions should change globally so deletion and consolidation
+  are default cleanup moves during ordinary implementation, not only during a
+  dedicated audit?

--- a/project/ideation/2026-04-15-problem-setup-language.md
+++ b/project/ideation/2026-04-15-problem-setup-language.md
@@ -1,0 +1,384 @@
+# Ideation: Problem Setup Language
+
+Date: 2026-04-15
+
+## Purpose
+
+This note is a design artifact, not product documentation. The goal is to write
+the *ideal* problem-setup surface for flux before further example cleanup,
+benchmark expansion, or API growth. The sketches below are intentionally a bit
+ahead of the current implementation.
+
+The pressure test for each sketch is:
+
+- Can a domain expert read the setup and recognize the physics?
+- Are the structural nouns clear?
+- Are cache and ownership boundaries explicit?
+- Do the hot paths worth benchmarking follow naturally from the setup?
+
+## Proposed top-level language
+
+The setup surface should eventually make four structural objects explicit:
+
+1. `Topology`
+Represents incidence, orientation, and entity counts. This is where `d` lives.
+
+2. `Geometry`
+Represents embedding-dependent geometric data and mesh motion. For fixed meshes,
+this may be little more than vertex positions plus derived measures. For moving
+meshes, this becomes state.
+
+3. `Metric`
+Represents the inner-product structure used by metric-dependent operators such
+as `★`, codifferentials, and Laplacians. Euclidean is the default structural
+special case, not a boolean mode.
+
+4. `Problem` or `System`
+Owns the assembled operators, boundary conditions, and evolution/solve logic
+for one PDE setup.
+
+The current `Mesh` likely still contains both topology and some geometry. That
+is acceptable today, but the setup language should stop pretending those are the
+same thing.
+
+## Sketch 1: User-defined fixed-mesh hyperbolic system
+
+This is the baseline setup sketch. It should be the easiest problem to read and
+the least magical. The important point is that flux should provide the language
+for defining a system cleanly, not a built-in catalog of named PDE systems.
+
+```zig
+const flux = @import("flux");
+
+const Topology = flux.topology.Mesh(2, 2);
+var mesh = try Topology.rectangular(allocator, .{
+    .cells_x = 64,
+    .cells_y = 64,
+    .width = 1.0,
+    .height = 1.0,
+});
+defer mesh.deinit(allocator);
+
+const geometry = flux.geometry.embedded(&mesh);
+const metric = flux.geometry.Metric(.euclidean);
+
+const MaxwellLikeSystem = flux.systems.DecSystem(Topology, struct {
+    pub const State = struct {
+        electric: flux.forms.Cochain(Topology, 1, flux.forms.Primal),
+        magnetic: flux.forms.Cochain(Topology, 2, flux.forms.Primal),
+    };
+
+    pub fn assemble(
+        allocator: std.mem.Allocator,
+        mesh_ref: *const Topology,
+        geometry_ref: anytype,
+        metric_ref: anytype,
+    ) !type {
+        _ = allocator;
+        _ = mesh_ref;
+        _ = geometry_ref;
+        _ = metric_ref;
+        return struct {};
+    }
+
+    pub fn initialState(allocator: std.mem.Allocator, mesh_ref: *const Topology) !State {
+        _ = allocator;
+        _ = mesh_ref;
+        return undefined;
+    }
+
+    pub fn rhs(self: *@This(), state: *const State) !State {
+        _ = self;
+        _ = state;
+        return undefined;
+    }
+});
+
+var system = try MaxwellLikeSystem.init(allocator, .{
+    .mesh = &mesh,
+    .geometry = &geometry,
+    .metric = &metric,
+    .boundary = .{ .essential = .all },
+});
+defer system.deinit();
+
+var state = try system.initialState();
+defer state.deinit();
+
+var evolution = try flux.integrators.leapfrog.Evolution(@TypeOf(system)).init(allocator, .{
+    .system = &system,
+    .time_step = 1.0e-3,
+    .observers = .{
+        system.observe.scalar("energy"),
+        system.observe.scalar("constraint"),
+    },
+});
+defer evolution.deinit();
+
+try evolution.advance(&state, .{ .steps = 1000 });
+```
+
+### What this sketch is trying to say
+
+- `Mesh` is still the concrete mesh constructor, but the user sees separate
+  `geometry` and `metric` objects immediately.
+- The user chooses the mathematical family at the system level, but the PDE
+  itself is user-defined rather than blessed by a built-in catalog of named
+  equations.
+- Boundary conditions belong to the problem setup, not to operator assembly in
+  the hot path.
+- The integrator consumes a system and a state. It should not need to know how
+  the system assembled its operators.
+
+### Nouns, verbs, adjectives
+
+- Nouns: `Mesh`, `Geometry`, `Metric`, `System`, `State`, `Evolution`
+- Verbs: `init`, `initialState`, `observe`, `advance`
+- Adjectives: `Dec`, `euclidean`, `essential`
+
+### Cache boundary
+
+For this problem, the cache boundary should be:
+
+- topology-owned: incidence
+- geometry-owned: measures derived from embedding
+- system-owned: assembled operators and boundary-conditioned variants
+- evolution-owned: step counters, observer staging, transient integration state
+
+### Benchmark targets implied by the setup
+
+- repeated `d` application in the hyperbolic update
+- repeated metric-dependent operator application if FEEC mass or `★` is used
+- observer overhead relative to timestep cost
+- one-time setup cost for assembling the system
+
+## Sketch 2: User-defined metric-aware elliptic or parabolic system
+
+This sketch exists to force metric semantics to be explicit and to test whether
+the language scales from hyperbolic stepping to elliptic/parabolic solves.
+
+```zig
+const flux = @import("flux");
+
+const Topology = flux.topology.Mesh(2, 2);
+
+var mesh = try Topology.surfaceSphere(allocator, .{
+    .refinement = 4,
+});
+defer mesh.deinit(allocator);
+
+const geometry = flux.geometry.embedded(&mesh);
+const metric = flux.geometry.Metric(.riemannian, .{
+    .from_embedding = true,
+});
+
+const DiffusionLikeSystem = flux.systems.FeecSystem(Topology, struct {
+    pub const State = flux.forms.feec.Form(
+        flux.forms.feec.WhitneySpace(Topology, 0),
+    );
+});
+
+var problem = try DiffusionLikeSystem.init(allocator, .{
+    .mesh = &mesh,
+    .geometry = &geometry,
+    .metric = &metric,
+    .boundary = .none,
+});
+defer problem.deinit();
+
+var field = try problem.initialField(.{
+    .analytic = diffusion_bump,
+});
+defer field.deinit();
+
+var solver = try flux.solvers.implicit.backwardEuler(@TypeOf(problem)).init(allocator, .{
+    .system = &problem,
+    .time_step = 5.0e-4,
+    .linear_solver = .{
+        .cg = .{
+            .preconditioner = .diagonal,
+            .tolerance = 1.0e-10,
+        },
+    },
+});
+defer solver.deinit();
+
+try solver.advance(&field, .{ .steps = 200 });
+```
+
+### What this sketch is trying to say
+
+- Metric choice is visible at setup time.
+- FEEC is selected because the weak-form and mass/stiffness structure matter.
+- The solver stack should read as part of the PDE language, not as detached
+  sparse-matrix plumbing.
+- If the metric changes, users should know which operators are invalidated.
+
+### Nouns, verbs, adjectives
+
+- Nouns: `Mesh`, `Geometry`, `Metric`, `System`, `Field`, `Solver`
+- Verbs: `init`, `initialField`, `advance`
+- Adjectives: `Feec`, `riemannian`, `diagonal`
+
+### Cache boundary
+
+For this problem, the cache boundary should make invalidation obvious:
+
+- changing topology invalidates everything
+- changing geometry may invalidate embedding-derived measures
+- changing metric invalidates metric-dependent FEEC operators
+- changing boundary conditions invalidates only the boundary-conditioned solve
+  structure, not topology itself
+
+### Benchmark targets implied by the setup
+
+- assembly of mass and stiffness operators
+- repeated sparse solve cost per timestep
+- preconditioner effectiveness on user-visible wall time
+- metric-update cost if geometry or metric is changed between solves
+
+## Sketch 3: User-defined moving-geometry or ALE-flavored transport
+
+This sketch is intentionally horizon-facing. Its job is to force the language to
+separate topology from evolving geometry before the implementation needs it.
+
+```zig
+const flux = @import("flux");
+
+const Topology = flux.topology.Mesh(2, 2);
+
+var mesh = try Topology.rectangular(allocator, .{
+    .cells_x = 96,
+    .cells_y = 48,
+    .width = 2.0,
+    .height = 1.0,
+});
+defer mesh.deinit(allocator);
+
+var geometry = try flux.geometry.MovingGeometry(Topology).init(allocator, .{
+    .mesh = &mesh,
+    .embedding = .current_positions,
+});
+defer geometry.deinit();
+
+var metric = flux.geometry.Metric(.euclidean);
+
+const AleTransportSystem = flux.systems.AleSystem(Topology, struct {
+    pub const State = struct {};
+});
+
+var problem = try AleTransportSystem.init(allocator, .{
+    .mesh = &mesh,
+    .geometry = &geometry,
+    .metric = &metric,
+    .mesh_velocity = prescribed_mesh_velocity,
+});
+defer problem.deinit();
+
+var state = try problem.initialState(.{
+    .density = gaussian_blob,
+    .velocity = rigid_rotation,
+});
+defer state.deinit();
+
+try problem.advanceGeometry(.{
+    .time_step = 1.0e-3,
+    .steps = 500,
+    .state = &state,
+});
+```
+
+### What this sketch is trying to say
+
+- Geometry is now plainly stateful and evolves in time.
+- The topology remains fixed unless explicitly remeshed.
+- The system can ask for reassembly of only the metric-dependent pieces after a
+  geometry update.
+- This should be possible without turning the mesh itself into a mutable bag of
+  cached operators.
+
+### Nouns, verbs, adjectives
+
+- Nouns: `Mesh`, `MovingGeometry`, `Metric`, `System`, `State`
+- Verbs: `init`, `initialState`, `advanceGeometry`
+- Adjectives: `Ale`, `moving`
+
+### Cache boundary
+
+This is the most important sketch for future-proofing:
+
+- topology-only operators should survive geometry motion untouched
+- geometry-dependent derived quantities should be recomputed incrementally if
+  possible
+- metric-dependent assembled operators should be invalidated explicitly and only
+  when needed
+
+### Benchmark targets implied by the setup
+
+- geometry-update cost
+- operator invalidation and reassembly cost after geometry motion
+- ratio of pure topology work to metric/geometry recomputation
+- total cost per coupled PDE step
+
+## Design pressure revealed by the sketches
+
+### 1. The family choice should likely sit at the problem or system layer
+
+Users should not have to manually assemble a bag of DEC and FEEC operators just
+to express a standard problem. The problem setup should name the mathematical
+family directly, while still allowing the actual PDE system to be defined by
+the user rather than by a built-in framework catalog.
+
+### 2. `Metric` should be explicit, but probably not alone
+
+The sketches suggest `Metric` is necessary but not sufficient. A broader
+`Geometry` noun likely needs to exist so the API can distinguish:
+
+- fixed embedding-derived geometry
+- prescribed metric on fixed topology
+- time-evolving geometry with possibly evolving metric dependence
+
+### 3. Caches should remain outside topology ownership
+
+All three sketches argue against moving assembled operators back onto the mesh.
+What users want is not mesh-owned numerics, but a setup surface that *reads*
+coherently while keeping ownership boundaries honest.
+
+### 4. Benchmark design should derive from setup and execution language
+
+The benchmark suite should answer user-relevant questions:
+
+- what costs dominate setup?
+- what costs dominate one step?
+- what costs dominate repeated solve/apply loops?
+- which costs change when geometry or metric changes?
+
+This is stronger than “benchmark all public operators.” It connects the suite to
+real usage rather than implementation accidents.
+
+## Recommendations
+
+1. Treat this note as input to example redesign, not as documentation to make
+   current examples mimic mechanically.
+
+2. Use these sketches to draft a narrower design note for the stable top-level
+   nouns:
+   `Mesh`, `Geometry`, `Metric`, `System`, `State`, `Evolution` or `Solver`.
+
+3. When designing the abstraction-audit skill, require it to check whether new
+   APIs move the project closer to these nouns by deleting weak layers rather
+   than wrapping them.
+
+4. Derive future benchmark additions from the hot paths named in these sketches.
+
+## Open questions
+
+- Should `Geometry` be a first-class public noun now, or remain implicit until a
+  moving-geometry use case lands?
+- Where should mixed FEEC/DEC formulations appear in the public setup surface:
+  separate `MixedSystem`, explicit expert composition, or a problem-specific
+  constructor?
+- Should integrator-facing types be called `Evolution`, `Stepper`, `Solver`, or
+  something problem-class-specific?
+- Which parts of boundary condition handling belong to `System` versus lower
+  operator layers?


### PR DESCRIPTION
Closes #201

## What

Add the first canonical architecture notes, introduce the `audit-abstraction` skill, and wire the project skills plus `AGENTS.md` around shared architecture memory, issue-thread context, and low-risk follow-through.

## Included

- add `project/docs/architecture_language.md`, `architecture_memory.md`, and `architecture_patterns.md`
- add the new `audit-abstraction` skill and update the audit umbrella
- wire workflow and audit skills to read/update canonical architecture docs when relevant
- strengthen `AGENTS.md` around deletion-first cleanup, shared-memory synchronization, issue/PR thread context, and obvious follow-through
- tighten `review` so abstraction regressions are first-class review targets
- preserve the ideation notes that produced these canonical docs

## Notes

- this PR is documentation and skill wiring only; it does not implement the `TimeStepper` cleanup itself
- I did not run `zig build ci --summary all` because no Zig source or build files changed
- issue #201 was clarified in-thread so its scope now explicitly covers the direct `System`/`Evolution` boundary cleanup, not just removing the forwarding wrapper
