### PR TITLE
add execution and geometry architecture notes

### DIFF
--- a/project/docs/architecture_execution.md
+++ b/project/docs/architecture_execution.md
@@ -1,0 +1,170 @@
+# Architecture Execution
+
+Date: 2026-04-15
+
+## Purpose
+
+This note defines the durable execution language for flux: what owns repeated
+time stepping, what contract a stepper must satisfy, and which wrapper patterns
+should be deleted rather than normalized.
+
+This is the canonical reference for execution-side API reviews. If a proposed
+execution type is hard to justify against this note, it should probably not
+exist.
+
+## Core rule
+
+Execution should read in terms of a small set of structural roles:
+
+- `System` owns assembled operators, solve state, boundary-conditioned variants,
+  and other problem-local caches
+- `State` is the evolving unknown
+- `Evolution` owns repeated-step orchestration
+- `TimeStepper` is a comptime contract, not a forwarding wrapper
+
+If examples need builder nouns, adapter nouns, or wrapper-only tests to fit the
+execution layer, the seam is wrong.
+
+## Preferred execution boundary
+
+The default shape is:
+
+- define a comptime stepper concept
+- validate that concept at the `Evolution` boundary
+- pass the conforming stepper directly
+
+The default shape is **not**:
+
+- define a stepper concept
+- wrap it in a `TimeStepper(...)` forwarding type
+- wrap that again for a runner or evolution helper
+- add builder objects whose only job is to manufacture the wrapper
+
+In other words: the boundary is the concept check.
+
+## `TimeStepper` is a concept
+
+`TimeStepper` should mean the direct execution contract required by
+`Evolution`. It should not also name a second wrapper noun.
+
+The preferred contract is intentionally small:
+
+- `pub fn step(self: *Stepper, allocator: std.mem.Allocator) !void`
+- `pub fn deinit(self: *Stepper, allocator: std.mem.Allocator) void`
+
+If execution later needs stronger guarantees, extend the concept. Do not add a
+wrapper type whose only job is to re-check the same declarations and forward
+them.
+
+This implies:
+
+- delete `src/time_stepper.zig` as a wrapper home
+- keep the concept near the execution layer, ideally as part of the evolution
+  module surface
+- make `Evolution` validate `TimeStepper` directly
+
+## `Evolution` is the execution noun
+
+`Evolution` earns its existence when it owns real orchestration state such as:
+
+- allocator and lifetime management for execution-owned state
+- step counts
+- run timing
+- listener dispatch
+- exact/reference auxiliary state
+- snapshot or observer staging
+
+That is a real noun. It should stay.
+
+What should **not** exist between `Evolution` and the stepper:
+
+- forwarding wrappers
+- builder objects with a single `initStepper` method
+- adapter types that only rename `step` and `deinit`
+
+If setup-time seeding is required before stepping begins, that belongs in one
+of two places:
+
+- system initialization, if it is inherent to system construction
+- stepper initialization, if it is specific to one execution story
+
+It should not force a second builder noun by default.
+
+## Relationship to `System`
+
+`System` and `Evolution` should remain separate.
+
+- `System` is the PDE/model noun
+- `Evolution` is the repeated-step execution noun
+
+The right simplification is a more direct contract between them, not merging
+them and not inserting additional wrapper layers.
+
+A stepper may hold:
+
+- a pointer to system-owned state
+- references to state storage
+- execution-local counters or scratch
+
+But those choices should be expressed directly in the stepper type the caller
+passes to `Evolution`.
+
+## Example pressure tests
+
+Good execution design should make these examples small:
+
+1. an explicit hyperbolic system with a custom stepper
+2. an implicit parabolic system whose stepper seeds a linear solve state once
+3. a reference or exact-solution run with observer/listener hooks
+
+If one of these requires:
+
+- `HeatStepperBuilder`
+- `SurfaceStepperBuilder`
+- `StepperWrapper`
+- `TimeStepper(Strategy)`
+
+then the execution seam is too indirect.
+
+## Test policy
+
+Prefer tests that prove:
+
+- `Evolution` rejects a non-conforming stepper at comptime
+- a conforming stepper advances state correctly
+- listeners and exact/reference hooks observe the right run events
+- PDE invariants hold over repeated steps
+
+Do not preserve tests whose only purpose is:
+
+- “the wrapper forwards to the inner type”
+- “the builder returns the wrapper”
+
+Those tests protect ceremony, not behavior.
+
+## Deletion guidance
+
+The default cleanup order for execution abstraction drift is:
+
+1. delete forwarding wrappers
+2. inline one-shot builder setup into direct init
+3. make `Evolution` consume the direct concept
+4. only then ask whether any additional noun is still necessary
+
+If a proposed fix adds execution code, the burden is to explain why deletion
+and direct concept validation are insufficient.
+
+## Current intended direction
+
+The current intended direction is:
+
+- `TimeStepper` becomes a comptime concept only
+- `Evolution` remains the execution owner
+- `Evolution` validates the direct stepper contract
+- `src/time_stepper.zig` should disappear as a wrapper-focused module
+- example-local stepper builders and adapter wrappers should be removed as the
+  execution seam is tightened
+
+This note records the target shape. Individual code changes should converge
+toward it incrementally, but they should not add new wrapper layers in the
+meantime.

--- a/project/docs/architecture_geometry.md
+++ b/project/docs/architecture_geometry.md
@@ -1,0 +1,159 @@
+# Architecture Geometry
+
+Date: 2026-04-15
+
+## Purpose
+
+This note defines the intended boundary between topology, geometry, and metric
+structure in flux.
+
+The implementation is still earlier than the final public language in some
+places. That is acceptable. What is not acceptable is letting temporary module
+placement harden into the long-term abstraction language by accident.
+
+## Core rule
+
+Users should be able to distinguish:
+
+- what is purely topological
+- what depends on embedding geometry
+- what depends on metric structure
+- what is system-owned assembly derived from those ingredients
+
+If those roles blur together at the API boundary, later generalization to
+Riemannian metrics, moving geometry, or alternate assembly families becomes
+needlessly expensive.
+
+## Preferred nouns
+
+### `Mesh`
+
+`Mesh` is the concrete discrete domain object used today.
+
+At present it still carries:
+
+- topology
+- vertex positions
+- some embedding-derived geometric data
+- some precomputed operator-support data
+
+That mixed reality is tolerated as an implementation stage, not celebrated as
+the final public language.
+
+### `Geometry`
+
+`Geometry` is the noun for embedding-dependent structure:
+
+- coordinates
+- edge lengths
+- face areas
+- cell volumes
+- future mesh motion or geometry updates
+
+Even when there is not yet a separate runtime `Geometry` object at every call
+site, this noun should guide design decisions. Geometry is not merely “whatever
+is stored on mesh today.”
+
+### `Metric`
+
+`Metric` is the noun for inner-product structure:
+
+- Euclidean as the explicit default specialization
+- Riemannian as a genuine extension
+
+The important point is conceptual: metric choice is a structural input, not an
+operator-local policy flag.
+
+That means the long-term language should read like:
+
+- `Metric(.flat)` or `Metric(.euclidean)`
+- `Metric(.riemannian, ...)`
+
+and not like a hidden mode buried inside one operator family.
+
+## Ownership boundary
+
+The intended ownership split is:
+
+- topology-owned: incidence, orientations, entity counts
+- geometry-owned: embedding-derived measures and future geometric updates
+- metric-owned: inner-product data and metric-specialized structure
+- system-owned: assembled operators, boundary-conditioned variants, and caches
+
+This is why mesh-owned operator caches are a bad default public model even when
+some low-level data is currently stored on `Mesh`.
+
+## Current implementation status
+
+Today, metric-aware execution is only partially surfaced:
+
+- metric-aware Hodge star support currently lives in
+  `src/operators/hodge_star.zig`
+- the flat specialization remains the default operator-context path
+- there is not yet a first-class top-level geometry namespace that owns
+  `Metric`
+
+This is a temporary implementation shape, not the desired final language.
+
+## Rule for API growth during the transition
+
+Until geometry and metric become more explicit public modules:
+
+- do not add new public APIs that make metric look like an implementation
+  detail of Hodge star alone
+- do not add new “mode” booleans when the real noun is metric structure
+- do not treat mesh storage location as proof of long-term ownership
+
+New code may temporarily use the existing operator-local metric types, but new
+design should speak in terms of the geometry/metric boundary above.
+
+## Family interaction
+
+The topology/geometry/metric split is orthogonal to DEC versus FEEC family
+choice.
+
+- `d` is topology-driven
+- Hodge stars, codifferentials, Laplacians, and weak inner products are metric
+  dependent
+- system-level family choice should decide which assembled operators are used,
+  not collapse geometry and metric into one opaque implementation switch
+
+Family adjectives refine operator and system assembly. They do not replace the
+underlying structural nouns.
+
+## Invalidation guidance
+
+The intended invalidation logic is:
+
+- topology changes invalidate everything
+- geometry changes invalidate embedding-derived measures and dependent assembly
+- metric changes invalidate metric-dependent operators and solves
+- boundary-condition changes invalidate only the affected system-owned
+  conditioned structures
+
+This should remain legible at the API level. If a caller cannot tell what a
+metric change invalidates, the abstraction boundary is too weak.
+
+## Pressure tests
+
+A good geometry boundary should support:
+
+1. fixed Euclidean meshes
+2. fixed meshes with user-supplied Riemannian metric data
+3. future moving-geometry or ALE-flavored problems
+
+If any of these would force a new wrapper family or another operator-local
+special case API, the geometry language is still too accidental.
+
+## Current intended direction
+
+The current intended direction is:
+
+- keep flat-specialized operator contexts working as the zero-cost default
+- treat operator-local `Metric` support as a temporary staging point
+- move toward a public language where geometry and metric are structural setup
+  inputs rather than hidden operator options
+
+This note does not force an immediate refactor of all operator code. It does
+set the standard for future API decisions so temporary placement does not
+become permanent design by inertia.


### PR DESCRIPTION
## Summary
Add canonical architecture notes for execution and geometry.

## What Changed
- added `project/docs/architecture_execution.md` to define the direct execution language around `System`, `Evolution`, and a concept-only `TimeStepper`
- added `project/docs/architecture_geometry.md` to define the intended topology/geometry/metric boundary and document the current temporary staging shape

## Why
The abstraction audit surfaced two missing canon documents. Without them, wrapper-heavy execution code and operator-local metric placement risk hardening into the public language by inertia.

## Impact
These notes give the upcoming execution refactor and geometry-related API work a durable reference point.

## Validation
- documentation-only change
- reviewed for alignment with the current architecture notes and decision log