### PR TITLE
Add Whitney weak-form assembly kernels

### DIFF
--- a/project/docs/architecture_language.md
+++ b/project/docs/architecture_language.md
@@ -160,6 +160,11 @@ The language should lean on a small set of strong verbs:
 These verbs should sit on stable nouns. Avoid creating a new noun when the real
 operation is simply “do X to this object.”
 
+For FEEC weak operators specifically, prefer one shared `assemble` seam for
+local-to-global scatter, with family-specific local kernels supplying the
+simplex-local mathematics. Do not duplicate orientation/scatter plumbing inside
+each weak operator family helper.
+
 ## Qualifiers should usually be adjectives
 
 Many distinctions in flux are qualifiers, not reasons to mint fresh public

--- a/project/epoch_2/decision_log.md
+++ b/project/epoch_2/decision_log.md
@@ -2,6 +2,27 @@
 
 <!-- Append entries with /decide. Format: ## YYYY-MM-DD: <title> -->
 
+## 2026-04-19: Separate FEEC weak-form scatter from Whitney local kernels
+
+**Decision:** Introduce `operators.weak_form.assemble` as the shared
+local-to-global assembly verb for FEEC weak operators, and express Whitney mass
+assembly through kernel types that provide per-top-simplex local matrices.
+
+**Alternatives considered:**
+1. Keep `assemble_whitney_mass*` as monolithic routines: rejected because that
+   keeps the only real FEEC weak-form path trapped in one special case, with
+   topology/orientation scatter interleaved with Whitney-specific local
+   integrals.
+2. Move the generic scatter logic into `Mesh`: rejected because assembled weak
+   operators are not topology-owned data. The mesh owns simplices and incidence;
+   operator-family assembly owns local kernels and global matrix construction.
+
+**Rationale:** The structural concept here is not "Whitney mass with helpers"
+but a reusable local-kernel/global-scatter seam for FEEC weak operators.
+Putting the scatter logic behind one `assemble` verb keeps future FEEC weak
+operators from re-implementing orientation and simplex-index plumbing, while
+keeping family-specific mathematics in the kernel layer where it belongs.
+
 ## 2026-04-18: Separate true de Rham projection from sampled continuous-form seeding
 
 **Decision:** Keep `operators.bridges.DeRhamProjection` as the exact

--- a/src/math/cg.zig
+++ b/src/math/cg.zig
@@ -433,7 +433,7 @@ test "CG solves Whitney mass matrix system" {
     var mesh = try Mesh2D.plane(allocator, 4, 4, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var mass = try whitney.assemble_whitney_mass(1, allocator, &mesh);
+    var mass = try whitney.assemble_whitney_mass(1, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     const row_count = mass.n_rows;

--- a/src/operators/hodge_star.zig
+++ b/src/operators/hodge_star.zig
@@ -247,7 +247,7 @@ fn apply_hodge_star_riemannian(
     errdefer output.deinit(allocator);
 
     if (comptime supportsWhitneyMassDegree(MeshType, k)) {
-        var matrix = try whitney_mass.assemble_whitney_mass_with_metric(k, allocator, input.mesh, metric.top_simplex_tensors);
+        var matrix = try whitney_mass.assemble_whitney_mass(k, allocator, input.mesh, metric.top_simplex_tensors);
         defer matrix.deinit(allocator);
         sparse.spmv(matrix, input.values, output.values);
         return output;
@@ -283,7 +283,7 @@ fn apply_hodge_star_inverse_riemannian(
     errdefer output.deinit(allocator);
 
     if (comptime supportsWhitneyMassDegree(MeshType, primal_degree)) {
-        var matrix = try whitney_mass.assemble_whitney_mass_with_metric(primal_degree, allocator, input.mesh, metric.top_simplex_tensors);
+        var matrix = try whitney_mass.assemble_whitney_mass(primal_degree, allocator, input.mesh, metric.top_simplex_tensors);
         defer matrix.deinit(allocator);
 
         const diagonal = try assembleMatrixDiagonal(allocator, matrix);

--- a/src/operators/weak_form.zig
+++ b/src/operators/weak_form.zig
@@ -3,19 +3,176 @@
 const std = @import("std");
 const sparse = @import("../math/sparse.zig");
 
-pub const AssembleError = error{
-    NotYetImplemented,
-};
-
 pub fn assemble(
     comptime k: comptime_int,
     allocator: std.mem.Allocator,
     mesh: anytype,
     kernel: anytype,
 ) !sparse.CsrMatrix(f64) {
-    _ = k;
-    _ = allocator;
-    _ = mesh;
-    _ = kernel;
-    return AssembleError.NotYetImplemented;
+    const MeshType = @TypeOf(mesh.*);
+    const n = MeshType.topological_dimension;
+
+    comptime {
+        if (k <= 0 or k >= n) {
+            @compileError("weak-form assembly is only defined for interior degrees 0 < k < n");
+        }
+        if (n > 3) {
+            @compileError("weak-form assembly is currently implemented for topological_dimension <= 3");
+        }
+        if (!@hasDecl(@TypeOf(kernel), "degree")) {
+            @compileError("weak-form kernels must declare their primal degree");
+        }
+        if (@TypeOf(kernel).degree != k) {
+            @compileError("weak-form kernel degree does not match assembly degree");
+        }
+        if (!@hasDecl(@TypeOf(kernel), "localMatrix")) {
+            @compileError("weak-form kernels must provide localMatrix(top_simplex_index)");
+        }
+    }
+
+    if (comptime @hasField(@TypeOf(kernel), "mesh")) {
+        std.debug.assert(kernel.mesh == mesh);
+    }
+
+    const simplex_count = mesh.num_cells(k);
+    const top_simplex_count = mesh.num_cells(n);
+    const simplex_vertices = mesh.simplices(k).items(.vertices);
+    const top_simplex_vertices = mesh.simplices(n).items(.vertices);
+    const local_faces = localFaces(n, k);
+
+    var simplex_index = std.AutoHashMap([k + 1]u32, u32).init(allocator);
+    defer simplex_index.deinit();
+    for (simplex_vertices, 0..) |vertices, global_idx| {
+        try simplex_index.put(vertices, @intCast(global_idx));
+    }
+
+    var assembler = sparse.TripletAssembler(f64).init(simplex_count, simplex_count);
+    defer assembler.deinit(allocator);
+
+    for (0..top_simplex_count) |top_idx| {
+        const local_matrix = kernel.localMatrix(top_idx);
+        const top_vertices = top_simplex_vertices[top_idx];
+
+        var global_indices: [local_faces.len]u32 = undefined;
+        var orientation_signs: [local_faces.len]i8 = undefined;
+        for (local_faces, 0..) |local_face, local_face_idx| {
+            const oriented_vertices = liftLocalFaceVertices(k, n, top_vertices, local_face);
+            const canonical_key = canonicalizeVertices(k + 1, oriented_vertices);
+            const global_idx = simplex_index.get(canonical_key).?;
+            global_indices[local_face_idx] = global_idx;
+            orientation_signs[local_face_idx] = orientationSign(k + 1, oriented_vertices, simplex_vertices[global_idx]);
+        }
+
+        for (0..local_faces.len) |i| {
+            const sign_i: f64 = @floatFromInt(orientation_signs[i]);
+            for (0..local_faces.len) |j| {
+                const sign_j: f64 = @floatFromInt(orientation_signs[j]);
+                try assembler.addEntry(
+                    allocator,
+                    global_indices[i],
+                    global_indices[j],
+                    sign_i * sign_j * local_matrix[i][j],
+                );
+            }
+        }
+    }
+
+    return assembler.build(allocator);
+}
+
+pub fn localFaceCount(comptime n: comptime_int, comptime k: comptime_int) comptime_int {
+    return choose(n + 1, k + 1);
+}
+
+pub fn localFaces(comptime n: comptime_int, comptime k: comptime_int) [localFaceCount(n, k)][k + 1]u8 {
+    return switch (n) {
+        2 => switch (k) {
+            1 => .{
+                .{ 0, 1 },
+                .{ 0, 2 },
+                .{ 1, 2 },
+            },
+            else => @compileError("unsupported local face degree for 2-simplex"),
+        },
+        3 => switch (k) {
+            1 => .{
+                .{ 0, 1 },
+                .{ 0, 2 },
+                .{ 0, 3 },
+                .{ 1, 2 },
+                .{ 1, 3 },
+                .{ 2, 3 },
+            },
+            2 => .{
+                .{ 0, 1, 2 },
+                .{ 0, 1, 3 },
+                .{ 0, 2, 3 },
+                .{ 1, 2, 3 },
+            },
+            else => @compileError("unsupported local face degree for 3-simplex"),
+        },
+        else => @compileError("local face enumeration is only implemented for topological_dimension <= 3"),
+    };
+}
+
+fn choose(comptime n: comptime_int, comptime k: comptime_int) comptime_int {
+    if (k < 0 or k > n) return 0;
+    if (k == 0 or k == n) return 1;
+    var numerator: comptime_int = 1;
+    var denominator: comptime_int = 1;
+    const k_small = if (k < n - k) k else n - k;
+    inline for (0..k_small) |i| {
+        numerator *= (n - i);
+        denominator *= (i + 1);
+    }
+    return @divExact(numerator, denominator);
+}
+
+fn liftLocalFaceVertices(
+    comptime k: comptime_int,
+    comptime n: comptime_int,
+    top_vertices: [n + 1]u32,
+    local_face: [k + 1]u8,
+) [k + 1]u32 {
+    var result: [k + 1]u32 = undefined;
+    for (local_face, 0..) |local_vertex_idx, write_idx| {
+        result[write_idx] = top_vertices[local_vertex_idx];
+    }
+    return result;
+}
+
+fn canonicalizeVertices(comptime len: comptime_int, vertices: [len]u32) [len]u32 {
+    var result = vertices;
+    inline for (1..len) |i| {
+        var j = i;
+        while (j > 0 and result[j - 1] > result[j]) : (j -= 1) {
+            std.mem.swap(u32, &result[j - 1], &result[j]);
+        }
+    }
+    return result;
+}
+
+fn orientationSign(comptime len: comptime_int, oriented_vertices: [len]u32, global_vertices: [len]u32) i8 {
+    var permutation: [len]u8 = undefined;
+    var used = [_]bool{false} ** len;
+    for (oriented_vertices, 0..) |vertex, oriented_idx| {
+        var found = false;
+        for (global_vertices, 0..) |global_vertex, global_idx| {
+            if (used[global_idx]) continue;
+            if (vertex != global_vertex) continue;
+            permutation[oriented_idx] = @intCast(global_idx);
+            used[global_idx] = true;
+            found = true;
+            break;
+        }
+        std.debug.assert(found);
+    }
+
+    var inversion_count: u32 = 0;
+    inline for (0..len) |i| {
+        inline for (i + 1..len) |j| {
+            if (permutation[i] > permutation[j]) inversion_count += 1;
+        }
+    }
+    return if (inversion_count % 2 == 0) 1 else -1;
 }

--- a/src/operators/weak_form.zig
+++ b/src/operators/weak_form.zig
@@ -1,0 +1,21 @@
+//! Local-to-global assembly for FEEC weak-form operators.
+
+const std = @import("std");
+const sparse = @import("../math/sparse.zig");
+
+pub const AssembleError = error{
+    NotYetImplemented,
+};
+
+pub fn assemble(
+    comptime k: comptime_int,
+    allocator: std.mem.Allocator,
+    mesh: anytype,
+    kernel: anytype,
+) !sparse.CsrMatrix(f64) {
+    _ = k;
+    _ = allocator;
+    _ = mesh;
+    _ = kernel;
+    return AssembleError.NotYetImplemented;
+}

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -22,16 +22,96 @@ const sparse = @import("../math/sparse.zig");
 const weak_form = @import("weak_form.zig");
 
 pub fn WhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type {
+    comptime {
+        if (k <= 0 or k >= MeshType.topological_dimension) {
+            @compileError("Whitney mass is only defined for interior degrees 0 < k < n");
+        }
+        if (MeshType.topological_dimension > 3) {
+            @compileError("Whitney mass assembly is currently implemented for topological_dimension <= 3");
+        }
+    }
+
     return struct {
         const Self = @This();
+        const n = MeshType.topological_dimension;
 
         pub const degree = k;
         pub const MeshT = MeshType;
+        pub const LocalMatrix = [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64;
 
         mesh: *const MeshType,
 
         pub fn init(mesh: *const MeshType) Self {
             return .{ .mesh = mesh };
+        }
+
+        pub fn localMatrix(self: Self, top_simplex_index: usize) LocalMatrix {
+            const top_simplex_vertices = self.mesh.simplices(n).items(.vertices);
+            const top_simplex_volumes = self.mesh.simplices(n).items(.volume);
+            const coords = self.mesh.vertices.slice().items(.coords);
+            const top_vertices = top_simplex_vertices[top_simplex_index];
+
+            var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
+            for (0..n + 1) |local_vertex_idx| {
+                top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
+            }
+
+            const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
+            return localWhitneyMass(MeshType.embedding_dimension, n, k, gradients, top_simplex_volumes[top_simplex_index]);
+        }
+    };
+}
+
+fn RiemannianWhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type {
+    comptime {
+        if (MeshType.embedding_dimension != MeshType.topological_dimension) {
+            @compileError("metric-aware Whitney mass currently requires embedding_dimension == topological_dimension");
+        }
+    }
+
+    return struct {
+        const Self = @This();
+        const n = MeshType.topological_dimension;
+
+        pub const degree = k;
+        pub const MeshT = MeshType;
+        pub const LocalMatrix = [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64;
+
+        mesh: *const MeshType,
+        top_simplex_metric_tensors: []const [n][n]f64,
+
+        pub fn init(mesh: *const MeshType, top_simplex_metric_tensors: []const [n][n]f64) Self {
+            std.debug.assert(top_simplex_metric_tensors.len == mesh.num_cells(n));
+            return .{
+                .mesh = mesh,
+                .top_simplex_metric_tensors = top_simplex_metric_tensors,
+            };
+        }
+
+        pub fn localMatrix(self: Self, top_simplex_index: usize) LocalMatrix {
+            const top_simplex_vertices = self.mesh.simplices(n).items(.vertices);
+            const top_simplex_volumes = self.mesh.simplices(n).items(.volume);
+            const coords = self.mesh.vertices.slice().items(.coords);
+            const top_vertices = top_simplex_vertices[top_simplex_index];
+
+            var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
+            for (0..n + 1) |local_vertex_idx| {
+                top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
+            }
+
+            const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
+            const metric_tensor = self.top_simplex_metric_tensors[top_simplex_index];
+            const metric_inverse = invertSmallMatrix(n, metric_tensor);
+            const metric_volume_scale = @sqrt(smallMatrixDeterminant(n, metric_tensor));
+            return localWhitneyMassWithMetric(
+                MeshType.embedding_dimension,
+                n,
+                k,
+                gradients,
+                top_simplex_volumes[top_simplex_index],
+                metric_inverse,
+                metric_volume_scale,
+            );
         }
     };
 }
@@ -53,54 +133,7 @@ pub fn assemble_whitney_mass(
         }
     }
 
-    const simplex_count = mesh.num_cells(k);
-    const top_simplex_count = mesh.num_cells(n);
-    const simplex_vertices = mesh.simplices(k).items(.vertices);
-    const top_simplex_vertices = mesh.simplices(n).items(.vertices);
-    const top_simplex_volumes = mesh.simplices(n).items(.volume);
-    const coords = mesh.vertices.slice().items(.coords);
-    const local_faces = localFaces(n, k);
-
-    var simplex_index = std.AutoHashMap([k + 1]u32, u32).init(allocator);
-    defer simplex_index.deinit();
-    for (simplex_vertices, 0..) |vertices, global_idx| {
-        try simplex_index.put(vertices, @intCast(global_idx));
-    }
-
-    var assembler = sparse.TripletAssembler(f64).init(simplex_count, simplex_count);
-    defer assembler.deinit(allocator);
-
-    for (0..top_simplex_count) |top_idx| {
-        const top_vertices = top_simplex_vertices[top_idx];
-
-        var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
-        for (0..n + 1) |local_vertex_idx| {
-            top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
-        }
-
-        const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
-        const local_mass = localWhitneyMass(MeshType.embedding_dimension, n, k, gradients, top_simplex_volumes[top_idx]);
-
-        var global_indices: [local_faces.len]u32 = undefined;
-        var orientation_signs: [local_faces.len]i8 = undefined;
-        for (local_faces, 0..) |local_face, local_face_idx| {
-            const oriented_vertices = liftLocalFaceVertices(k, n, top_vertices, local_face);
-            const canonical_key = canonicalizeVertices(k + 1, oriented_vertices);
-            const global_idx = simplex_index.get(canonical_key).?;
-            global_indices[local_face_idx] = global_idx;
-            orientation_signs[local_face_idx] = orientationSign(k + 1, oriented_vertices, simplex_vertices[global_idx]);
-        }
-
-        for (0..local_faces.len) |i| {
-            const sign_i: f64 = @floatFromInt(orientation_signs[i]);
-            for (0..local_faces.len) |j| {
-                const sign_j: f64 = @floatFromInt(orientation_signs[j]);
-                try assembler.addEntry(allocator, global_indices[i], global_indices[j], sign_i * sign_j * local_mass[i][j]);
-            }
-        }
-    }
-
-    return assembler.build(allocator);
+    return weak_form.assemble(k, allocator, mesh, WhitneyMassKernel(MeshType, k).init(mesh));
 }
 
 pub fn assemble_whitney_mass_with_metric(
@@ -124,67 +157,12 @@ pub fn assemble_whitney_mass_with_metric(
         }
     }
 
-    const simplex_count = mesh.num_cells(k);
-    const top_simplex_count = mesh.num_cells(n);
-    std.debug.assert(top_simplex_metric_tensors.len == top_simplex_count);
-
-    const simplex_vertices = mesh.simplices(k).items(.vertices);
-    const top_simplex_vertices = mesh.simplices(n).items(.vertices);
-    const top_simplex_volumes = mesh.simplices(n).items(.volume);
-    const coords = mesh.vertices.slice().items(.coords);
-    const local_faces = localFaces(n, k);
-
-    var simplex_index = std.AutoHashMap([k + 1]u32, u32).init(allocator);
-    defer simplex_index.deinit();
-    for (simplex_vertices, 0..) |vertices, global_idx| {
-        try simplex_index.put(vertices, @intCast(global_idx));
-    }
-
-    var assembler = sparse.TripletAssembler(f64).init(simplex_count, simplex_count);
-    defer assembler.deinit(allocator);
-
-    for (0..top_simplex_count) |top_idx| {
-        const top_vertices = top_simplex_vertices[top_idx];
-
-        var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
-        for (0..n + 1) |local_vertex_idx| {
-            top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
-        }
-
-        const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
-        const metric_tensor = top_simplex_metric_tensors[top_idx];
-        const metric_inverse = invertSmallMatrix(n, metric_tensor);
-        const metric_volume_scale = @sqrt(smallMatrixDeterminant(n, metric_tensor));
-        const local_mass = localWhitneyMassWithMetric(
-            MeshType.embedding_dimension,
-            n,
-            k,
-            gradients,
-            top_simplex_volumes[top_idx],
-            metric_inverse,
-            metric_volume_scale,
-        );
-
-        var global_indices: [local_faces.len]u32 = undefined;
-        var orientation_signs: [local_faces.len]i8 = undefined;
-        for (local_faces, 0..) |local_face, local_face_idx| {
-            const oriented_vertices = liftLocalFaceVertices(k, n, top_vertices, local_face);
-            const canonical_key = canonicalizeVertices(k + 1, oriented_vertices);
-            const global_idx = simplex_index.get(canonical_key).?;
-            global_indices[local_face_idx] = global_idx;
-            orientation_signs[local_face_idx] = orientationSign(k + 1, oriented_vertices, simplex_vertices[global_idx]);
-        }
-
-        for (0..local_faces.len) |i| {
-            const sign_i: f64 = @floatFromInt(orientation_signs[i]);
-            for (0..local_faces.len) |j| {
-                const sign_j: f64 = @floatFromInt(orientation_signs[j]);
-                try assembler.addEntry(allocator, global_indices[i], global_indices[j], sign_i * sign_j * local_mass[i][j]);
-            }
-        }
-    }
-
-    return assembler.build(allocator);
+    return weak_form.assemble(
+        k,
+        allocator,
+        mesh,
+        RiemannianWhitneyMassKernel(MeshType, k).init(mesh, top_simplex_metric_tensors),
+    );
 }
 
 pub fn assemble_whitney_preconditioner(
@@ -247,99 +225,6 @@ fn factorial(comptime n: comptime_int) comptime_int {
     return result;
 }
 
-fn choose(comptime n: comptime_int, comptime k: comptime_int) comptime_int {
-    if (k < 0 or k > n) return 0;
-    if (k == 0 or k == n) return 1;
-    var numerator: comptime_int = 1;
-    var denominator: comptime_int = 1;
-    const k_small = if (k < n - k) k else n - k;
-    inline for (0..k_small) |i| {
-        numerator *= (n - i);
-        denominator *= (i + 1);
-    }
-    return @divExact(numerator, denominator);
-}
-
-fn localFaces(comptime n: comptime_int, comptime k: comptime_int) [choose(n + 1, k + 1)][k + 1]u8 {
-    return switch (n) {
-        2 => switch (k) {
-            1 => .{
-                .{ 0, 1 },
-                .{ 0, 2 },
-                .{ 1, 2 },
-            },
-            else => @compileError("unsupported local face degree for 2-simplex"),
-        },
-        3 => switch (k) {
-            1 => .{
-                .{ 0, 1 },
-                .{ 0, 2 },
-                .{ 0, 3 },
-                .{ 1, 2 },
-                .{ 1, 3 },
-                .{ 2, 3 },
-            },
-            2 => .{
-                .{ 0, 1, 2 },
-                .{ 0, 1, 3 },
-                .{ 0, 2, 3 },
-                .{ 1, 2, 3 },
-            },
-            else => @compileError("unsupported local face degree for 3-simplex"),
-        },
-        else => @compileError("local face enumeration is only implemented for topological_dimension <= 3"),
-    };
-}
-
-fn liftLocalFaceVertices(
-    comptime k: comptime_int,
-    comptime n: comptime_int,
-    top_vertices: [n + 1]u32,
-    local_face: [k + 1]u8,
-) [k + 1]u32 {
-    var result: [k + 1]u32 = undefined;
-    for (local_face, 0..) |local_vertex_idx, write_idx| {
-        result[write_idx] = top_vertices[local_vertex_idx];
-    }
-    return result;
-}
-
-fn canonicalizeVertices(comptime len: comptime_int, vertices: [len]u32) [len]u32 {
-    var result = vertices;
-    inline for (1..len) |i| {
-        var j = i;
-        while (j > 0 and result[j - 1] > result[j]) : (j -= 1) {
-            std.mem.swap(u32, &result[j - 1], &result[j]);
-        }
-    }
-    return result;
-}
-
-fn orientationSign(comptime len: comptime_int, oriented_vertices: [len]u32, global_vertices: [len]u32) i8 {
-    var permutation: [len]u8 = undefined;
-    var used = [_]bool{false} ** len;
-    for (oriented_vertices, 0..) |vertex, oriented_idx| {
-        var found = false;
-        for (global_vertices, 0..) |global_vertex, global_idx| {
-            if (used[global_idx]) continue;
-            if (vertex != global_vertex) continue;
-            permutation[oriented_idx] = @intCast(global_idx);
-            used[global_idx] = true;
-            found = true;
-            break;
-        }
-        std.debug.assert(found);
-    }
-
-    var inversion_count: u32 = 0;
-    inline for (0..len) |i| {
-        inline for (i + 1..len) |j| {
-            if (permutation[i] > permutation[j]) inversion_count += 1;
-        }
-    }
-    return if (inversion_count % 2 == 0) 1 else -1;
-}
-
 fn barycentricGradients(
     comptime embedding_dimension: usize,
     comptime n: comptime_int,
@@ -383,8 +268,8 @@ fn localWhitneyMass(
     comptime k: comptime_int,
     gradients: [n + 1][embedding_dimension]f64,
     simplex_volume: f64,
-) [choose(n + 1, k + 1)][choose(n + 1, k + 1)]f64 {
-    const local_faces = localFaces(n, k);
+) [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64 {
+    const local_faces = weak_form.localFaces(n, k);
     var local_mass: [local_faces.len][local_faces.len]f64 = undefined;
     const lambda_integral_scale = simplex_volume / @as(f64, @floatFromInt((n + 1) * (n + 2)));
     const whitney_scale = @as(f64, @floatFromInt(factorial(k) * factorial(k)));
@@ -419,8 +304,8 @@ fn localWhitneyMassWithMetric(
     simplex_volume: f64,
     metric_inverse: [n][n]f64,
     metric_volume_scale: f64,
-) [choose(n + 1, k + 1)][choose(n + 1, k + 1)]f64 {
-    const local_faces = localFaces(n, k);
+) [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64 {
+    const local_faces = weak_form.localFaces(n, k);
     var local_mass: [local_faces.len][local_faces.len]f64 = undefined;
     const lambda_integral_scale = simplex_volume * metric_volume_scale /
         @as(f64, @floatFromInt((n + 1) * (n + 2)));

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -19,6 +19,7 @@ const std = @import("std");
 const testing = std.testing;
 const topology = @import("../topology/mesh.zig");
 const sparse = @import("../math/sparse.zig");
+const weak_form = @import("weak_form.zig");
 
 pub fn assemble_whitney_mass(
     comptime k: comptime_int,
@@ -764,5 +765,77 @@ test "Whitney 2-form mass matrix is symmetric positive definite on tetrahedral m
 
         try testing.expectApproxEqRel(dot_axy, dot_xay, 1e-12);
         try testing.expect(xtmx > 0.0);
+    }
+}
+
+test "generic weak-form assembly matches Whitney mass on 2D edges" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
+    defer mesh.deinit(allocator);
+
+    var reference = try assemble_whitney_mass(1, allocator, &mesh);
+    defer reference.deinit(allocator);
+
+    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh2D, 1).init(&mesh));
+    defer assembled.deinit(allocator);
+
+    try expectEqualSparseMatrix(reference, assembled);
+}
+
+test "generic weak-form assembly matches Whitney mass on 3D faces" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 1, 1.0, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    var reference = try assemble_whitney_mass(2, allocator, &mesh);
+    defer reference.deinit(allocator);
+
+    var assembled = try weak_form.assemble(2, allocator, &mesh, WhitneyMassKernel(Mesh3D, 2).init(&mesh));
+    defer assembled.deinit(allocator);
+
+    try expectEqualSparseMatrix(reference, assembled);
+}
+
+test "generic weak-form Whitney assembly preserves symmetry" {
+    const allocator = testing.allocator;
+    var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 1, 1.0, 1.0, 1.0);
+    defer mesh.deinit(allocator);
+
+    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh3D, 1).init(&mesh));
+    defer assembled.deinit(allocator);
+
+    var rng = std.Random.DefaultPrng.init(0xDEC_3D_03);
+    const x = try allocator.alloc(f64, assembled.n_cols);
+    defer allocator.free(x);
+    const y = try allocator.alloc(f64, assembled.n_cols);
+    defer allocator.free(y);
+    const ax = try allocator.alloc(f64, assembled.n_rows);
+    defer allocator.free(ax);
+    const ay = try allocator.alloc(f64, assembled.n_rows);
+    defer allocator.free(ay);
+
+    for (0..100) |_| {
+        for (x) |*v| v.* = rng.random().float(f64) * 2.0 - 1.0;
+        for (y) |*v| v.* = rng.random().float(f64) * 2.0 - 1.0;
+
+        sparse.spmv(assembled, x, ax);
+        sparse.spmv(assembled, y, ay);
+
+        var dot_axy: f64 = 0.0;
+        var dot_xay: f64 = 0.0;
+        for (ax, y) |axi, yi| dot_axy += axi * yi;
+        for (x, ay) |xi, ayi| dot_xay += xi * ayi;
+
+        try testing.expectApproxEqRel(dot_axy, dot_xay, 1e-12);
+    }
+}
+
+fn expectEqualSparseMatrix(expected: sparse.CsrMatrix(f64), actual: sparse.CsrMatrix(f64)) !void {
+    try testing.expectEqual(expected.n_rows, actual.n_rows);
+    try testing.expectEqual(expected.n_cols, actual.n_cols);
+    try testing.expectEqualSlices(u32, expected.row_ptr, actual.row_ptr);
+    try testing.expectEqualSlices(u32, expected.col_idx, actual.col_idx);
+    for (expected.values, actual.values) |expected_value, actual_value| {
+        try testing.expectApproxEqRel(expected_value, actual_value, 1e-12);
     }
 }

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -21,6 +21,21 @@ const topology = @import("../topology/mesh.zig");
 const sparse = @import("../math/sparse.zig");
 const weak_form = @import("weak_form.zig");
 
+pub fn WhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type {
+    return struct {
+        const Self = @This();
+
+        pub const degree = k;
+        pub const MeshT = MeshType;
+
+        mesh: *const MeshType,
+
+        pub fn init(mesh: *const MeshType) Self {
+            return .{ .mesh = mesh };
+        }
+    };
+}
+
 pub fn assemble_whitney_mass(
     comptime k: comptime_int,
     allocator: std.mem.Allocator,

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -113,36 +113,29 @@ pub fn assemble_whitney_mass(
     comptime k: comptime_int,
     allocator: std.mem.Allocator,
     mesh: anytype,
-) !sparse.CsrMatrix(f64) {
-    return assemble_whitney_mass_generic(k, allocator, mesh, .flat, {});
-}
-
-pub fn assemble_whitney_mass_with_metric(
-    comptime k: comptime_int,
-    allocator: std.mem.Allocator,
-    mesh: anytype,
-    top_simplex_metric_tensors: []const [@TypeOf(mesh.*).topological_dimension][@TypeOf(mesh.*).topological_dimension]f64,
-) !sparse.CsrMatrix(f64) {
-    return assemble_whitney_mass_generic(k, allocator, mesh, .riemannian, top_simplex_metric_tensors);
-}
-
-fn assemble_whitney_mass_generic(
-    comptime k: comptime_int,
-    allocator: std.mem.Allocator,
-    mesh: anytype,
-    comptime mode: MetricMode,
-    top_simplex_metric_tensors: switch (mode) {
-        .flat => void,
-        .riemannian => []const [@TypeOf(mesh.*).topological_dimension][@TypeOf(mesh.*).topological_dimension]f64,
-    },
+    metric_data: anytype,
 ) !sparse.CsrMatrix(f64) {
     const MeshType = @TypeOf(mesh.*);
+    const mode: MetricMode = comptime whitneyMassMetricMode(MeshType, @TypeOf(metric_data));
     return weak_form.assemble(
         k,
         allocator,
         mesh,
-        WhitneyMassKernel(MeshType, k, mode).init(mesh, top_simplex_metric_tensors),
+        WhitneyMassKernel(MeshType, k, mode).init(mesh, metric_data),
     );
+}
+
+fn whitneyMassMetricMode(comptime MeshType: type, comptime MetricArgType: type) MetricMode {
+    if (MetricArgType == void) {
+        return .flat;
+    }
+    if (MetricArgType == []const [MeshType.topological_dimension][MeshType.topological_dimension]f64) {
+        return .riemannian;
+    }
+    @compileError(std.fmt.comptimePrint(
+        "assemble_whitney_mass expects metric data to be void or []const [{d}][{d}]f64",
+        .{ MeshType.topological_dimension, MeshType.topological_dimension },
+    ));
 }
 
 pub fn assemble_whitney_preconditioner(
@@ -507,7 +500,7 @@ test "Whitney mass matrix is square with n_edges dimension" {
     var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var mass = try assemble_whitney_mass(1, allocator, &mesh);
+    var mass = try assemble_whitney_mass(1, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     try testing.expectEqual(mesh.num_edges(), mass.n_rows);
@@ -519,7 +512,7 @@ test "Whitney mass matrix is symmetric" {
     var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
-    var mass = try assemble_whitney_mass(1, allocator, &mesh);
+    var mass = try assemble_whitney_mass(1, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     // Check M(i,j) = M(j,i) by comparing Ax with Aᵀx for random x.
@@ -560,7 +553,7 @@ test "Whitney mass matrix is positive definite (xᵀMx > 0 for random x)" {
     var mesh = try Mesh2D.plane(allocator, 3, 3, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var mass = try assemble_whitney_mass(1, allocator, &mesh);
+    var mass = try assemble_whitney_mass(1, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_AA55_01);
@@ -587,7 +580,7 @@ test "Whitney mass matrix has nonzero diagonal and at least one entry per row" {
     var mesh = try Mesh2D.plane(allocator, 2, 2, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var mass = try assemble_whitney_mass(1, allocator, &mesh);
+    var mass = try assemble_whitney_mass(1, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     // Every edge appears in at least one face, so every row has entries.
@@ -613,7 +606,7 @@ test "Whitney 2-form mass matrix is symmetric positive definite on tetrahedral m
     var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 1, 1.0, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var mass = try assemble_whitney_mass(2, allocator, &mesh);
+    var mass = try assemble_whitney_mass(2, allocator, &mesh, {});
     defer mass.deinit(allocator);
 
     try testing.expectEqual(mesh.num_faces(), mass.n_rows);
@@ -653,7 +646,7 @@ test "generic weak-form assembly matches Whitney mass on 2D edges" {
     var mesh = try Mesh2D.plane(allocator, 4, 3, 2.0, 1.5);
     defer mesh.deinit(allocator);
 
-    var reference = try assemble_whitney_mass(1, allocator, &mesh);
+    var reference = try assemble_whitney_mass(1, allocator, &mesh, {});
     defer reference.deinit(allocator);
 
     var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh2D, 1, .flat).init(&mesh, {}));
@@ -667,7 +660,7 @@ test "generic weak-form assembly matches Whitney mass on 3D faces" {
     var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 1, 1.0, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var reference = try assemble_whitney_mass(2, allocator, &mesh);
+    var reference = try assemble_whitney_mass(2, allocator, &mesh, {});
     defer reference.deinit(allocator);
 
     var assembled = try weak_form.assemble(2, allocator, &mesh, WhitneyMassKernel(Mesh3D, 2, .flat).init(&mesh, {}));

--- a/src/operators/whitney_mass.zig
+++ b/src/operators/whitney_mass.zig
@@ -21,7 +21,12 @@ const topology = @import("../topology/mesh.zig");
 const sparse = @import("../math/sparse.zig");
 const weak_form = @import("weak_form.zig");
 
-pub fn WhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type {
+pub const MetricMode = enum {
+    flat,
+    riemannian,
+};
+
+pub fn WhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int, comptime mode: MetricMode) type {
     comptime {
         if (k <= 0 or k >= MeshType.topological_dimension) {
             @compileError("Whitney mass is only defined for interior degrees 0 < k < n");
@@ -29,42 +34,7 @@ pub fn WhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type
         if (MeshType.topological_dimension > 3) {
             @compileError("Whitney mass assembly is currently implemented for topological_dimension <= 3");
         }
-    }
-
-    return struct {
-        const Self = @This();
-        const n = MeshType.topological_dimension;
-
-        pub const degree = k;
-        pub const MeshT = MeshType;
-        pub const LocalMatrix = [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64;
-
-        mesh: *const MeshType,
-
-        pub fn init(mesh: *const MeshType) Self {
-            return .{ .mesh = mesh };
-        }
-
-        pub fn localMatrix(self: Self, top_simplex_index: usize) LocalMatrix {
-            const top_simplex_vertices = self.mesh.simplices(n).items(.vertices);
-            const top_simplex_volumes = self.mesh.simplices(n).items(.volume);
-            const coords = self.mesh.vertices.slice().items(.coords);
-            const top_vertices = top_simplex_vertices[top_simplex_index];
-
-            var top_coords: [n + 1][MeshType.embedding_dimension]f64 = undefined;
-            for (0..n + 1) |local_vertex_idx| {
-                top_coords[local_vertex_idx] = coords[top_vertices[local_vertex_idx]];
-            }
-
-            const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
-            return localWhitneyMass(MeshType.embedding_dimension, n, k, gradients, top_simplex_volumes[top_simplex_index]);
-        }
-    };
-}
-
-fn RiemannianWhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int) type {
-    comptime {
-        if (MeshType.embedding_dimension != MeshType.topological_dimension) {
+        if (mode == .riemannian and MeshType.embedding_dimension != MeshType.topological_dimension) {
             @compileError("metric-aware Whitney mass currently requires embedding_dimension == topological_dimension");
         }
     }
@@ -75,13 +45,25 @@ fn RiemannianWhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int
 
         pub const degree = k;
         pub const MeshT = MeshType;
+        pub const metric_mode = mode;
         pub const LocalMatrix = [weak_form.localFaceCount(n, k)][weak_form.localFaceCount(n, k)]f64;
 
         mesh: *const MeshType,
-        top_simplex_metric_tensors: []const [n][n]f64,
+        top_simplex_metric_tensors: switch (mode) {
+            .flat => void,
+            .riemannian => []const [n][n]f64,
+        },
 
-        pub fn init(mesh: *const MeshType, top_simplex_metric_tensors: []const [n][n]f64) Self {
-            std.debug.assert(top_simplex_metric_tensors.len == mesh.num_cells(n));
+        pub fn init(
+            mesh: *const MeshType,
+            top_simplex_metric_tensors: switch (mode) {
+                .flat => void,
+                .riemannian => []const [n][n]f64,
+            },
+        ) Self {
+            if (mode == .riemannian) {
+                std.debug.assert(top_simplex_metric_tensors.len == mesh.num_cells(n));
+            }
             return .{
                 .mesh = mesh,
                 .top_simplex_metric_tensors = top_simplex_metric_tensors,
@@ -100,18 +82,29 @@ fn RiemannianWhitneyMassKernel(comptime MeshType: type, comptime k: comptime_int
             }
 
             const gradients = barycentricGradients(MeshType.embedding_dimension, n, top_coords);
-            const metric_tensor = self.top_simplex_metric_tensors[top_simplex_index];
-            const metric_inverse = invertSmallMatrix(n, metric_tensor);
-            const metric_volume_scale = @sqrt(smallMatrixDeterminant(n, metric_tensor));
-            return localWhitneyMassWithMetric(
-                MeshType.embedding_dimension,
-                n,
-                k,
-                gradients,
-                top_simplex_volumes[top_simplex_index],
-                metric_inverse,
-                metric_volume_scale,
-            );
+            return switch (mode) {
+                .flat => localWhitneyMass(
+                    MeshType.embedding_dimension,
+                    n,
+                    k,
+                    gradients,
+                    top_simplex_volumes[top_simplex_index],
+                ),
+                .riemannian => blk: {
+                    const metric_tensor = self.top_simplex_metric_tensors[top_simplex_index];
+                    const metric_inverse = invertSmallMatrix(n, metric_tensor);
+                    const metric_volume_scale = @sqrt(smallMatrixDeterminant(n, metric_tensor));
+                    break :blk localWhitneyMassWithMetric(
+                        MeshType.embedding_dimension,
+                        n,
+                        k,
+                        gradients,
+                        top_simplex_volumes[top_simplex_index],
+                        metric_inverse,
+                        metric_volume_scale,
+                    );
+                },
+            };
         }
     };
 }
@@ -121,19 +114,7 @@ pub fn assemble_whitney_mass(
     allocator: std.mem.Allocator,
     mesh: anytype,
 ) !sparse.CsrMatrix(f64) {
-    const MeshType = @TypeOf(mesh.*);
-    const n = MeshType.topological_dimension;
-
-    comptime {
-        if (k <= 0 or k >= n) {
-            @compileError("Whitney mass is only defined for interior degrees 0 < k < n");
-        }
-        if (n > 3) {
-            @compileError("Whitney mass assembly is currently implemented for topological_dimension <= 3");
-        }
-    }
-
-    return weak_form.assemble(k, allocator, mesh, WhitneyMassKernel(MeshType, k).init(mesh));
+    return assemble_whitney_mass_generic(k, allocator, mesh, .flat, {});
 }
 
 pub fn assemble_whitney_mass_with_metric(
@@ -142,26 +123,25 @@ pub fn assemble_whitney_mass_with_metric(
     mesh: anytype,
     top_simplex_metric_tensors: []const [@TypeOf(mesh.*).topological_dimension][@TypeOf(mesh.*).topological_dimension]f64,
 ) !sparse.CsrMatrix(f64) {
+    return assemble_whitney_mass_generic(k, allocator, mesh, .riemannian, top_simplex_metric_tensors);
+}
+
+fn assemble_whitney_mass_generic(
+    comptime k: comptime_int,
+    allocator: std.mem.Allocator,
+    mesh: anytype,
+    comptime mode: MetricMode,
+    top_simplex_metric_tensors: switch (mode) {
+        .flat => void,
+        .riemannian => []const [@TypeOf(mesh.*).topological_dimension][@TypeOf(mesh.*).topological_dimension]f64,
+    },
+) !sparse.CsrMatrix(f64) {
     const MeshType = @TypeOf(mesh.*);
-    const n = MeshType.topological_dimension;
-
-    comptime {
-        if (MeshType.embedding_dimension != n) {
-            @compileError("metric-aware Whitney mass currently requires embedding_dimension == topological_dimension");
-        }
-        if (k <= 0 or k >= n) {
-            @compileError("Whitney mass is only defined for interior degrees 0 < k < n");
-        }
-        if (n > 3) {
-            @compileError("Whitney mass assembly is currently implemented for topological_dimension <= 3");
-        }
-    }
-
     return weak_form.assemble(
         k,
         allocator,
         mesh,
-        RiemannianWhitneyMassKernel(MeshType, k).init(mesh, top_simplex_metric_tensors),
+        WhitneyMassKernel(MeshType, k, mode).init(mesh, top_simplex_metric_tensors),
     );
 }
 
@@ -676,7 +656,7 @@ test "generic weak-form assembly matches Whitney mass on 2D edges" {
     var reference = try assemble_whitney_mass(1, allocator, &mesh);
     defer reference.deinit(allocator);
 
-    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh2D, 1).init(&mesh));
+    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh2D, 1, .flat).init(&mesh, {}));
     defer assembled.deinit(allocator);
 
     try expectEqualSparseMatrix(reference, assembled);
@@ -690,7 +670,7 @@ test "generic weak-form assembly matches Whitney mass on 3D faces" {
     var reference = try assemble_whitney_mass(2, allocator, &mesh);
     defer reference.deinit(allocator);
 
-    var assembled = try weak_form.assemble(2, allocator, &mesh, WhitneyMassKernel(Mesh3D, 2).init(&mesh));
+    var assembled = try weak_form.assemble(2, allocator, &mesh, WhitneyMassKernel(Mesh3D, 2, .flat).init(&mesh, {}));
     defer assembled.deinit(allocator);
 
     try expectEqualSparseMatrix(reference, assembled);
@@ -701,7 +681,7 @@ test "generic weak-form Whitney assembly preserves symmetry" {
     var mesh = try Mesh3D.uniform_tetrahedral_grid(allocator, 2, 2, 1, 1.0, 1.0, 1.0);
     defer mesh.deinit(allocator);
 
-    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh3D, 1).init(&mesh));
+    var assembled = try weak_form.assemble(1, allocator, &mesh, WhitneyMassKernel(Mesh3D, 1, .flat).init(&mesh, {}));
     defer assembled.deinit(allocator);
 
     var rng = std.Random.DefaultPrng.init(0xDEC_3D_03);

--- a/src/root.zig
+++ b/src/root.zig
@@ -70,6 +70,7 @@ pub const operators = struct {
         pub const codifferential = @import("operators/codifferential.zig");
         pub const hodge_star = @import("operators/hodge_star.zig");
         pub const laplacian = @import("operators/laplacian.zig");
+        pub const weak_form = @import("operators/weak_form.zig");
         pub const whitney_mass = @import("operators/whitney_mass.zig");
     };
     pub const bridges = @import("operators/bridges.zig");
@@ -81,6 +82,7 @@ pub const operators = struct {
     pub const laplacian = @import("operators/laplacian.zig");
     pub const observers = @import("operators/observers.zig");
     pub const poisson = @import("operators/poisson.zig");
+    pub const weak_form = @import("operators/weak_form.zig");
     pub const whitney_mass = @import("operators/whitney_mass.zig");
     pub const wedge_product = @import("operators/wedge_product.zig");
 };

--- a/src/topology/mesh.zig
+++ b/src/topology/mesh.zig
@@ -375,7 +375,7 @@ pub fn Mesh(comptime mesh_embedding_dimension: usize, comptime mesh_topological_
             }
 
             inline for (1..topological_dimension) |k| {
-                var mass = try whitney.assemble_whitney_mass(k, allocator, mesh);
+                var mass = try whitney.assemble_whitney_mass(k, allocator, mesh, {});
                 errdefer mass.deinit(allocator);
 
                 const preconditioner = try whitney.assemble_whitney_preconditioner(k, allocator, mesh);


### PR DESCRIPTION
Closes #194

## What

Add a shared FEEC weak-form assembly seam that scatters simplex-local contributions into global sparse operators, and route Whitney mass assembly through kernel types on that seam.

## Acceptance criterion

Weak-form FEEC assembly no longer depends on basis probing for the supported Whitney cases, and the implementation is structured around local FEEC kernels and global scatter rather than around case-specific global hacks.

## Tasks

- [x] Write property tests encoding the acceptance criterion
- [x] Design public API (stubs)
- [x] Implement
- [x] CI green

## Decisions

- Introduced `operators.weak_form.assemble` as the shared local-to-global scatter verb for FEEC weak operators.
- Kept Whitney-specific mathematics in `WhitneyMassKernel` / metric-aware kernel types rather than embedding scatter/orientation logic in `assemble_whitney_mass*`.
- Logged in `project/epoch_2/decision_log.md` and aligned `project/docs/architecture_language.md`.

## Limitations

- The generic weak-form scatter currently supports interior degrees on simplicial meshes with topological dimension up to 3, matching the current Whitney support surface.
- This PR extracts the assembly seam and routes Whitney mass through it; it does not yet add additional FEEC weak-operator kernels beyond Whitney mass.

## Molecule checklist

- Horizon conflict: none found against `project/horizons.md`.
- Architecture docs updated: yes, `project/docs/architecture_language.md`.
- Public API impact: adds `operators.weak_form` / `operators.feec.weak_form` and `WhitneyMassKernel` as the FEEC local-kernel entry surface.
- Follow-on issues opened: none.
